### PR TITLE
replace bottomnav label stamps to badges

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -44,9 +44,9 @@ import io.github.droidkaigi.confsched2023.floormap.nestedFloorMapScreen
 import io.github.droidkaigi.confsched2023.main.MainNestedGraphStateHolder
 import io.github.droidkaigi.confsched2023.main.MainScreenTab
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.About
+import io.github.droidkaigi.confsched2023.main.MainScreenTab.Badges
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.Contributor
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.FloorMap
-import io.github.droidkaigi.confsched2023.main.MainScreenTab.Badges
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.Timetable
 import io.github.droidkaigi.confsched2023.main.mainScreen
 import io.github.droidkaigi.confsched2023.main.mainScreenRoute

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -46,7 +46,7 @@ import io.github.droidkaigi.confsched2023.main.MainScreenTab
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.About
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.Contributor
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.FloorMap
-import io.github.droidkaigi.confsched2023.main.MainScreenTab.Stamps
+import io.github.droidkaigi.confsched2023.main.MainScreenTab.Badges
 import io.github.droidkaigi.confsched2023.main.MainScreenTab.Timetable
 import io.github.droidkaigi.confsched2023.main.mainScreen
 import io.github.droidkaigi.confsched2023.main.mainScreenRoute
@@ -188,7 +188,7 @@ class KaigiAppMainNestedGraphStateHolder : MainNestedGraphStateHolder {
             contributorsScreenRoute -> Contributor
             aboutScreenRoute -> About
             floorMapScreenRoute -> FloorMap
-            stampsScreenRoute -> Stamps
+            stampsScreenRoute -> Badges
             else -> null
         }
     }
@@ -202,7 +202,7 @@ class KaigiAppMainNestedGraphStateHolder : MainNestedGraphStateHolder {
             About -> mainNestedNavController.navigateAboutScreen()
             FloorMap -> mainNestedNavController.navigateFloorMapScreen()
             Contributor -> mainNestedNavController.navigate(contributorsScreenRoute)
-            Stamps -> mainNestedNavController.navigateStampsScreen()
+            Badges -> mainNestedNavController.navigateStampsScreen()
         }
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/KaigiAppRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/KaigiAppRobot.kt
@@ -54,7 +54,7 @@ class KaigiAppRobot @Inject constructor(
 
     fun goToStamps() {
         composeTestRule
-            .onNode(hasTestTag(MainScreenTab.Stamps.testTag))
+            .onNode(hasTestTag(MainScreenTab.Badges.testTag))
             .performClick()
         waitUntilIdle()
     }

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -95,7 +95,7 @@ enum class MainScreenTab(
         label = MainStrings.FloorMap.asString(),
         contentDescription = MainStrings.FloorMap.asString(),
     ),
-    Stamps(
+    Badges(
         icon = Icons.Outlined.Approval,
         selectedIcon = Icons.Filled.Approval,
         label = MainStrings.Badges.asString(),

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -98,8 +98,8 @@ enum class MainScreenTab(
     Stamps(
         icon = Icons.Outlined.Approval,
         selectedIcon = Icons.Filled.Approval,
-        label = MainStrings.Stamps.asString(),
-        contentDescription = MainStrings.Stamps.asString(),
+        label = MainStrings.Badges.asString(),
+        contentDescription = MainStrings.Badges.asString(),
     ),
     About(
         icon = Icons.Outlined.Info,

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiBottomBar.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiBottomBar.kt
@@ -22,7 +22,7 @@ fun KaigiBottomBar(
         modifier = modifier,
     ) {
         mainScreenTabs.forEach { tab ->
-            if (tab == MainScreenTab.Stamps && isEnableStamps.not()) return@forEach
+            if (tab == MainScreenTab.Badges && isEnableStamps.not()) return@forEach
             val selected = currentTab == tab
             NavigationBarItem(
                 modifier = Modifier.testTag(tab.testTag),

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/strings/MainStrings.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/strings/MainStrings.kt
@@ -7,7 +7,7 @@ import io.github.droidkaigi.confsched2023.designsystem.strings.StringsBindings
 sealed class MainStrings : Strings<MainStrings>(Bindings) {
     data object Timetable : MainStrings()
     data object FloorMap : MainStrings()
-    data object Stamps : MainStrings()
+    data object Badges : MainStrings()
     data object About : MainStrings()
     data object Contributors : MainStrings()
     class Time(val hours: Int, val minutes: Int) : MainStrings()
@@ -17,7 +17,7 @@ sealed class MainStrings : Strings<MainStrings>(Bindings) {
             when (item) {
                 Timetable -> "Timetable"
                 FloorMap -> "Floor Map"
-                Stamps -> "Stamps"
+                Badges -> "Badges"
                 About -> "About"
                 Contributors -> "Contributors"
                 is Time -> "${item.hours}時${item.minutes}分"
@@ -27,7 +27,7 @@ sealed class MainStrings : Strings<MainStrings>(Bindings) {
             when (item) {
                 Timetable -> "Timetable"
                 FloorMap -> "Floor Map"
-                Stamps -> "Stamps"
+                Badges -> "Badges"
                 About -> "About"
                 Contributors -> "Contributors"
                 is Time -> "${item.hours}:${item.minutes}"


### PR DESCRIPTION
## Issue
- close #381 

## Overview (Required)

- Replaced the bottom navigation label. (Stamps -> Badges)

- Changed MainStrings class string.

- Icon image is not changed. (If you want to change it, please let me know. (If so, which image should I use?)

- The value of MainScreenTab is also changed to Stamps -> Badges.
However, The names of StampsScreen etc. remain the same.


## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/62790209/0325dae6-a10d-4358-ae43-b7b138f6f353" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/62790209/6b679f56-20a9-4ea4-92f1-5da4a6b33d70" width="300" />
