### PR TITLE
fixed, #276 BookmarkFilters uses Theme Color

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
@@ -5,17 +5,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2023.designsystem.theme.md_theme_light_outline
 import io.github.droidkaigi.confsched2023.model.DroidKaigi2023Day
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
 import kotlinx.collections.immutable.PersistentList
@@ -31,10 +30,11 @@ fun BookmarkFilters(
     modifier: Modifier = Modifier,
 ) {
     val selectedChipColor = AssistChipDefaults.assistChipColors(
-        containerColor = Color(0xFFCEE9DB),
+        containerColor = MaterialTheme.colorScheme.primary,
+        labelColor = MaterialTheme.colorScheme.onPrimary
     )
     val selectedChipBoarderColor = AssistChipDefaults.assistChipBorder(
-        borderColor = md_theme_light_outline,
+        borderColor = MaterialTheme.colorScheme.outline,
         borderWidth = 0.dp,
     )
     val isAll = currentDayFilter.size == DroidKaigi2023Day.values().size

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
@@ -31,7 +31,7 @@ fun BookmarkFilters(
 ) {
     val selectedChipColor = AssistChipDefaults.assistChipColors(
         containerColor = MaterialTheme.colorScheme.primary,
-        labelColor = MaterialTheme.colorScheme.onPrimary
+        labelColor = MaterialTheme.colorScheme.onPrimary,
     )
     val selectedChipBoarderColor = AssistChipDefaults.assistChipBorder(
         borderColor = MaterialTheme.colorScheme.outline,


### PR DESCRIPTION
## Issue
- close #276 

## Overview (Required)
- Use the value of MaterialTheme.colorScheme instead of the fixed color.
- Mapping
  - containerColor :  MaterialTheme.colorScheme.primary
  - labelColor : MaterialTheme.colorScheme.onPrimary
  - border color : MaterialTheme.colorScheme.outline

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/4b3afb99-2075-44c9-b5f2-193047bf12aa" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/bf6e69a3-ba1b-46ed-b75c-d817caf585f2" width="300" />