### PR TITLE
chore(kmm): decrease gradle agp version

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -14,12 +14,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
 }
 
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-}
-
 dependencies {
     implementation(libs.androidGradlePlugin)
     implementation(libs.kotlinGradlePlugin)

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidComposePlugin.kt
@@ -11,7 +11,8 @@ class AndroidComposePlugin : Plugin<Project> {
             android {
                 buildFeatures.compose = true
                 composeOptions {
-                    kotlinCompilerExtensionVersion = libs.findVersion("composeCompiler").get().toString()
+                    kotlinCompilerExtensionVersion = libs.findLibrary("composeCompiler").get()
+                        .get().versionConstraint.requiredVersion
                 }
             }
             dependencies {

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidPlugin.kt
@@ -1,10 +1,7 @@
 package io.github.droidkaigi.confsched2023.primitive
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.kotlin.dsl.dependencies
 
 @Suppress("unused")
 class AndroidPlugin : Plugin<Project> {

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpAndroidPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpAndroidPlugin.kt
@@ -17,17 +17,14 @@ class KmpAndroidPlugin : Plugin<Project> {
                 setupAndroid()
                 sourceSets {
                     getByName("main") {
-                        setRoot("src/androidMain")
-                        assets.srcDirs(file("src/androidMain/assets"))
-                        manifest.srcFile("src/androidMain/AndroidManifest.xml")
-                        java.srcDirs(file("src/androidMain/kotlin"))
-                        res.srcDirs(file("src/androidMain/res"))
+                        assets.srcDirs("src/androidMain/assets")
+                        java.srcDirs("src/androidMain/kotlin", "src/commonMain/kotlin")
+                        res.srcDirs("src/androidMain/res")
                     }
-                    // FIXME: Without this, kaptDebugKotlinAndroid can't see commonMain
-                    // If you can run ./gradlew kaptDebugKotlinAndroid without this,
-                    // please delete this
-                    sourceSets.all {
-                        java.srcDir("src/commonMain/kotlin")
+                    getByName("test") {
+                        assets.srcDirs("src/androidUnitTest/assets")
+                        java.srcDirs("src/androidUnitTest/kotlin", "src/commonTest/kotlin")
+                        res.srcDirs("src/androidUnitTest/res")
                     }
                 }
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 }
 
 android.namespace = "io.github.droidkaigi.confsched2023.core.data"
-kotlin{
+kotlin {
     sourceSets {
-        commonMain{
+        commonMain {
             dependencies {
                 implementation(projects.core.model)
                 implementation(libs.kotlinxCoroutinesCore)

--- a/core/data/src/commonMain/AndroidManifest.xml
+++ b/core/data/src/commonMain/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest></manifest>

--- a/core/model/src/commonMain/AndroidManifest.xml
+++ b/core/model/src/commonMain/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest></manifest>

--- a/core/ui/src/main/AndroidManifest.xml
+++ b/core/ui/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest></manifest>

--- a/feature/sessions/src/main/AndroidManifest.xml
+++ b/feature/sessions/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest></manifest>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,33 +1,17 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
+# gradle
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official
-
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true
-
 org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.parallel=true
+
+# android
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+
+# kotlin
+kotlin.code.style=official
+kotlin.native.binary.memoryModel=experimental
+kotlin.native.ignoreDisabledTargets=true
+kotlin.mpp.enableCInteropCommonization=true
+kotlin.mpp.stability.nowarn=true
+kotlin.mpp.androidSourceSetLayoutVersion=2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-androidGradlePlugin = "8.0.0"
-kotlin = "1.8.10"
+androidGradlePlugin = "7.4.2"
+kotlin = "1.8.20"
 
 androidxCore = "1.10.0"
 androidDesugarJdkLibs = "2.0.3"
 compose = "1.4.2"
-composeCompiler = "1.4.4"
+composeCompiler = "1.4.6"
 composeHiltNavigatiaon = "1.0.0"
 androidxLifecycle = "2.6.1"
 androidxActivity = "1.7.1"
@@ -26,6 +26,7 @@ hiltGradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-pl
 
 androidDesugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
 
+composeCompiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
 composeUi = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 composeMaterial = { module = "androidx.compose.material:material", version.ref = "compose" }
 composeUiToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
-networkTimeout=10000
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Why

https://github.com/DroidKaigi/conference-app-2023/issues/74

AGP 8.0 requests gradle 8, but gradle 8 can't assemble XCFramework
https://youtrack.jetbrains.com/issue/KT-56019

so, decrease gradle to 7.6.1

# What
decrease gradle, agp version