### PR TITLE
[Android] Add navigation from bookmark screen to timetable item detail screen

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -70,6 +70,11 @@ private fun KaigiNavHost(
             onNavigationIconClick = {
                 navController.popBackStack()
             },
+            onTimetableItemClick = { timetableItem ->
+                navController.navigateToTimetableItemDetailScreen(
+                    timetableItem.id,
+                )
+            },
         )
         searchScreen(
             onNavigationIconClick = {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreen.kt
@@ -46,12 +46,14 @@ sealed interface BookmarkScreenUiState {
 @Composable
 fun BookmarkScreen(
     onBackPressClick: () -> Unit,
+    onTimetableItemClick: (TimetableItem) -> Unit,
     viewModel: BookmarkScreenViewModel = hiltViewModel<BookmarkScreenViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     BookmarkScreen(
         uiState = uiState,
         onBackPressClick = onBackPressClick,
+        onTimetableItemClick = onTimetableItemClick,
         onBookmarkClick = { viewModel.updateBookmark(it) },
         onAllFilterChipClick = { viewModel.onAllFilterChipClick() },
         onDayFirstChipClick = { viewModel.onDayFirstChipClick() },
@@ -66,6 +68,7 @@ const val BookmarkScreenTestTag = "BookmarkScreenTestTag"
 private fun BookmarkScreen(
     uiState: BookmarkScreenUiState,
     onBackPressClick: () -> Unit,
+    onTimetableItemClick: (TimetableItem) -> Unit,
     onBookmarkClick: (TimetableItem) -> Unit,
     onAllFilterChipClick: () -> Unit,
     onDayFirstChipClick: () -> Unit,
@@ -87,6 +90,7 @@ private fun BookmarkScreen(
         BookmarkSheet(
             modifier = Modifier.padding(padding),
             scrollState = scrollState,
+            onTimetableItemClick = onTimetableItemClick,
             onBookmarkClick = onBookmarkClick,
             onAllFilterChipClick = onAllFilterChipClick,
             onDayFirstChipClick = onDayFirstChipClick,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -25,7 +25,10 @@ const val timetableItemDetailScreenRouteItemIdParameterName = "timetableItemId"
 const val timetableItemDetailScreenRoute =
     "timetableItemDetail/{$timetableItemDetailScreenRouteItemIdParameterName}"
 
-fun NavGraphBuilder.sessionScreens(onNavigationIconClick: () -> Unit) {
+fun NavGraphBuilder.sessionScreens(
+    onNavigationIconClick: () -> Unit,
+    onTimetableItemClick: (TimetableItem) -> Unit,
+) {
     composable(timetableItemDetailScreenRoute) {
         TimetableItemDetailScreen(
             onNavigationIconClick = onNavigationIconClick,
@@ -34,6 +37,7 @@ fun NavGraphBuilder.sessionScreens(onNavigationIconClick: () -> Unit) {
     composable(bookmarkScreenRoute) {
         BookmarkScreen(
             onBackPressClick = onNavigationIconClick,
+            onTimetableItemClick = onTimetableItemClick,
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
@@ -42,6 +42,7 @@ fun BookmarkList(
     scrollState: LazyListState,
     bookmarkedTimetableItemIds: PersistentSet<TimetableItemId>,
     timetableItemMap: PersistentMap<String, List<TimetableItem>>,
+    onTimetableItemClick: (TimetableItem) -> Unit,
     onBookmarkIconClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -110,7 +111,7 @@ fun BookmarkList(
                                 label = { Text(timetableItem.day?.name.orEmpty()) },
                             )
                         },
-                        onClick = { TODO() },
+                        onClick = onTimetableItemClick,
                         onBoomarkClick = onBookmarkIconClick,
                     )
                 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -34,6 +34,7 @@ import io.github.droidkaigi.confsched2023.sessions.component.BookmarkFilters
 fun BookmarkSheet(
     uiState: BookmarkScreenUiState,
     scrollState: LazyListState,
+    onTimetableItemClick: (TimetableItem) -> Unit,
     onBookmarkClick: (TimetableItem) -> Unit,
     onAllFilterChipClick: () -> Unit,
     onDayFirstChipClick: () -> Unit,
@@ -63,6 +64,7 @@ fun BookmarkSheet(
                     scrollState = scrollState,
                     bookmarkedTimetableItemIds = uiState.bookmarkedTimetableItemIds,
                     timetableItemMap = uiState.timetableItemMap,
+                    onTimetableItemClick = onTimetableItemClick,
                     onBookmarkIconClick = onBookmarkClick,
                 )
             }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Added an unimplemented navigation

## Links
- 

## Screenshot
Before | After
:--: | :--:
Not implemented | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/8e71a042-8782-4332-8ec3-ce50c0a0dbdd" width="300" />

