### PR TITLE
Fix Workflow Hook sometimes comments on a none-related PR

### DIFF
--- a/.github/workflows/WorkflowHook.yml
+++ b/.github/workflows/WorkflowHook.yml
@@ -49,11 +49,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
       - id: linked-pull-request
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:


### PR DESCRIPTION
## Issue
- close #230

## Overview (Required)

Workflow Hook sometimes comments on a none-related PR .
This is because we don't specify the `head` parameter properly to get `List pull requests`.
We need to pass `user:ref-name` or `organization:ref-name` as a `head` parameter.

https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests

![image](https://github.com/DroidKaigi/conference-app-2023/assets/5106629/16427e98-053d-4f8b-bb3f-07328a58b43a)

I considered saving the PR numbers to a file as in the screenshot test.
However, adding that process in several workflows did not seem like a good way to go, and the amount of change would be too large, so I did not adopt it this time.