### PR TITLE
[feature/#424] Implement Sponsor List and Design on SponsorsScreen

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -97,6 +97,9 @@ private fun KaigiNavHost(
             },
         )
         sponsorsScreen(
+            onNavigationIconClick = {
+                navController.popBackStack()
+            },
             onSponsorClick = { sponsor ->
                 TODO()
             },

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Sponsor.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Sponsor.kt
@@ -35,21 +35,21 @@ public enum class Plan {
 public fun Sponsor.Companion.fakes(): PersistentList<Sponsor> = (
     List(3) {
         Sponsor(
-            name = "DroidKaigi",
+            name = "DroidKaigi PLATINUM Section $it",
             logo = "https://placehold.jp/150x150.png",
             plan = Plan.PLATINUM,
             link = "https://developer.android.com/",
         )
     } + List(5) {
         Sponsor(
-            name = "DroidKaigi",
+            name = "DroidKaigi GOLD Section $it",
             logo = "https://placehold.jp/150x150.png",
             plan = Plan.GOLD,
             link = "https://developer.android.com/",
         )
     } + List(12) {
         Sponsor(
-            name = "DroidKaigi",
+            name = "DroidKaigi Supporter Section $it",
             logo = "https://placehold.jp/150x150.png",
             plan = Plan.SUPPORTER,
             link = "https://developer.android.com/",

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Sponsor.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Sponsor.kt
@@ -26,6 +26,10 @@ public enum class Plan {
 
     public val isSupporter: Boolean
         get() = this == SUPPORTER
+    public val isPlatinum: Boolean
+        get() = this == PLATINUM
+    public val isGold: Boolean
+        get() = this == GOLD
 }
 
 public fun Sponsor.Companion.fakes(): PersistentList<Sponsor> = (

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/SponsorsScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/SponsorsScreenRobot.kt
@@ -29,7 +29,8 @@ class SponsorsScreenRobot @Inject constructor(
         composeTestRule.setContent {
             KaigiTheme {
                 SponsorsScreen(
-                    onSponsorClick = { },
+                    onNavigationIconClick = {},
+                    onSponsorClick = {},
                 )
             }
         }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -2,11 +2,18 @@ package io.github.droidkaigi.confsched2023.sponsors
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -22,10 +29,12 @@ import kotlinx.collections.immutable.ImmutableList
 
 const val sponsorsScreenRoute = "sponsors"
 fun NavGraphBuilder.sponsorsScreen(
+    onNavigationIconClick: () -> Unit,
     onSponsorClick: (Sponsor) -> Unit,
 ) {
     composable(sponsorsScreenRoute) {
         SponsorsScreen(
+            onNavigationIconClick = onNavigationIconClick,
             onSponsorClick = onSponsorClick,
         )
     }
@@ -39,6 +48,7 @@ const val SponsorsScreenTestTag = "SponsorsScreen"
 
 @Composable
 fun SponsorsScreen(
+    onNavigationIconClick: () -> Unit,
     onSponsorClick: (Sponsor) -> Unit,
     viewModel: SponsorsScreenViewModel = hiltViewModel<SponsorsScreenViewModel>(),
 ) {
@@ -51,6 +61,7 @@ fun SponsorsScreen(
     )
     SponsorsScreen(
         uiState = uiState,
+        onBackClick = onNavigationIconClick,
         snackbarHostState = snackbarHostState,
         onSponsorClick = onSponsorClick,
     )
@@ -60,14 +71,35 @@ data class SponsorsScreenUiState(
     val sponsors: ImmutableList<Sponsor>,
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SponsorsScreen(
     uiState: SponsorsScreenUiState,
+    onBackClick: () -> Unit,
     snackbarHostState: SnackbarHostState,
     onSponsorClick: (Sponsor) -> Unit,
 ) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
         modifier = Modifier.testTag(SponsorsScreenTestTag),
+        topBar = {
+            LargeTopAppBar(
+                title = {
+                    Text(text = "Sponsor")
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBackClick,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->
             Column(

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2023.sponsors
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -8,7 +8,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -18,12 +17,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import io.github.droidkaigi.confsched2023.model.Sponsor
+import io.github.droidkaigi.confsched2023.sponsors.section.SponsorList
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.ImmutableList
 
@@ -102,16 +103,14 @@ private fun SponsorsScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->
-            Column(
-                Modifier
-                    .padding(padding),
-            ) {
-                Text(
-                    text = "Please implement SponsorsScreen!!!",
-                    style = MaterialTheme.typography.titleLarge,
-                )
-                Text(text = "uiState.sponsors.size:" + uiState.sponsors.size)
-            }
+            SponsorList(
+                sponsors = uiState.sponsors,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .nestedScroll(scrollBehavior.nestedScrollConnection),
+                onSponsorClick = onSponsorClick,
+            )
         },
     )
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -100,7 +100,7 @@ private fun SponsorsScreen(
                         )
                     }
                 },
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -70,6 +70,9 @@ fun SponsorsScreen(
 
 data class SponsorsScreenUiState(
     val sponsors: ImmutableList<Sponsor>,
+    val platinumSponsors: ImmutableList<Sponsor>,
+    val goldSponsors: ImmutableList<Sponsor>,
+    val supporters: ImmutableList<Sponsor>,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -104,7 +107,9 @@ private fun SponsorsScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->
             SponsorList(
-                sponsors = uiState.sponsors,
+                platinumSponsors = uiState.platinumSponsors,
+                goldSponsors = uiState.goldSponsors,
+                supporters = uiState.supporters,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -69,7 +69,6 @@ fun SponsorsScreen(
 }
 
 data class SponsorsScreenUiState(
-    val sponsors: ImmutableList<Sponsor>,
     val platinumSponsors: ImmutableList<Sponsor>,
     val goldSponsors: ImmutableList<Sponsor>,
     val supporters: ImmutableList<Sponsor>,

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
@@ -7,6 +7,7 @@ import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched2023.ui.buildUiState
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -29,6 +30,9 @@ class SponsorsScreenViewModel @Inject constructor(
     val uiState: StateFlow<SponsorsScreenUiState> = buildUiState(sponsorsStateFlow) { sponsors ->
         SponsorsScreenUiState(
             sponsors = sponsors,
+            platinumSponsors = sponsors.filter { it.plan.isPlatinum }.toImmutableList(),
+            goldSponsors = sponsors.filter { it.plan.isGold }.toImmutableList(),
+            supporters = sponsors.filter { it.plan.isSupporter }.toImmutableList(),
         )
     }
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
@@ -29,7 +29,6 @@ class SponsorsScreenViewModel @Inject constructor(
 
     val uiState: StateFlow<SponsorsScreenUiState> = buildUiState(sponsorsStateFlow) { sponsors ->
         SponsorsScreenUiState(
-            sponsors = sponsors,
             platinumSponsors = sponsors.filter { it.plan.isPlatinum }.toImmutableList(),
             goldSponsors = sponsors.filter { it.plan.isGold }.toImmutableList(),
             supporters = sponsors.filter { it.plan.isSupporter }.toImmutableList(),

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorHeader.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorHeader.kt
@@ -1,0 +1,29 @@
+package io.github.droidkaigi.confsched2023.sponsors.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SponsorHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = title,
+        modifier = modifier.padding(16.dp),
+        style = MaterialTheme.typography.titleMedium,
+    )
+}
+
+@Preview
+@Composable
+fun SponsorHeaderPreview() {
+    SponsorHeader(
+        title = "PLATINUM SPONSORS",
+    )
+}

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorHeader.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorHeader.kt
@@ -15,7 +15,7 @@ fun SponsorHeader(
 ) {
     Text(
         text = title,
-        modifier = modifier.padding(16.dp),
+        modifier = modifier.padding(vertical = 16.dp),
         style = MaterialTheme.typography.titleMedium,
     )
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
@@ -1,0 +1,55 @@
+package io.github.droidkaigi.confsched2023.sponsors.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.model.Sponsor
+import io.github.droidkaigi.confsched2023.model.fakes
+
+@Composable
+fun SponsorItem(
+    sponsor: Sponsor,
+    modifier: Modifier = Modifier,
+    onSponsorClick: (Sponsor) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                top = if (sponsor.plan.isPlatinum) 0.dp else 8.dp,
+                bottom = if (sponsor.plan.isPlatinum) 12.dp else 8.dp
+            )
+            .clickable { onSponsorClick(sponsor) }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    color = Color.White,
+                    shape = RoundedCornerShape(if (sponsor.plan.isSupporter) 4.dp else 8.dp)
+                )
+        ) {
+            // TODO Implement Sponsor UI
+        }
+
+    }
+}
+
+@Preview
+@Composable
+fun SponsorItemPreview() {
+    SponsorItem(
+        sponsor = Sponsor.fakes().first(),
+        onSponsorClick = {},
+    )
+}

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
@@ -27,21 +27,20 @@ fun SponsorItem(
             .fillMaxWidth()
             .padding(
                 top = if (sponsor.plan.isPlatinum) 0.dp else 8.dp,
-                bottom = if (sponsor.plan.isPlatinum) 12.dp else 8.dp
+                bottom = if (sponsor.plan.isPlatinum) 12.dp else 8.dp,
             )
-            .clickable { onSponsorClick(sponsor) }
+            .clickable { onSponsorClick(sponsor) },
     ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(
                     color = Color.White,
-                    shape = RoundedCornerShape(if (sponsor.plan.isSupporter) 4.dp else 8.dp)
-                )
+                    shape = RoundedCornerShape(if (sponsor.plan.isSupporter) 4.dp else 8.dp),
+                ),
         ) {
             // TODO Implement Sponsor UI
         }
-
     }
 }
 

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -1,17 +1,26 @@
 package io.github.droidkaigi.confsched2023.sponsors.section
 
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
 import io.github.droidkaigi.confsched2023.sponsors.component.SponsorHeader
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+
+private const val SPONSOR_LIST_COLUMNS = 6
+private const val SINGLE_ITEM_SPAN_COUNT = 6
+private const val DOUBLE_ITEM_SPAN_COUNT = 6 / 2
+private const val TRIPLE_ITEM_SPAN_COUNT = 6 / 3
 
 @Composable
 fun SponsorList(
@@ -21,39 +30,49 @@ fun SponsorList(
     modifier: Modifier = Modifier,
     onSponsorClick: (Sponsor) -> Unit = {},
 ) {
-    LazyColumn(
-        modifier = modifier
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(SPONSOR_LIST_COLUMNS),
+        modifier = modifier.padding(horizontal = 16.dp),
     ) {
-        item {
+        item(
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+        ) {
             SponsorHeader(title = "PLATINUM SPONSORS")
         }
         items(
             items = platinumSponsors,
             key = { sponsor -> sponsor.name },
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
         ) { sponsor ->
             Text(
                 text = sponsor.name,
                 style = MaterialTheme.typography.bodyMedium,
             )
         }
-        item {
+        item(
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+        ) {
             SponsorHeader(title = "GOLD SPONSORS")
         }
         items(
             items = goldSponsors,
             key = { sponsor -> sponsor.name },
+            span = { GridItemSpan(DOUBLE_ITEM_SPAN_COUNT) }
         ) { sponsor ->
             Text(
                 text = sponsor.name,
                 style = MaterialTheme.typography.bodyMedium,
             )
         }
-        item {
+        item(
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+        ) {
             SponsorHeader(title = "SUPPORTERS")
         }
         items(
             items = supporters,
             key = { sponsor -> sponsor.name },
+            span = { GridItemSpan(TRIPLE_ITEM_SPAN_COUNT) }
         ) { sponsor ->
             Text(
                 text = sponsor.name,

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -11,10 +11,13 @@ import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
 import io.github.droidkaigi.confsched2023.sponsors.component.SponsorHeader
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun SponsorList(
-    sponsors: ImmutableList<Sponsor>,
+    platinumSponsors: ImmutableList<Sponsor>,
+    goldSponsors: ImmutableList<Sponsor>,
+    supporters: ImmutableList<Sponsor>,
     modifier: Modifier = Modifier,
     onSponsorClick: (Sponsor) -> Unit = {},
 ) {
@@ -25,7 +28,7 @@ fun SponsorList(
             SponsorHeader(title = "PLATINUM SPONSORS")
         }
         items(
-            items = sponsors.drop(5),
+            items = platinumSponsors,
             key = { sponsor -> sponsor.name },
         ) { sponsor ->
             Text(
@@ -37,7 +40,7 @@ fun SponsorList(
             SponsorHeader(title = "GOLD SPONSORS")
         }
         items(
-            items = sponsors.drop(5),
+            items = goldSponsors,
             key = { sponsor -> sponsor.name },
         ) { sponsor ->
             Text(
@@ -49,7 +52,7 @@ fun SponsorList(
             SponsorHeader(title = "SUPPORTERS")
         }
         items(
-            items = sponsors.drop(5),
+            items = supporters,
             key = { sponsor -> sponsor.name },
         ) { sponsor ->
             Text(
@@ -64,6 +67,8 @@ fun SponsorList(
 @Composable
 fun SponsorListPreview() {
     SponsorList(
-        sponsors = Sponsor.fakes(),
+        platinumSponsors = Sponsor.fakes().take(5).toImmutableList(),
+        goldSponsors = Sponsor.fakes().take(5).toImmutableList(),
+        supporters = Sponsor.fakes().take(5).toImmutableList(),
     )
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -1,12 +1,13 @@
 package io.github.droidkaigi.confsched2023.sponsors.section
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -14,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
 import io.github.droidkaigi.confsched2023.sponsors.component.SponsorHeader
+import io.github.droidkaigi.confsched2023.sponsors.component.SponsorItem
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -33,6 +35,7 @@ fun SponsorList(
     LazyVerticalGrid(
         columns = GridCells.Fixed(SPONSOR_LIST_COLUMNS),
         modifier = modifier.padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item(
             span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
@@ -44,10 +47,14 @@ fun SponsorList(
             key = { sponsor -> sponsor.name },
             span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
         ) { sponsor ->
-            Text(
-                text = sponsor.name,
-                style = MaterialTheme.typography.bodyMedium,
+            SponsorItem(
+                sponsor = sponsor,
+                modifier = Modifier.height(110.dp),
+                onSponsorClick = onSponsorClick,
             )
+        }
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
         }
         item(
             span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
@@ -59,9 +66,10 @@ fun SponsorList(
             key = { sponsor -> sponsor.name },
             span = { GridItemSpan(DOUBLE_ITEM_SPAN_COUNT) }
         ) { sponsor ->
-            Text(
-                text = sponsor.name,
-                style = MaterialTheme.typography.bodyMedium,
+            SponsorItem(
+                sponsor = sponsor,
+                modifier = Modifier.height(77.dp),
+                onSponsorClick = onSponsorClick,
             )
         }
         item(
@@ -74,10 +82,14 @@ fun SponsorList(
             key = { sponsor -> sponsor.name },
             span = { GridItemSpan(TRIPLE_ITEM_SPAN_COUNT) }
         ) { sponsor ->
-            Text(
-                text = sponsor.name,
-                style = MaterialTheme.typography.bodyMedium,
+            SponsorItem(
+                sponsor = sponsor,
+                modifier = Modifier.height(77.dp),
+                onSponsorClick = onSponsorClick,
             )
+        }
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -1,0 +1,44 @@
+package io.github.droidkaigi.confsched2023.sponsors.section
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import io.github.droidkaigi.confsched2023.model.Sponsor
+import io.github.droidkaigi.confsched2023.model.fakes
+import kotlinx.collections.immutable.ImmutableList
+
+@Composable
+fun SponsorList(
+    sponsors: ImmutableList<Sponsor>,
+    modifier: Modifier = Modifier,
+    onSponsorClick: (Sponsor) -> Unit = {},
+) {
+    LazyColumn(
+        modifier = modifier
+    ) {
+        item {
+            Text(
+                text = "PLATINUM SPONSORS",
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+        items(sponsors) { sponsor ->
+            Text(
+                text = sponsor.name,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SponsorListPreview() {
+    SponsorList(
+        sponsors = Sponsor.fakes(),
+    )
+}

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -38,14 +38,14 @@ fun SponsorList(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item(
-            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) {
             SponsorHeader(title = "PLATINUM SPONSORS")
         }
         items(
             items = platinumSponsors,
             key = { sponsor -> sponsor.name },
-            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) { sponsor ->
             SponsorItem(
                 sponsor = sponsor,
@@ -57,14 +57,14 @@ fun SponsorList(
             Spacer(modifier = Modifier.height(8.dp))
         }
         item(
-            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) {
             SponsorHeader(title = "GOLD SPONSORS")
         }
         items(
             items = goldSponsors,
             key = { sponsor -> sponsor.name },
-            span = { GridItemSpan(DOUBLE_ITEM_SPAN_COUNT) }
+            span = { GridItemSpan(DOUBLE_ITEM_SPAN_COUNT) },
         ) { sponsor ->
             SponsorItem(
                 sponsor = sponsor,
@@ -73,14 +73,14 @@ fun SponsorList(
             )
         }
         item(
-            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) }
+            span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) {
             SponsorHeader(title = "SUPPORTERS")
         }
         items(
             items = supporters,
             key = { sponsor -> sponsor.name },
-            span = { GridItemSpan(TRIPLE_ITEM_SPAN_COUNT) }
+            span = { GridItemSpan(TRIPLE_ITEM_SPAN_COUNT) },
         ) { sponsor ->
             SponsorItem(
                 sponsor = sponsor,

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
+import io.github.droidkaigi.confsched2023.sponsors.component.SponsorHeader
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -21,10 +22,7 @@ fun SponsorList(
         modifier = modifier
     ) {
         item {
-            Text(
-                text = "PLATINUM SPONSORS",
-                style = MaterialTheme.typography.titleMedium,
-            )
+            SponsorHeader(title = "PLATINUM SPONSORS")
         }
         items(sponsors) { sponsor ->
             Text(
@@ -37,7 +35,7 @@ fun SponsorList(
 
 @Preview
 @Composable
-private fun SponsorListPreview() {
+fun SponsorListPreview() {
     SponsorList(
         sponsors = Sponsor.fakes(),
     )

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -38,6 +38,7 @@ fun SponsorList(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item(
+            key = "platinum_sponsor_header",
             span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) {
             SponsorHeader(title = "PLATINUM SPONSORS")
@@ -53,10 +54,13 @@ fun SponsorList(
                 onSponsorClick = onSponsorClick,
             )
         }
-        item {
+        item(
+            key = "spacer_under_platinum_sponsor",
+        ) {
             Spacer(modifier = Modifier.height(8.dp))
         }
         item(
+            key = "gold_sponsor_header",
             span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) {
             SponsorHeader(title = "GOLD SPONSORS")
@@ -73,6 +77,7 @@ fun SponsorList(
             )
         }
         item(
+            key = "supporter_header",
             span = { GridItemSpan(SINGLE_ITEM_SPAN_COUNT) },
         ) {
             SponsorHeader(title = "SUPPORTERS")
@@ -88,7 +93,9 @@ fun SponsorList(
                 onSponsorClick = onSponsorClick,
             )
         }
-        item {
+        item(
+            key = "spacer_under_supporter",
+        ) {
             Spacer(modifier = Modifier.height(16.dp))
         }
     }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -24,7 +24,34 @@ fun SponsorList(
         item {
             SponsorHeader(title = "PLATINUM SPONSORS")
         }
-        items(sponsors) { sponsor ->
+        items(
+            items = sponsors.drop(5),
+            key = { sponsor -> sponsor.name },
+        ) { sponsor ->
+            Text(
+                text = sponsor.name,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        item {
+            SponsorHeader(title = "GOLD SPONSORS")
+        }
+        items(
+            items = sponsors.drop(5),
+            key = { sponsor -> sponsor.name },
+        ) { sponsor ->
+            Text(
+                text = sponsor.name,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        item {
+            SponsorHeader(title = "SUPPORTERS")
+        }
+        items(
+            items = sponsors.drop(5),
+            key = { sponsor -> sponsor.name },
+        ) { sponsor ->
             Text(
                 text = sponsor.name,
                 style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
## Issue
- close #424 

## Overview (Required)
- Add SponsorList Composable in section package
- Add SponsorItem, SponsorHeader in component package
- Separate sponsors by plan at SponsorsUiState 

## Screenshot

<img src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/783087dc-91fb-4512-9b4f-aa9dd9c038d7" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/aad36225-a136-4a00-b915-c4cfaf443728" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/3e5b47f0-bbb8-4fbe-842e-684423325c73" width="300" />
