### PR TITLE
rename TimetableItemDetailFooter to TimetableItemDetailBottomAppBar

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -19,8 +19,8 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItemId
+import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailBottomAppBar
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailContent
-import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailFooter
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailScreenTopAppBar
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailSummaryCard
 
@@ -98,7 +98,7 @@ private fun TimetableItemDetailScreen(
         },
         bottomBar = {
             if (uiState is TimetableItemDetailScreenUiState.Loaded) {
-                TimetableItemDetailFooter(
+                TimetableItemDetailBottomAppBar(
                     timetableItem = uiState.timetableItem,
                     isBookmarked = uiState.isBookmarked,
                     onBookmarkClick = onBookmarkClick,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailBottomAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailBottomAppBar.kt
@@ -21,7 +21,7 @@ import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
 const val TimetableItemDetailBookmarkIconTestTag = "TimetableItemDetailBookmarkIcon"
 
 @Composable
-fun TimetableItemDetailFooter(
+fun TimetableItemDetailBottomAppBar(
     timetableItem: TimetableItem,
     isBookmarked: Boolean,
     onBookmarkClick: (TimetableItem) -> Unit,


### PR DESCRIPTION
## Issue
- close #285

## Overview (Required)
- just renamed a composable function for developer convenience :)

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/12797442/b2395367-a459-4302-adf7-62a7252492af" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/12797442/a94e6e21-b3e5-4d19-b5c4-14ca964ae56d" width="300" />
