### PR TITLE
[Proposal] add custom preview annotations for multi themes and languages

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpComposePlugin.kt
@@ -34,6 +34,7 @@ class KmpComposePlugin : Plugin<Project> {
                         dependencies {
                             implementation(libs.findLibrary("androidxActivityActivityCompose").get())
                             implementation(libs.findLibrary("androidxLifecycleLifecycleRuntimeKtx").get())
+                            implementation(libs.findLibrary("composeUiToolingPreview").get())
                         }
                     }
                 }

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
@@ -1,0 +1,34 @@
+package io.github.droidkaigi.confsched2023.designsystem.preview
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Annotation for previewing multiple themes.
+ */
+@Preview(
+    name = "Light Mode",
+    group = "Theme",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Preview(
+    name = "Dark Mode",
+    group = "Theme",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+annotation class MultiThemePreviews
+
+/**
+ * Annotation for previewing multiple languages.
+ */
+@Preview(
+    name = "Japanese",
+    group = "Language",
+    locale = "ja",
+)
+@Preview(
+    name = "English",
+    group = "Language",
+    locale = "en",
+)
+annotation class MultiLanguagePreviews


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- We are adopting multi themes (light/dark) and languages (ja/en)
- So added annotations to preview these configurations

## Example

```xml
<!-- Japanese -->
<string name="aaa">あああ</string>

<!-- English -->
<string name="aaa">aaa</string>
```

```kotlin
@MultiThemePreviews
@MultiLanguagePreviews
@Composable
fun TestPreview() {
    KaigiTheme {
        Surface {
            Text(text = stringResource(id = R.string.aaa))
        }
    }
}
```

![image](https://github.com/DroidKaigi/conference-app-2023/assets/43767445/09eb4fc9-4b25-41e2-a8d6-eab973c82931)

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />