### PR TITLE
Use jvmTarget instead of jvmToolchain

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `kotlin-dsl`
 }
@@ -9,11 +11,9 @@ repositories {
     mavenCentral()
 }
 
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-}
+// If we use jvmToolchain, we need to install JDK 11
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions.jvmTarget = "11"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- If we use jvmToolchain, we need to install JDK 11
- I think all we need jdk is 17.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />