### PR TITLE
[Android] Fix to show the last timetable item

### DIFF
--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2023.main
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Approval
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -18,6 +19,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -141,6 +143,7 @@ private fun MainScreen(
         NavHost(
             navController = mainNestedNavController,
             startDestination = "timetable",
+            modifier = Modifier.padding(padding),
         ) {
             mainNestedNavGraph(mainNestedNavController, padding)
         }


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2023/issues/333

## Overview (Required)
- When scrolling down to the bottom, the last item was hidden by the bottom bar. So, fixed it to show.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/5ae16c2c-eb0d-4021-94f7-f8230b2054a1" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/01ce1613-62ac-409e-8108-24880a258410" width="300" />

