### PR TITLE
Make use of gh-actions 2023 in StagePush workflow

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - tomoya0x00/make_use_of_gh-actions_2023
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## Issue
- related issue https://github.com/DroidKaigi/conference-app-2023/issues/292

## Overview (Required)

Since `stage-app-push` has dependencies that use deprecated ways, we have some warnings in the action result of it like this:
https://github.com/DroidKaigi/conference-app-2023/actions/runs/5784566473

![image](https://github.com/DroidKaigi/conference-app-2023/assets/5106629/39ef9067-8b51-4067-94ba-93554cca1dc1)

This PR will fix it like this:

https://github.com/DroidKaigi/conference-app-2023/actions/runs/5786377245

There are no warnings!
![image](https://github.com/DroidKaigi/conference-app-2023/assets/5106629/f5dacb05-765c-43d0-a156-1ee8f0534198)


## Links
- https://github.com/DroidKaigi/conference-app-2023/tree/gh-actions
- https://github.com/tomoya0x00/dg-upload-app-action

