### PR TITLE
Enable trailing comma on Kotlin

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -31,6 +31,7 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="99" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="99" />
       <option name="IMPORT_NESTED_CLASSES" value="true" />
+      <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <Properties>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>


### PR DESCRIPTION
## Issue
- close #477

## Overview (Required)
- The properties below should always be enabled.
- Check style
  - Preferences | Editor | Code Style | Kotlin 
  - Select other tab
  - Checked "trailing comma"

## Links
- none

## Screenshot

<img width="982" alt="image" src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/9d3c4fb7-2b33-4cd0-940e-6494c5a94d31">
