### PR TITLE
Update Bookmark Icon to bookmarks Icon in TimetableTopArea

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -2,9 +2,9 @@ package io.github.droidkaigi.confsched2023.sessions.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -54,7 +54,7 @@ fun TimetableTopArea(
                 onClick = { onTopAreaBookmarkIconClick() },
             ) {
                 Icon(
-                    imageVector = Icons.Default.BookmarkBorder,
+                    imageVector = Icons.Outlined.Bookmarks,
                     contentDescription = Timetable.asString(),
                 )
             }


### PR DESCRIPTION
## Issue
- close  #356

## Overview (Required)
- Change Icon to bookmark instead of bookmarks to clarify not bookmarking

## Screenshot
Before | After
:--: | :--:
![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/1da22284-74fb-44b9-80f6-0224c1a80468) | ![after](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/8161d1ff-c0aa-4de1-ae5d-566ee111a547)
