### PR TITLE
fix day label on timetable

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
@@ -24,7 +24,7 @@ public enum class DroidKaigi2023Day(
             .toInstant(TimeZone.of("UTC+9")),
     ),
     Day2(
-        day = 1,
+        day = 2,
         dayOfMonth = 15,
         start = LocalDateTime
             .parse("2023-09-15T00:00:00")
@@ -34,7 +34,7 @@ public enum class DroidKaigi2023Day(
             .toInstant(TimeZone.of("UTC+9")),
     ),
     Day3(
-        day = 1,
+        day = 3,
         dayOfMonth = 16,
         start = LocalDateTime
             .parse("2023-09-16T00:00:00")


### PR DESCRIPTION
## Issue
- close #358 

## Overview (Required)
- The day labels on timetable have all been fixed to the proper ones.

## Links
- Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/69156255/bcbd8b3e-6d58-4776-83d2-c95323f72541" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/69156255/1ed7ddac-aae0-4c53-bd0a-9bd420b58c69" width="300" />