### PR TITLE
support retrying, if multiple exception are thrown

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/TimetableScreen.kt
@@ -189,25 +189,30 @@ fun <T1, T2, T3, T4, R> ViewModel.buildUiState(
 fun <T> Flow<T>.handleErrorAndRetry(
     actionLabel: String,
     userMessageStateHolder: UserMessageStateHolder,
-    retryAction: (suspend (Throwable) -> Unit)? = null,
 ) = retry { throwable ->
-    // ② Application wide error handling
-    val applicationErrorMessage = throwable.toApplicationErrorMessage()
-
-    // Shared snackbar message logic
     val messageResult = userMessageStateHolder.showMessage(
-        message = applicationErrorMessage,
+        message = throwable.toApplicationErrorMessage(),
         actionLabel = actionLabel,
     )
 
     val retryPerformed = messageResult == UserMessageResult.ActionPerformed
 
-    if (retryPerformed && retryAction != null) {
-        retryAction(throwable)
-        return@retry false
-    }
-
     retryPerformed
+}.catch { /* Do nothing if the user dose not retry. */ }
+
+fun <T> Flow<T>.handleErrorAndRetryAction(
+    actionLabel: String,
+    userMessageStateHolder: UserMessageStateHolder,
+    retryAction: suspend ((Throwable) -> Unit),
+) = catch { throwable ->
+    val messageResult = userMessageStateHolder.showMessage(
+        message = throwable.toApplicationErrorMessage(),
+        actionLabel = actionLabel,
+    )
+
+    if (messageResult == UserMessageResult.ActionPerformed) {
+        retryAction(throwable)
+    }
 }.catch { /* Do nothing if the user dose not retry. */ }
 
 // ① Single source of truth of UiState


### PR DESCRIPTION
The following issue: https://github.com/DroidKaigi/conference-app-2023/issues/96.

Originally crashed when multiple exceptions occurred, but changed to allow multiple retries.
Defined as an extension function at the same time.

I also thought about allowing another process to be performed instead of retrying when an exception occurs, but I decided that there would be more cases of retries, so I made the process assuming a retry.

https://user-images.githubusercontent.com/19385268/236610942-35f3f1a2-5d85-4012-a977-28713a512678.mp4


