### PR TITLE
[iOS] Expand the description if it exceeds its line limit

### DIFF
--- a/app-ios/Modules/Sources/Session/SessionView.swift
+++ b/app-ios/Modules/Sources/Session/SessionView.swift
@@ -14,7 +14,8 @@ private let startDateFormatter: DateFormatter = {
 
 public struct SessionView: View {
     let viewModel: SessionViewModel
-    @State var isDescriptionExpanded: Bool = false
+    @State private var isDescriptionExpanded: Bool = false
+    @State private var canBeExpanded = false
 
     public init(timetableItem: TimetableItem) {
         self.viewModel = .init(timetableItem: timetableItem)
@@ -66,9 +67,21 @@ public struct SessionView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         Text(session.description_)
                             .lineLimit(isDescriptionExpanded ? nil : 5)
-                        if !isDescriptionExpanded {
+                            .background {
+                                ViewThatFits(in: .vertical) {
+                                    Text(session.description_)
+                                        .hidden()
+                                    // Just for receiving onAppear event if the description exceeds its line limit
+                                    Color.clear
+                                        .onAppear {
+                                            canBeExpanded = true
+                                        }
+                                }
+                            }
+                        if canBeExpanded {
                             Button {
                                 isDescriptionExpanded = true
+                                canBeExpanded = false
                             } label: {
                                 Text("続きを読む")
                                     .font(Font.system(size: 14, weight: .medium))
@@ -78,7 +91,6 @@ public struct SessionView: View {
                                         Capsule()
                                             .stroke(AssetColors.outline.swiftUIColor)
                                     }
-
                             }
                         }
                     }


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2023/issues/388

## Overview (Required)
- Expand the description if it exceeds its line limit
- I could not implement it with animation, so just switched the line limit and the visibility of "read more" button
- Recorded it by changing its line limit from 5 to 3
- The correct wording is not 続きを**見る** but 続きを**読む** (meaning that the issue is wrong 🙏)

## Links
- https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=54902-39762&mode=design&t=6onYY32rrDiIdXXS-0

## Screenshot
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/00318c8b-73d0-45e5-b818-ccaa8af1a99f" width="300" />


