### PR TITLE
[WIP]Address FIXME in Animation Calculation in BookmarkTopArea.kt

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreen.kt
@@ -7,6 +7,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -76,11 +79,15 @@ private fun BookmarkScreen(
     onDayThirdChipClick: () -> Unit,
 ) {
     val scrollState = rememberLazyListState()
+    var firstItemHeightDp by remember {
+        mutableStateOf<Float?>(null)
+    }
     Scaffold(
         modifier = Modifier.testTag(BookmarkScreenTestTag),
         topBar = {
             BookmarkTopArea(
                 scrollState = scrollState,
+                firstItemHeightDp = firstItemHeightDp,
                 onBackPressClick = onBackPressClick,
             )
         },
@@ -96,6 +103,9 @@ private fun BookmarkScreen(
             onDayFirstChipClick = onDayFirstChipClick,
             onDaySecondChipClick = onDaySecondChipClick,
             onDayThirdChipClick = onDayThirdChipClick,
+            onFirstItemHeightDpMeasured = {
+                firstItemHeightDp = it
+            },
             uiState = uiState,
         )
     }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkTopArea.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.lerp
@@ -34,6 +35,7 @@ import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
 @Composable
 fun BookmarkTopArea(
     scrollState: LazyListState,
+    firstItemHeightDp: Float?,
     onBackPressClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -46,22 +48,33 @@ fun BookmarkTopArea(
         fontWeight = FontWeight.Normal,
     )
 
-    val fraction by remember {
+    val density = LocalDensity.current.density
+    val fraction by remember(firstItemHeightDp) {
         derivedStateOf {
-            if (scrollState.firstVisibleItemIndex == 0) {
-                scrollState.firstVisibleItemScrollOffset / 520F
+            if (firstItemHeightDp != null) {
+                if (scrollState.firstVisibleItemIndex == 0) {
+                    scrollState.firstVisibleItemScrollOffset / (firstItemHeightDp * density)
+                } else {
+                    1F
+                }
             } else {
-                1F
+                0F
             }
         }
     }
-
-    val rowNum by remember {
+    val rowNum by remember(firstItemHeightDp) {
         derivedStateOf {
-            if (scrollState.firstVisibleItemIndex == 0 && scrollState.firstVisibleItemScrollOffset / 520F < 1F) {
-                1
+            if (firstItemHeightDp != null) {
+                if (scrollState.firstVisibleItemIndex == 0 &&
+                    scrollState.firstVisibleItemScrollOffset /
+                    (firstItemHeightDp * density) < 1F
+                ) {
+                    1
+                } else {
+                    2
+                }
             } else {
-                2
+                1
             }
         }
     }
@@ -122,9 +135,8 @@ fun BookmarkTopArea(
                 text = SessionsStrings.Bookmark.asString(),
                 style = titleTextStyle,
                 modifier = Modifier.padding(
-                    // FIXME: If we don't use this `if` expresson, a crash happen
-                    start = if (titlePaddingStart >= 0.dp) titlePaddingStart else 0.dp,
-                    top = if (titlePaddingTop >= 0.dp) titlePaddingTop else 0.dp,
+                    start = titlePaddingStart,
+                    top = titlePaddingTop,
                 ),
             )
         }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
@@ -17,6 +17,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -44,15 +46,31 @@ fun BookmarkList(
     timetableItemMap: PersistentMap<String, List<TimetableItem>>,
     onTimetableItemClick: (TimetableItem) -> Unit,
     onBookmarkIconClick: (TimetableItem) -> Unit,
+    onFirstItemHeightDpMeasured: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val current = LocalDensity.current
     LazyColumn(
         state = scrollState,
         modifier = modifier.padding(end = 16.dp),
     ) {
-        timetableItemMap.forEach { (_, values) ->
+        val firstKey = timetableItemMap.keys.firstOrNull()
+        timetableItemMap.forEach { (key, values) ->
             itemsIndexed(values) { index, timetableItem ->
-                Row(modifier = Modifier.padding(top = 10.dp)) {
+                val onGloballyPositionedModifier = if (key == firstKey && index == 0) {
+                    Modifier.onGloballyPositioned {
+                        with(current) {
+                            onFirstItemHeightDpMeasured(it.size.height.toDp().value)
+                        }
+                    }
+                } else {
+                    Modifier
+                }
+                Row(
+                    modifier = Modifier
+                        .then(onGloballyPositionedModifier)
+                        .padding(top = 10.dp),
+                ) {
                     Column(
                         modifier = Modifier.width(58.dp),
                         verticalArrangement = Arrangement.Center,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -40,6 +40,7 @@ fun BookmarkSheet(
     onDayFirstChipClick: () -> Unit,
     onDaySecondChipClick: () -> Unit,
     onDayThirdChipClick: () -> Unit,
+    onFirstItemHeightDpMeasured: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -65,6 +66,7 @@ fun BookmarkSheet(
                     bookmarkedTimetableItemIds = uiState.bookmarkedTimetableItemIds,
                     timetableItemMap = uiState.timetableItemMap,
                     onTimetableItemClick = onTimetableItemClick,
+                    onFirstItemHeightDpMeasured = onFirstItemHeightDpMeasured,
                     onBookmarkIconClick = onBookmarkClick,
                 )
             }


### PR DESCRIPTION
## Issue
- close #273

## Overview (Required)

### Problem

- On this issue, `titlePaddingStart` and `titlePaddingTop` in the BookmarkTopArea.kt is calculated by `fraction`.
- `fraction` is culculated by `scrollState.firstVisibleItemScrollOffset` and fixed pixel 520.
- If user selects large font and bookmarks item which has long title, `scrollState.firstVisibleItemScrollOffset` may be more than 520 pixel.
- So `fraction` may be more than 1.0f.
- So `titlePaddingTop` may be less than 0.0f
- `Modifier.padding` must not be a negative value, or the app will crash.

### Solution

- I use first item's height insted of fixed pixel 520.
- First item's height is measured by `onGloballyPositioned` modifier

## Links

- [Jetpack Composeでサイズを取得する](https://zenn.dev/yumemi_inc/articles/36c43b84f8a3e3)

## Screenshot
Before(not use this `if` expresson) | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/16898831/d85063a7-ec13-4a2c-8c2b-4924519c7aac" width="300" /> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/16898831/aa5326c5-27c0-4495-9e78-e5a4b3f735bf" width="300" />