### PR TITLE
[iOS] Fix wrong day information on timetable screen

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
@@ -14,14 +14,13 @@ struct TimetableDayHeader: View {
                 [DroidKaigi2023Day].fromKotlinArray(DroidKaigi2023Day.values()),
                 id: \.ordinal
             ) { (day: DroidKaigi2023Day) in
-                let startDay = Calendar.current.component(.day, from: day.start.toDate())
                 Button {
                     onSelect(day)
                 } label: {
                     VStack(spacing: 0) {
                         Text(day.name)
                             .font(Font.system(size: 12, weight: .semibold))
-                        Text("\(startDay)")
+                        Text("\(day.dayOfMonth)")
                             .font(Font.system(size: 24, weight: .semibold))
                             .frame(height: 32)
                     }


### PR DESCRIPTION
## Issue
- close #386 

## Overview (Required)
- SSIA

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/6c2dee19-25aa-48b7-a60c-bb85a9510fcb" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/384c8c10-a6c7-4a43-9301-d34ea1ea82a7" width="300" />
