### PR TITLE
Fixed layout around TopAppBar

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -1,16 +1,20 @@
 package io.github.droidkaigi.confsched2023.sessions
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -19,10 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.sessions.component.rememberTimetableScreenScrollState
@@ -77,22 +79,27 @@ private fun TimetableScreen(
             )
         },
         topBar = {
-            // TODO: Implement design
-            val insetPadding = TopAppBarDefaults.windowInsets.asPaddingValues()
-            val statusBarHeight = with(LocalDensity.current) {
-                insetPadding.calculateTopPadding().toPx()
+            Column {
+                // TODO: Implement TopAppBar design
+                TopAppBar(
+                    title = {
+                        Text(text = "KaigiApp")
+                    },
+                    colors = TopAppBarDefaults.largeTopAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    ),
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .onGloballyPositioned { coordinates ->
+                            state.onHeaderPositioned(coordinates.size.height.toFloat())
+                        },
+                ) {
+                    // TODO: Implement header desing(title and image etc..)
+                    Spacer(modifier = Modifier.height(130.dp))
+                }
             }
-            LargeTopAppBar(
-                title = {
-                    Text(text = "KaigiApp")
-                },
-                colors = TopAppBarDefaults.largeTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                ),
-                modifier = Modifier.onGloballyPositioned { coordinates ->
-                    state.onLargeTopBarPositioned(coordinates.size.height.toFloat(), statusBarHeight)
-                },
-            )
         },
         containerColor = MaterialTheme.colorScheme.surfaceVariant,
         contentWindowInsets = WindowInsets(0.dp),
@@ -100,7 +107,6 @@ private fun TimetableScreen(
         TimetableSheet(
             modifier = Modifier
                 .fillMaxSize()
-                .zIndex(2f) // display above TopAppBar
                 .padding(innerPadding)
                 .layout { measurable, constraints ->
                     val placeable = measurable.measure(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableScreenScrollState.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableScreenScrollState.kt
@@ -97,8 +97,8 @@ class TimetableScreenScrollState(
         }
     }
 
-    fun onLargeTopBarPositioned(largeAppBarHeight: Float, statusBarHeight: Float) {
-        sheetScrollOffsetLimit = 0f - abs(largeAppBarHeight - statusBarHeight)
+    fun onHeaderPositioned(headerHeight: Float) {
+        sheetScrollOffsetLimit = 0f - abs(headerHeight)
     }
 
     companion object {


### PR DESCRIPTION
## Issue
- #209

## Overview (Required)
- Fixed timetable sheet does not cover TopAppBar.  

## Links
- https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=54477-38169&mode=dev

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13705006/0aea7867-420c-4027-8017-858027996096" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13705006/c647c2f3-f800-4c45-9036-a189c770377d" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13705006/76615cf9-8bc4-43b5-9dfe-7008a148242e" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13705006/f3ef6112-2db5-46a0-b704-af74b56d6994" width="300" />
