### PR TITLE
fixed, BookmarkFilters chip color

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
@@ -31,8 +31,8 @@ fun BookmarkFilters(
     modifier: Modifier = Modifier,
 ) {
     val selectedChipColor = AssistChipDefaults.assistChipColors(
-        containerColor = MaterialTheme.colorScheme.primary,
-        labelColor = MaterialTheme.colorScheme.onPrimary,
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
     )
     val selectedChipBoarderColor = AssistChipDefaults.assistChipBorder(
         borderColor = MaterialTheme.colorScheme.outline,


### PR DESCRIPTION
## Issue
- close #491

## Overview (Required)
- According to the M3 Color Rule, a chip should have a secondary container applied to it.
- Use secondary container Color
- The Light Theme colors you see in Figma are different from the actual Secondary colors, but that's a different issue, so we're only focusing on the color mapping.

## Links
- M3 : https://m3.material.io/styles/color/the-color-system/color-roles#904230ec-ae73-4f0f-8bff-4024a036ca66
- DroidKaigi figma : https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=54588-37352&mode=dev

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/e965aa09-3309-4d1d-bbaa-00e02575edac" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/318d1d86-70d7-45fa-a72a-b1abbb91092e" width="300" />