### PR TITLE
Correction of Stamps package name

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -28,9 +28,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.momomomo111.stamps.navigateStampsScreen
-import com.momomomo111.stamps.nestedStampsScreen
-import com.momomomo111.stamps.stampsScreenRoute
 import io.github.droidkaigi.confsched2023.about.aboutScreenRoute
 import io.github.droidkaigi.confsched2023.about.navigateAboutScreen
 import io.github.droidkaigi.confsched2023.about.nestedAboutScreen
@@ -69,6 +66,9 @@ import io.github.droidkaigi.confsched2023.sessions.sessionScreens
 import io.github.droidkaigi.confsched2023.sessions.timetableScreenRoute
 import io.github.droidkaigi.confsched2023.sponsors.navigateSponsorsScreen
 import io.github.droidkaigi.confsched2023.sponsors.sponsorsScreen
+import io.github.droidkaigi.confsched2023.stamps.navigateStampsScreen
+import io.github.droidkaigi.confsched2023.stamps.nestedStampsScreen
+import io.github.droidkaigi.confsched2023.stamps.stampsScreenRoute
 
 @Composable
 fun KaigiApp(modifier: Modifier = Modifier) {

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/StampsScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/StampsScreenRobot.kt
@@ -3,8 +3,8 @@ package io.github.droidkaigi.confsched2023.testing.robot
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import com.github.takahirom.roborazzi.captureRoboImage
-import com.momomomo111.stamps.StampsScreen
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2023.stamps.StampsScreen
 import io.github.droidkaigi.confsched2023.testing.RobotTestRule
 import io.github.droidkaigi.confsched2023.testing.coroutines.runTestWithLogging
 import kotlinx.coroutines.test.TestDispatcher

--- a/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsScreen.kt
+++ b/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsScreen.kt
@@ -1,4 +1,4 @@
-package com.momomomo111.stamps
+package io.github.droidkaigi.confsched2023.stamps
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding

--- a/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsScreenViewModel.kt
+++ b/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsScreenViewModel.kt
@@ -1,4 +1,4 @@
-package com.momomomo111.stamps
+package io.github.droidkaigi.confsched2023.stamps
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsStrings.kt
+++ b/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsStrings.kt
@@ -1,4 +1,4 @@
-package com.momomomo111.stamps
+package io.github.droidkaigi.confsched2023.stamps
 
 import io.github.droidkaigi.confsched2023.designsystem.strings.Lang
 import io.github.droidkaigi.confsched2023.designsystem.strings.Strings

--- a/feature/stamps/src/test/java/io/github/droidkaigi/confsched2023/stamps/StampsScreenTest.kt
+++ b/feature/stamps/src/test/java/io/github/droidkaigi/confsched2023/stamps/StampsScreenTest.kt
@@ -1,4 +1,4 @@
-package com.momomomo111.stamps
+package io.github.droidkaigi.confsched2023.stamps
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers


### PR DESCRIPTION
## Overview (Required)
- Stamps package name was `com.momomomo111`, changed to `io.github.droidkaigi.confsched2023`.

## Links
- https://github.com/DroidKaigi/conference-app-2023/pull/513