### PR TITLE
Implement transition effects for navigation

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -24,7 +24,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -95,7 +94,7 @@ private fun KaigiNavHost(
     navController: NavHostController = rememberNavController(),
     externalNavController: ExternalNavController = rememberExternalNavController(),
 ) {
-    NavHost(navController = navController, startDestination = mainScreenRoute) {
+    NavHostWithSharedAxisX(navController = navController, startDestination = mainScreenRoute) {
         mainScreen(navController, externalNavController)
         sessionScreens(
             onNavigationIconClick = {

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/NavHostWithSharedAxisX.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/NavHostWithSharedAxisX.kt
@@ -1,0 +1,113 @@
+package io.github.droidkaigi.confsched2023
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+
+@Composable
+fun NavHostWithSharedAxisX(
+    navController: NavHostController,
+    startDestination: String,
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.Center,
+    route: String? = null,
+    builder: NavGraphBuilder.() -> Unit,
+) {
+    val slideDistance = rememberSlideDistance()
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = modifier,
+        contentAlignment = contentAlignment,
+        route = route,
+        enterTransition = {
+            materialSharedAxisXIn(
+                forward = true,
+                slideDistance = slideDistance,
+            )
+        },
+        exitTransition = {
+            materialSharedAxisXOut(
+                forward = true,
+                slideDistance = slideDistance,
+            )
+        },
+        popEnterTransition = {
+            materialSharedAxisXIn(
+                forward = false,
+                slideDistance = slideDistance,
+            )
+        },
+        popExitTransition = {
+            materialSharedAxisXOut(
+                forward = false,
+                slideDistance = slideDistance,
+            )
+        },
+        builder = builder,
+    )
+}
+
+@Composable
+private fun rememberSlideDistance(): Int {
+    val slideDistance: Dp = 30.dp
+    val density = LocalDensity.current
+    return remember(density, slideDistance) {
+        with(density) { slideDistance.roundToPx() }
+    }
+}
+
+private fun materialSharedAxisXIn(
+    forward: Boolean,
+    slideDistance: Int,
+): EnterTransition = slideInHorizontally(
+    animationSpec = tween(
+        durationMillis = 300,
+        easing = FastOutSlowInEasing,
+    ),
+    initialOffsetX = {
+        if (forward) slideDistance else -slideDistance
+    }
+) + fadeIn(
+    animationSpec = tween(
+        durationMillis = 195,
+        delayMillis = 105,
+        easing = LinearOutSlowInEasing,
+    )
+)
+
+private fun materialSharedAxisXOut(
+    forward: Boolean,
+    slideDistance: Int,
+): ExitTransition = slideOutHorizontally(
+    animationSpec = tween(
+        durationMillis = 300,
+        easing = FastOutSlowInEasing,
+    ),
+    targetOffsetX = {
+        if (forward) -slideDistance else slideDistance
+    }
+) + fadeOut(
+    animationSpec = tween(
+        durationMillis = 105,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing,
+    )
+)

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/NavHostWithSharedAxisX.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/NavHostWithSharedAxisX.kt
@@ -84,13 +84,13 @@ private fun materialSharedAxisXIn(
     ),
     initialOffsetX = {
         if (forward) slideDistance else -slideDistance
-    }
+    },
 ) + fadeIn(
     animationSpec = tween(
         durationMillis = 195,
         delayMillis = 105,
         easing = LinearOutSlowInEasing,
-    )
+    ),
 )
 
 private fun materialSharedAxisXOut(
@@ -103,11 +103,11 @@ private fun materialSharedAxisXOut(
     ),
     targetOffsetX = {
         if (forward) -slideDistance else slideDistance
-    }
+    },
 ) + fadeOut(
     animationSpec = tween(
         durationMillis = 105,
         delayMillis = 0,
         easing = FastOutLinearInEasing,
-    )
+    ),
 )

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(libs.composeMaterial)
     implementation(libs.composeMaterialIcon)
     implementation(libs.composeUiToolingPreview)
+    implementation(libs.composeNavigation)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
     implementation(libs.androidxActivityActivityCompose)
     androidTestImplementation(libs.composeUiTestJunit4)

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -163,13 +163,12 @@ private fun MainScreen(
     }
 }
 
-private fun materialFadeThroughIn(
-): EnterTransition = fadeIn(
+private fun materialFadeThroughIn(): EnterTransition = fadeIn(
     animationSpec = tween(
         durationMillis = 195,
         delayMillis = 105,
         easing = LinearOutSlowInEasing,
-    )
+    ),
 ) + scaleIn(
     animationSpec = tween(
         durationMillis = 195,
@@ -179,11 +178,10 @@ private fun materialFadeThroughIn(
     initialScale = 0.92f,
 )
 
-private fun materialFadeThroughOut(
-): ExitTransition = fadeOut(
+private fun materialFadeThroughOut(): ExitTransition = fadeOut(
     animationSpec = tween(
         durationMillis = 105,
         delayMillis = 0,
         easing = FastOutLinearInEasing,
-    )
+    ),
 )

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -1,5 +1,13 @@
 package io.github.droidkaigi.confsched2023.main
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
@@ -147,8 +155,35 @@ private fun MainScreen(
             navController = mainNestedNavController,
             startDestination = "timetable",
             modifier = Modifier.padding(padding),
+            enterTransition = { materialFadeThroughIn() },
+            exitTransition = { materialFadeThroughOut() },
         ) {
             mainNestedNavGraph(mainNestedNavController, padding)
         }
     }
 }
+
+private fun materialFadeThroughIn(
+): EnterTransition = fadeIn(
+    animationSpec = tween(
+        durationMillis = 195,
+        delayMillis = 105,
+        easing = LinearOutSlowInEasing,
+    )
+) + scaleIn(
+    animationSpec = tween(
+        durationMillis = 195,
+        delayMillis = 105,
+        easing = LinearOutSlowInEasing,
+    ),
+    initialScale = 0.92f,
+)
+
+private fun materialFadeThroughOut(
+): ExitTransition = fadeOut(
+    animationSpec = tween(
+        durationMillis = 105,
+        delayMillis = 0,
+        easing = FastOutLinearInEasing,
+    )
+)


### PR DESCRIPTION
## Issue
- close #530

## Overview (Required)
- Implement transition effects for `NavHost`.
   - In **MainScreen.kt**: [Fade through](https://m2.material.io/design/motion/the-motion-system.html#fade-through)
   - In **KaigiApp.kt**: [Shared Axis](https://m2.material.io/design/motion/the-motion-system.html#shared-axis)

## Links
- Material Design - Motion Specs:
   - Fade through: https://m2.material.io/design/motion/the-motion-system.html#fade-through
   - Shared axis: https://m2.material.io/design/motion/the-motion-system.html#shared-axis
- References: https://github.com/fornewid/material-motion-compose

## Screenshot
After (Fade through) | After (Shared Axis)
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/3405740/524230c1-3020-4c2b-ac23-823189770f96" width="300" /> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/3405740/03e8bb8f-6ef8-4a31-a49c-bbb97967a748" width="300" />
