### PR TITLE
fixed, accessibility of session details

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailFooter.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailFooter.kt
@@ -33,13 +33,13 @@ fun TimetableItemDetailFooter(
             IconButton(onClick = { /*TODO*/ }) {
                 Icon(
                     imageVector = Icons.Filled.Share,
-                    contentDescription = SessionsStrings.Share.toString(),
+                    contentDescription = SessionsStrings.Share.asString(),
                 )
             }
             IconButton(onClick = { /*TODO*/ }) {
                 Icon(
                     painter = painterResource(id = R.drawable.calendar_add_on),
-                    contentDescription = SessionsStrings.AddToCalendar.toString(),
+                    contentDescription = SessionsStrings.AddToCalendar.asString(),
                 )
             }
         },
@@ -53,7 +53,7 @@ fun TimetableItemDetailFooter(
                 if (isBookmarked) {
                     Icon(
                         imageVector = Icons.Filled.Bookmark,
-                        contentDescription = SessionsStrings.RemoveFromFavorites.toString(),
+                        contentDescription = SessionsStrings.RemoveFromFavorites.asString(),
                     )
                 } else {
                     Icon(


### PR DESCRIPTION
## Issue
- close #503 

## Overview (Required)
- Improve accessibility of the bottom area of the session details.

## Links
- none

## Screenshot
Share | Calendar
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/5f7caaf2-a2b4-4970-8681-6b0dffa738b1" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/256f7b19-f39b-4f79-9525-22fa312cdee2" width="300" />

Bookmark Checked | Bookmark Unchecked
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/15d2c28f-1bbd-46da-b08c-5342674a9177" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1534926/d1a8674d-5cc0-4eeb-885a-c26505502a8a" width="300" />