### PR TITLE
:recycle: Implement processing when "View Map" is tapped.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -157,6 +157,7 @@ private fun NavGraphBuilder.mainScreen(
                         YouTube -> externalNavController.navigate(url = "https://www.youtube.com/c/DroidKaigi")
                     }
                 },
+                onLinkClick = externalNavController::navigate
             )
             nestedFloorMapScreen(
                 onSideEventClick = {

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -157,7 +157,7 @@ private fun NavGraphBuilder.mainScreen(
                         YouTube -> externalNavController.navigate(url = "https://www.youtube.com/c/DroidKaigi")
                     }
                 },
-                onLinkClick = externalNavController::navigate
+                onLinkClick = externalNavController::navigate,
             )
             nestedFloorMapScreen(
                 onSideEventClick = {

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/AboutScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/AboutScreenRobot.kt
@@ -37,6 +37,7 @@ class AboutScreenRobot @Inject constructor(
             KaigiTheme {
                 AboutScreen(
                     onAboutItemClick = { },
+                    onLinkClick = { },
                 )
             }
         }

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutScreen.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutScreen.kt
@@ -26,10 +26,12 @@ import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 const val aboutScreenRoute = "about"
 fun NavGraphBuilder.nestedAboutScreen(
     onAboutItemClick: (AboutItem) -> Unit,
+    onLinkClick: (url: String) -> Unit,
 ) {
     composable(aboutScreenRoute) {
         AboutScreen(
             onAboutItemClick = onAboutItemClick,
+            onLinkClick = onLinkClick,
         )
     }
 }
@@ -44,6 +46,7 @@ const val AboutScreenTestTag = "AboutScreen"
 fun AboutScreen(
     onAboutItemClick: (AboutItem) -> Unit,
     viewModel: AboutScreenViewModel = hiltViewModel<AboutScreenViewModel>(),
+    onLinkClick: (url: String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = SnackbarHostState()
@@ -56,6 +59,7 @@ fun AboutScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         onAboutItemClick = onAboutItemClick,
+        onLinkClick = onLinkClick,
     )
 }
 
@@ -66,6 +70,7 @@ private fun AboutScreen(
     uiState: AboutScreenUiState,
     snackbarHostState: SnackbarHostState,
     onAboutItemClick: (AboutItem) -> Unit,
+    onLinkClick: (url: String) -> Unit,
 ) {
     Scaffold(
         modifier = Modifier.testTag(AboutScreenTestTag),
@@ -82,7 +87,9 @@ private fun AboutScreen(
                     )
                 }
                 item {
-                    AboutDroidKaigiDetail()
+                    AboutDroidKaigiDetail(
+                        onLinkClick = onLinkClick,
+                    )
                 }
                 aboutCredits(
                     onSponsorsItemClick = {

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
@@ -11,7 +11,9 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
     object DateDescription : AboutStrings()
     object PlaceTitle : AboutStrings()
     object PlaceDescription : AboutStrings()
-    object PlaceLink : AboutStrings()
+    class PlaceLink(
+        val url: String = "https://goo.gl/maps/vv9sE19JvRjYKtSP9",
+    ) : AboutStrings()
     object CreditsTitle : AboutStrings()
     object Staff : AboutStrings()
     object Contributor : AboutStrings()
@@ -30,7 +32,7 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
                 DateDescription -> "2023.09.14(木) 〜 16(土) 3日間"
                 PlaceTitle -> "場所"
                 PlaceDescription -> "ベルサール渋谷ガーデン"
-                PlaceLink -> "地図を見る"
+                is PlaceLink -> "地図を見る"
                 CreditsTitle -> "Credits"
                 Staff -> "スタッフ"
                 Contributor -> "コントリビューター"
@@ -49,7 +51,7 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
                 DateDescription -> "2023.09.14(Thu) - 16(Sat) 3days"
                 PlaceTitle -> "Location"
                 PlaceDescription -> "Bellesalle Shibuya Garden"
-                PlaceLink -> "View Map"
+                is PlaceLink -> "View Map"
                 CreditsTitle -> bindings.defaultBinding(item, bindings)
                 Staff -> "Staff"
                 Contributor -> "Contributor"

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetail.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetail.kt
@@ -21,6 +21,7 @@ import io.github.droidkaigi.confsched2023.feature.about.R
 @Composable
 fun AboutDroidKaigiDetail(
     modifier: Modifier = Modifier,
+    onLinkClick: (url: String) -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -65,6 +66,7 @@ fun AboutDroidKaigiDetail(
                     top = 12.dp,
                     end = 16.dp,
                 ),
+            onLinkClick = onLinkClick,
         )
     }
 }
@@ -75,7 +77,9 @@ fun AboutDroidKaigiDetail(
 fun AboutDroidKaigiDetailPreview() {
     KaigiTheme {
         Surface {
-            AboutDroidKaigiDetail()
+            AboutDroidKaigiDetail(
+                onLinkClick = {},
+            )
         }
     }
 }
@@ -86,7 +90,9 @@ fun AboutDroidKaigiDetailPreview() {
 fun AboutDroidKaigiDetailDarkModePreview() {
     KaigiTheme {
         Surface {
-            AboutDroidKaigiDetail()
+            AboutDroidKaigiDetail(
+                onLinkClick = {},
+            )
         }
     }
 }

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetailSummaryCard.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetailSummaryCard.kt
@@ -20,6 +20,7 @@ import io.github.droidkaigi.confsched2023.about.AboutStrings
 @Composable
 fun AboutDroidKaigiDetailSummaryCard(
     modifier: Modifier = Modifier,
+    onLinkClick: (url: String) -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(12.dp),
@@ -42,11 +43,12 @@ fun AboutDroidKaigiDetailSummaryCard(
                 content = AboutStrings.DateDescription.asString(),
             )
             val placeContent = AboutStrings.PlaceDescription.asString()
-                .plus(" " + AboutStrings.PlaceLink.asString())
+                .plus(" " + AboutStrings.PlaceLink().asString())
             AboutDroidKaigiDetailSummaryCardRow(
                 leadingIcon = Icons.Filled.Place,
                 label = AboutStrings.PlaceTitle.asString(),
                 content = placeContent,
+                onLinkClick = onLinkClick,
             )
         }
     }

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
@@ -29,6 +29,7 @@ fun AboutDroidKaigiDetailSummaryCardRow(
     content: String,
     modifier: Modifier = Modifier,
     leadingIconContentDescription: String? = null,
+    onLinkClick: (url: String) -> Unit = {},
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -49,7 +50,7 @@ fun AboutDroidKaigiDetailSummaryCardRow(
         ClickableLinkText(
             style = MaterialTheme.typography.bodyMedium,
             content = content,
-            onLinkClick = {}, // TODO Go to FloorMapScreen
+            onLinkClick = onLinkClick,
         )
     }
 }
@@ -116,8 +117,9 @@ fun ClickableLinkText(
 ) {
     val findResults = findResults(
         content = content,
-        regex = AboutStrings.PlaceLink.asString().toRegex(),
+        regex = AboutStrings.PlaceLink().asString().toRegex(),
     )
+    val googleMapUrl = AboutStrings.PlaceLink().url
     val annotatedString = getAnnotatedString(
         content = content,
         findUrlResults = findResults,
@@ -134,7 +136,7 @@ fun ClickableLinkText(
                     start = offset,
                     end = offset,
                 ).firstOrNull()?.let {
-                    onLinkClick(matchResult.value)
+                    onLinkClick(googleMapUrl)
                 }
             }
         },


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fixed to be able to display the map using the #506 implementation from the About screen.

## Movie

- before
https://github.com/DroidKaigi/conference-app-2023/assets/13657682/f9a89c8f-dccd-4505-96d8-5b1b38b51616

- after
https://github.com/DroidKaigi/conference-app-2023/assets/13657682/a3d6f7c9-68a8-4ed7-89c4-da9c076935df
