### PR TITLE
Import compose multiplatform screen from contributor module for trial

### DIFF
--- a/app-ios-shared/build.gradle.kts
+++ b/app-ios-shared/build.gradle.kts
@@ -16,10 +16,12 @@ kotlin {
             it.binaries {
                 framework {
                     baseName = frameworkName
+                    isStatic = true
                     embedBitcode(BitcodeEmbeddingMode.DISABLE)
                     binaryOption("bundleId", "io.github.droidkaigi.confsched2023.shared")
                     binaryOption("bundleVersion", version.toString())
                     xcf.add(this)
+                    export(project(":feature:contributors"))
                 }
             }
         }
@@ -44,6 +46,7 @@ kotlin {
             dependencies {
                 implementation(projects.core.model)
                 implementation(libs.kotlinxCoroutinesCore)
+                api(project(":feature:contributors"))
             }
         }
     }

--- a/app-ios/App/DroidKaigi2023/DroidKaigi2023/ContentView.swift
+++ b/app-ios/App/DroidKaigi2023/DroidKaigi2023/ContentView.swift
@@ -8,6 +8,16 @@
 import SwiftUI
 import shared
 
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let controller = Main_iosKt.MainViewController()
+        controller.overrideUserInterfaceStyle = .light
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
 struct ContentView: View {
     var body: some View {
         VStack {
@@ -16,6 +26,7 @@ struct ContentView: View {
                 .foregroundColor(.accentColor)
             Text("Hello, world!")
             Text(EntryPoint().echo())
+            ComposeView()
         }
         .padding()
     }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpIosPlugin.kt
@@ -24,7 +24,10 @@ class KmpIosPlugin : Plugin<Project> {
                         } ?: System.getenv("arch")
                 )
                 when (activeArch) {
-                    ARM -> iosSimulatorArm64()
+                    ARM -> {
+                        iosSimulatorArm64()
+                        iosArm64()
+                    }
                     X86 -> iosX64()
                     ALL -> {
                         iosArm64()

--- a/feature/contributors/src/iosMain/kotlin/main.ios.kt
+++ b/feature/contributors/src/iosMain/kotlin/main.ios.kt
@@ -1,0 +1,11 @@
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.ComposeUIViewController
+import platform.UIKit.UIViewController
+
+fun MainViewController() : UIViewController = ComposeUIViewController { MainView() }
+
+@Composable
+fun MainView() {
+    Text("2023/06/02")
+}


### PR DESCRIPTION
close https://github.com/DroidKaigi/conference-app-2023/issues/78

This PR is based on https://github.com/DroidKaigi/conference-app-2023/pull/166.
Added 1 compose-based `MainView` and referred from iOS side.

<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/4f8be586-35d5-40cf-801f-51e27d5bcba2" width="300" />
