### PR TITLE
Modify the design of the icons in the card section

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
@@ -12,11 +12,10 @@ import androidx.compose.material.icons.outlined.Place
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
@@ -36,11 +35,7 @@ fun TimetableItemDetailSummaryCard(
     Card(
         shape = RoundedCornerShape(12.dp),
         modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                1.dp,
-            ),
-        ),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF2F4F1))
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
@@ -12,10 +12,11 @@ import androidx.compose.material.icons.outlined.Place
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
@@ -35,7 +36,11 @@ fun TimetableItemDetailSummaryCard(
     Card(
         shape = RoundedCornerShape(12.dp),
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = Color(0xFFF2F4F1)),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
+                1.dp,
+            ),
+        ),
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
@@ -35,7 +35,7 @@ fun TimetableItemDetailSummaryCard(
     Card(
         shape = RoundedCornerShape(12.dp),
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = Color(0xFFF2F4F1))
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF2F4F1)),
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Category
-import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.Place
-import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.outlined.Category
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material.icons.outlined.Place
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -49,22 +49,22 @@ fun TimetableItemDetailSummaryCard(
                 .padding(horizontal = 16.dp, vertical = 24.dp),
         ) {
             TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Filled.Schedule,
+                leadingIcon = Icons.Outlined.Schedule,
                 label = SessionsStrings.Date.asString(),
                 content = timetableItem.formattedDateTimeString,
             )
             TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Filled.Place,
+                leadingIcon = Icons.Outlined.Place,
                 label = SessionsStrings.Place.asString(),
                 content = timetableItem.room.name.currentLangTitle,
             )
             TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Filled.Language,
+                leadingIcon = Icons.Outlined.Language,
                 label = SessionsStrings.SupportedLanguages.asString(),
                 content = timetableItem.getSupportedLangString(isJapaneseLocale),
             )
             TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Filled.Category,
+                leadingIcon = Icons.Outlined.Category,
                 label = SessionsStrings.Category.asString(),
                 content = timetableItem.category.title.currentLangTitle,
             )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCardRow.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCardRow.kt
@@ -36,7 +36,7 @@ fun TimetableItemDetailSummaryCardRow(
             text = label,
             fontWeight = FontWeight.Bold,
             style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.width(12.dp))
         Text(text = content, style = MaterialTheme.typography.bodyMedium)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCardRow.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCardRow.kt
@@ -36,6 +36,7 @@ fun TimetableItemDetailSummaryCardRow(
             text = label,
             fontWeight = FontWeight.Bold,
             style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         Spacer(modifier = Modifier.width(12.dp))
         Text(text = content, style = MaterialTheme.typography.bodyMedium)


### PR DESCRIPTION
## Issue
- close #319

## Overview (Required)
- Modified the design of the icons in the card section on the timetable detail screen.
- [x] Icon tint colors are different, change to appropriate color
- [x] wording tint colors are different, change to appropriate color
- [ ] Change the background color of the card components to the appropriate color because they are different

## Links
- [Figma link](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=54902-39762&mode=design&t=8E9hM0o5yKWdKDoQ-4)

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/57510192/7ed58729-4c90-44cd-8dab-864ae4c3e133" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/57510192/672f73e7-b958-4747-8f66-111d0dc32c2c" width="300" />