### PR TITLE
Update bookmarksheet emptyview colors to use theme colors

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -130,7 +130,7 @@ private fun EmptyView() {
             fontSize = 16.sp,
             fontWeight = FontWeight.Medium,
             lineHeight = 24.sp,
-            color = Color(0xFF191C1A),
+            color = MaterialTheme.colorScheme.onSurface,
         )
         Spacer(modifier = Modifier.size(8.dp))
         Text(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -139,7 +139,7 @@ private fun EmptyView() {
             lineHeight = 20.sp,
             letterSpacing = 0.25.sp,
             textAlign = TextAlign.Center,
-            color = Color(0xFF404944),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(108.dp))
     }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -113,7 +114,7 @@ private fun EmptyView() {
             modifier = Modifier
                 .size(84.dp)
                 .background(
-                    color = Color(0xFFCEE9DB),
+                    color = MaterialTheme.colorScheme.secondaryContainer,
                     shape = RoundedCornerShape(24.dp),
                 ),
             contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Issue
- close #275

## Overview (Required)
- I used material theme colors in `BookmarkSheet`.
  - ~~Because theme colors are not correctly defined, I have to fix the theme colors.~~
    - This is why the filter ui color is also fixed.
  - Because this page does not implement dark theme properly, I could not confirm to the design for dark mode. Anyway, I thought I fixed some theme colors for dark mode properly.
    - I found another issue for this problem ( #277 ) so this problem would be fixed in the near future.
- ~~I also thought that fixing theme colors unnecessarily expand the scope of the PR, so I'd like to discard some changes to theme colors if the reviewer requested :)~~

## Links
- 

## Screenshot

### Light mode

Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/12797442/d9ed1766-37d8-4fdf-93b2-9bff7bab5787" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/12797442/05ef6477-0ec9-4b10-a3c3-8f976f170656" width="300" />

### Dark mode

Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/12797442/ccdef15d-3214-4db3-ba27-995c687b889a" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/12797442/94eb65b9-c85a-4644-bd2e-cba026371c6a" width="300" />