### PR TITLE
Improved build.gradle in contributors module

### DIFF
--- a/feature/contributors/build.gradle.kts
+++ b/feature/contributors/build.gradle.kts
@@ -17,9 +17,10 @@ kotlin {
                 implementation(libs.kotlinxCoroutinesCore)
             }
         }
+        androidMain {
+            dependencies {
+                implementation(projects.core.ui)
+            }
+        }
     }
-}
-dependencies {
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
 }


### PR DESCRIPTION
Follow-up PR for comments in https://github.com/DroidKaigi/conference-app-2023/pull/108
- Removed dependency with `projects.core.model`
- Use `SourceSets` to specify dependency depending on platform