### PR TITLE
Add a workflow that safely runs after Format fails

### DIFF
--- a/.github/workflows/WorkflowHook.yml
+++ b/.github/workflows/WorkflowHook.yml
@@ -1,0 +1,100 @@
+# Run after-hooks of workflow executions. Changes to this workflow file enables only if it's available on the default branch.
+#
+# Please note that we should not checkout the code because it contains unverified changes.
+
+name: Workflow Hook
+
+on:
+  workflow_run:
+    workflows:
+      - Format
+    types:
+      - completed
+
+# Disable all permissions. We have to enable required permissions at job-level.
+permissions: {}
+
+run-name: ${{ github.event.workflow_run.name }} - ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
+
+# Restrict the concurrency on a pair of a repository owner and a branch.
+concurrency:
+  group: workflow-hook-${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  # Run every failure of workflows specified in workflow_run#workflows
+  # This job will expose an associated pull request if exists.
+  on-failure:
+    if: >
+      github.event.workflow_run.conclusion == 'failure'
+
+    permissions:
+      pull-requests: read # for listing pull requests
+
+    timeout-minutes: 2
+
+    outputs:
+      pull-request: ${{ steps.linked-pull-request.outputs.entity }} # pull request entity (string)
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: linked-pull-request
+        uses: actions/github-script@060d68304cc19ea84d828af10e34b9c6ca7bdb31
+        with:
+          script: |
+            // Get the latest pull request
+
+            // We have to use different branch format for fork repos.
+            // fork repo = <author-repo>:<branch-name>
+            // original repo = <branch-name>
+
+            const headBranch = '${{ github.event.workflow_run.head_repository.fork && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch) || github.event.workflow_run.head_branch }}';
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+
+              head: headBranch,
+
+              direction: 'desc',
+              sort: 'updated',
+              per_page: 1
+            });
+
+            if (pulls.length === 0) {
+              core.warning('No pull request is found.');
+            } else {
+              core.setOutput('entity', pulls[0]);
+            }
+
+  # Run every failure of Format workflow.
+  on-failure-of-Format:
+    needs:
+      - on-failure
+
+    if: >
+      github.event.workflow_run.name == 'Format' &&
+      needs.on-failure.outputs.pull-request &&
+      fromJSON(needs.on-failure.outputs.pull-request).number
+
+    permissions:
+      pull-requests: write # for creating a comment on pull requests
+
+    timeout-minutes: 2
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: >
+          needs.on-failure.outputs.pull-request
+        uses: marocchino/sticky-pull-request-comment@ab2e48d202c7f90b66b32abb04df5005a4b29276
+        with:
+          header: ping-format
+          number: ${{ fromJSON(needs.on-failure.outputs.pull-request).number }}
+          recreate: true
+          message: >
+            Hi @${{ github.event.workflow_run.actor.login }}!
+            Codes seem to be unformatted. Please run `./gradlew spotlessKotlinApply` to fix this issue.
+            Thank you for your contribution.


### PR DESCRIPTION
Ref: https://github.com/DroidKaigi/conference-app-2023/issues/40

As we discussed, we should have safe code-format reminders. Please feel free to ask me anything for the clarification.

Examples: https://github.com/DroidKaigi/conference-app-2023/pull/52#issuecomment-1521029689