### PR TITLE
Remove constraintlayout-compose for Kotlin Multiplatform Compatibility

### DIFF
--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
     implementation(libs.androidxActivityActivityCompose)
-    implementation(libs.composeConstraintLayout)
     implementation(libs.composeMaterialIcon)
     androidTestImplementation(libs.composeUiTestJunit4)
     debugImplementation(libs.composeUiTooling)

--- a/feature/floor-map/build.gradle.kts
+++ b/feature/floor-map/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
     implementation(libs.androidxActivityActivityCompose)
-    implementation(libs.composeConstraintLayout)
     implementation(libs.composeMaterialIcon)
     androidTestImplementation(libs.composeUiTestJunit4)
     debugImplementation(libs.composeUiTooling)

--- a/feature/sessions/build.gradle.kts
+++ b/feature/sessions/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
     implementation(libs.androidxActivityActivityCompose)
-    implementation(libs.composeConstraintLayout)
     implementation(libs.composeMaterialIcon)
     androidTestImplementation(libs.composeUiTestJunit4)
     debugImplementation(libs.composeUiTooling)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -1,10 +1,12 @@
 package io.github.droidkaigi.confsched2023.sessions.section
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
@@ -21,7 +23,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.sessions.BookmarkScreenUiState
 import io.github.droidkaigi.confsched2023.sessions.BookmarkScreenUiState.Empty
@@ -74,22 +75,18 @@ fun BookmarkSheet(
 
 @Composable
 private fun EmptyView() {
-    ConstraintLayout(
+    Column(
         modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
-        val (emptyText, icon) = createRefs()
         Box(
             modifier = Modifier
                 .size(84.dp)
                 .background(
                     color = Color(0xFFCEE9DB),
                     shape = RoundedCornerShape(24.dp),
-                )
-                .constrainAs(icon) {
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                    bottom.linkTo(emptyText.top, margin = 24.dp)
-                },
+                ),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
@@ -97,31 +94,23 @@ private fun EmptyView() {
                 contentDescription = null,
             )
         }
-        Column(
-            modifier = Modifier.constrainAs(emptyText) {
-                start.linkTo(parent.start)
-                end.linkTo(parent.end)
-                top.linkTo(parent.top)
-                bottom.linkTo(parent.bottom)
-            },
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                text = BookmarkedItemNotFound.asString(),
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium,
-                lineHeight = 24.sp,
-                color = Color(0xFF191C1A),
-            )
-            Spacer(modifier = Modifier.size(8.dp))
-            Text(
-                text = BookmarkedItemNotFoundSideNote.asString(),
-                fontSize = 14.sp,
-                lineHeight = 20.sp,
-                letterSpacing = 0.25.sp,
-                textAlign = TextAlign.Center,
-                color = Color(0xFF404944),
-            )
-        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = BookmarkedItemNotFound.asString(),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            lineHeight = 24.sp,
+            color = Color(0xFF191C1A),
+        )
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(
+            text = BookmarkedItemNotFoundSideNote.asString(),
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            letterSpacing = 0.25.sp,
+            textAlign = TextAlign.Center,
+            color = Color(0xFF404944),
+        )
+        Spacer(modifier = Modifier.height(108.dp))
     }
 }

--- a/feature/sponsors/build.gradle.kts
+++ b/feature/sponsors/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.composeUiToolingPreview)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
     implementation(libs.androidxActivityActivityCompose)
-    implementation(libs.composeConstraintLayout)
     implementation(libs.composeMaterialIcon)
     androidTestImplementation(libs.composeUiTestJunit4)
     debugImplementation(libs.composeUiTooling)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,6 @@ composeUiTestManifest = { module = "androidx.compose.ui:ui-test-manifest", versi
 composeHiltNavigtation = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "composeHiltNavigatiaon" }
 composeLintCheck = { module = "com.slack.lint.compose:compose-lint-checks", version = "1.2.0" }
 composeCoil = { module = "io.coil-kt:coil-compose", version = "2.4.0" }
-composeConstraintLayout = { module = "androidx.constraintlayout:constraintlayout-compose", version = "1.0.1" }
 composeImageLoader = { module = "io.github.qdsfdhvh:image-loader", version = "1.6.4" }
 accompanistSystemUiController = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 


### PR DESCRIPTION
## Issue
- close #270

## Overview (Required)
- Remove dependencies from all feature modules. 👋
- Use additional `Spacer` to align the layout without ConstraintLayout.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3405740/73279811-11c7-4ccc-95ea-5252abb9957c" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3405740/e80112f4-329c-47f2-936a-cc08947c6cd0" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3405740/4d331ff4-55a6-4bf1-b13f-e3b8ea33f02a" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3405740/223893d7-2a39-4c73-acf9-643f3b8446e3" width="300" />
