### PR TITLE
Proper layout of AssistChip in the archive portion of the timetable detail screen.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SessionsStrings.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SessionsStrings.kt
@@ -56,7 +56,7 @@ sealed class SessionsStrings : Strings<SessionsStrings>(Bindings) {
                 SupportedLanguages -> "対応言語"
                 InterpretationTarget -> "同時通訳対象"
                 Archive -> "アーカイブ"
-                ViewDocument -> "ドキュメントを見る"
+                ViewDocument -> "資料を見る"
                 TargetAudience -> "対象者"
                 WatchVideo -> "動画を見る"
                 Speaker -> "スピーカー"

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,15 +13,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.PlayCircle
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2023.designsystem.theme.md_theme_light_outline
@@ -168,69 +168,82 @@ private fun ArchiveSection(
             modifier = Modifier
                 .padding(top = 16.dp)
                 .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(space = 8.dp)
         ) {
-            Box(modifier = Modifier.weight(1F)) {
-                AssistChip(
-                    onClick = { onViewDocumentClick() },
-                    label = {
-                        Text(
-                            text = SessionsStrings.ViewDocument.asString(),
-                            fontSize = 14.sp,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            textAlign = TextAlign.Center,
-                        )
-                    },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Default.Description,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(width = 18.dp, height = 18.dp),
-                        )
-                    },
-                    colors = AssistChipDefaults.assistChipColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                    ),
-                    shape = RoundedCornerShape(100.dp),
-                    border = AssistChipDefaults.assistChipBorder(
-                        borderColor = MaterialTheme.colorScheme.primary,
-                    ),
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
-            Box(modifier = Modifier.weight(1F)) {
-                AssistChip(
-                    onClick = { onWatchVideoClick() },
-                    label = {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.PlayCircle,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onPrimary,
-                                modifier = Modifier.size(width = 18.dp, height = 18.dp),
-                            )
-                            Text(
-                                text = SessionsStrings.WatchVideo.asString(),
-                                fontSize = 14.sp,
-                                color = MaterialTheme.colorScheme.onPrimary,
-                            )
-                        }
-                    },
-                    colors = AssistChipDefaults.assistChipColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                    ),
-                    shape = RoundedCornerShape(100.dp),
-                    border = AssistChipDefaults.assistChipBorder(
-                        borderColor = MaterialTheme.colorScheme.primary,
-                    ),
-                    modifier = Modifier.align(Alignment.Center),
-                )
-            }
+            TimeTableIconButton(
+                icon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Description,
+                        contentDescription = null,
+                        modifier = Modifier.size(width = 18.dp, height = 18.dp),
+                    )
+                },
+                label = {
+                    Text(
+                        text = SessionsStrings.ViewDocument.asString(),
+                        fontSize = 14.sp,
+                        textAlign = TextAlign.Center
+                    )
+                },
+                onClick = { onViewDocumentClick() },
+                modifier = Modifier
+                    .width(0.dp)
+                    .weight(1F)
+            )
+
+            TimeTableIconButton(
+                icon = {
+                    Icon(
+                        imageVector = Icons.Outlined.PlayCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(width = 18.dp, height = 18.dp),
+                    )
+                },
+                label = {
+                    Text(
+                        text = SessionsStrings.WatchVideo.asString(),
+                        fontSize = 14.sp,
+                        textAlign = TextAlign.Center
+                    )
+                },
+                onClick = { onWatchVideoClick() },
+                modifier = Modifier
+                    .width(0.dp)
+                    .weight(1F)
+            )
         }
         Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun TimeTableIconButton(
+    icon: @Composable () -> Unit,
+    label: @Composable () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    iconSpacing: Dp = 8.dp
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        shape = RoundedCornerShape(100.dp),
+        onClick = { onClick() }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(
+                space = iconSpacing,
+                alignment = Alignment.CenterHorizontally
+            )
+        ) {
+            icon()
+            label()
+        }
     }
 }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -170,7 +170,7 @@ private fun ArchiveSection(
                 .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(space = 8.dp)
         ) {
-            TimeTableIconButton(
+            ArchiveSectionIconButton(
                 icon = {
                     Icon(
                         imageVector = Icons.Outlined.Description,
@@ -191,7 +191,7 @@ private fun ArchiveSection(
                     .weight(1F)
             )
 
-            TimeTableIconButton(
+            ArchiveSectionIconButton(
                 icon = {
                     Icon(
                         imageVector = Icons.Outlined.PlayCircle,
@@ -217,7 +217,7 @@ private fun ArchiveSection(
 }
 
 @Composable
-private fun TimeTableIconButton(
+private fun ArchiveSectionIconButton(
     icon: @Composable () -> Unit,
     label: @Composable () -> Unit,
     onClick: () -> Unit,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -168,7 +168,7 @@ private fun ArchiveSection(
             modifier = Modifier
                 .padding(top = 16.dp)
                 .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(space = 8.dp)
+            horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
         ) {
             ArchiveSectionIconButton(
                 icon = {
@@ -182,13 +182,13 @@ private fun ArchiveSection(
                     Text(
                         text = SessionsStrings.ViewDocument.asString(),
                         fontSize = 14.sp,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
                 },
                 onClick = { onViewDocumentClick() },
                 modifier = Modifier
                     .width(0.dp)
-                    .weight(1F)
+                    .weight(1F),
             )
 
             ArchiveSectionIconButton(
@@ -203,13 +203,13 @@ private fun ArchiveSection(
                     Text(
                         text = SessionsStrings.WatchVideo.asString(),
                         fontSize = 14.sp,
-                        textAlign = TextAlign.Center
+                        textAlign = TextAlign.Center,
                     )
                 },
                 onClick = { onWatchVideoClick() },
                 modifier = Modifier
                     .width(0.dp)
-                    .weight(1F)
+                    .weight(1F),
             )
         }
         Spacer(modifier = Modifier.height(24.dp))
@@ -222,14 +222,14 @@ private fun ArchiveSectionIconButton(
     label: @Composable () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    iconSpacing: Dp = 8.dp
+    iconSpacing: Dp = 8.dp,
 ) {
     Surface(
         modifier = modifier,
         color = MaterialTheme.colorScheme.primary,
         contentColor = MaterialTheme.colorScheme.onPrimary,
         shape = RoundedCornerShape(100.dp),
-        onClick = { onClick() }
+        onClick = { onClick() },
     ) {
         Row(
             modifier = Modifier
@@ -238,8 +238,8 @@ private fun ArchiveSectionIconButton(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(
                 space = iconSpacing,
-                alignment = Alignment.CenterHorizontally
-            )
+                alignment = Alignment.CenterHorizontally,
+            ),
         ) {
             icon()
             label()


### PR DESCRIPTION
## Issue
- close #335

## Overview (Required)
Make the following modifications
- Change "ドキュメント" to "資料
- Change the icon from the Filled style to the Outline style to match the design of the Figma.
- **Implementation of ArchiveSectionIconButton using slot api concept**
>    AssistChip was not able to set the spacing between the icon and label.
Because of this, I noticed that existing code also had this problem, bundling the icon and label together in the 'label' parameter.
I didn't think this was right, so I created a TimeTableIconButton composable to represent the two buttons.

## Links


## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/53253298/af3d7e22-6d7a-4eeb-ba37-7bbe06c4af64" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/53253298/330231b1-499e-4e34-9fda-ebc45f15c063" width="300" />