### PR TITLE
Customize Chip Colors According to Room Labels 

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
@@ -1,7 +1,5 @@
 package io.github.droidkaigi.confsched2023.data.sessions
 
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion
 import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.http.GET
 import io.github.droidkaigi.confsched2023.data.NetworkService

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2023.data.sessions
 
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Logger.Companion
 import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.http.GET
 import io.github.droidkaigi.confsched2023.data.NetworkService
@@ -70,19 +72,19 @@ internal fun SessionsAllResponse.toTimetable(): Timetable {
                 )
             }.first()
         }
-    val roomIdToRoom = timetableContents.rooms
-        .groupBy { it.id }
-        .mapValues { (_, apiRooms) ->
-            apiRooms.map { apiRoom ->
-                val roomSorts = apiRooms.map { it.sort }.sorted()
+    val roomIdToRoom: Map<Int, TimetableRoom> = timetableContents.rooms
+        .associateBy(
+            keySelector = { room -> room.id },
+            valueTransform = { room ->
+                val roomSorts = timetableContents.rooms.map { it.sort }.sorted()
                 TimetableRoom(
-                    id = apiRoom.id,
-                    name = apiRoom.name.toMultiLangText(),
-                    sort = apiRoom.sort,
-                    sortIndex = roomSorts.indexOf(apiRoom.sort),
+                    id = room.id,
+                    name = room.name.toMultiLangText(),
+                    sort = room.sort,
+                    sortIndex = roomSorts.indexOf(room.sort),
                 )
-            }.first()
-        }
+            },
+        )
 
     return Timetable(
         TimetableItemList(


### PR DESCRIPTION
## Issue
- close #501 

## Overview (Required)
- The reason why the color did not change was that the sortIndex was always set to 0
- Used `associateBy` to make it clear that it is a `Map<Int, TimetableRoom>`

## Log
I used `.also { println(it) }` at the end of the variable `roomIdToRoom` that I changed this time to output the log
- Before
```
{35497=TimetableRoom(id=35497, name=MultiLangText(jaTitle=Chipmunk, enTitle=Chipmunk), sort=0, sortIndex=0), 37290=TimetableRoom(id=37290, name=MultiLangText(jaTitle=Dolphin, enTitle=Dolphin), sort=4, sortIndex=0), 37291=TimetableRoom(id=37291, name=MultiLangText(jaTitle=Electric Eel, enTitle=Electric Eel), sort=5, sortIndex=0), 35499=TimetableRoom(id=35499, name=MultiLangText(jaTitle=Bumblebee, enTitle=Bumblebee), sort=2, sortIndex=0), 35498=TimetableRoom(id=35498, name=MultiLangText(jaTitle=Arctic Fox, enTitle=Arctic Fox), sort=1, sortIndex=0)}
```
- After
```
{35497=TimetableRoom(id=35497, name=MultiLangText(jaTitle=Chipmunk, enTitle=Chipmunk), sort=0, sortIndex=0), 37290=TimetableRoom(id=37290, name=MultiLangText(jaTitle=Dolphin, enTitle=Dolphin), sort=4, sortIndex=3), 37291=TimetableRoom(id=37291, name=MultiLangText(jaTitle=Electric Eel, enTitle=Electric Eel), sort=5, sortIndex=4), 35499=TimetableRoom(id=35499, name=MultiLangText(jaTitle=Bumblebee, enTitle=Bumblebee), sort=2, sortIndex=2), 35498=TimetableRoom(id=35498, name=MultiLangText(jaTitle=Arctic Fox, enTitle=Arctic Fox), sort=1, sortIndex=1)}
```

## Links
- [Kotlin - associateBy](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.sequences/associate-by.html)

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/60963155/e40b9a74-ab12-4cda-a0e5-5e8df77a2314" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/60963155/25800d6e-c031-4997-8d33-5957393a2da5" width="300" />
