### PR TITLE
[iOS] Rename `sessions()` to `timetable()`

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableViewModel.swift
@@ -15,7 +15,7 @@ final class TimetableViewModel: ObservableObject {
             state = .loading
         }
         do {
-            let timetable = try await FakeSessionsApi().sessions()
+            let timetable = try await FakeSessionsApi().timetable()
             let timetableTimeGroupItems = timetable.timetableItems.map {
                     TimetableTimeGroupItems.Duration(startsAt: $0.startsAt, endsAt: $0.endsAt)
                 }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Rename `sessions()` to `timetable()` in order to fix the compilation error.
  - It was renamed in https://github.com/DroidKaigi/conference-app-2023/commit/ee61d39f1a644e6577ddb0bb2e25ff0654cc3b68#diff-f8b250227c2be377950003f19b299b7f3325f9e8a1ba951321846b9bf070f23cR7.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />