### PR TITLE
[Bug][Android] Language is not switched in preview when the implementation of StringsBindings is used

### DIFF
--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/Lang.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/Lang.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched2023.designsystem.strings
 
-import java.util.Locale
+import androidx.compose.ui.text.intl.Locale
 
 actual fun lang(): String {
-    return Locale.getDefault().language
+    return Locale.current.language
 }


### PR DESCRIPTION
## Issue
- close #509 

## Overview (Required)
- `java.util.Locale.getDefault().language` -> `androidx.compose.ui.text.intl.Locale.current.language`

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/29175998/f0807a68-dde4-4355-ad09-0e8593d99293" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/29175998/2c226b2a-709d-41f3-8921-fbf678f08b87" width="300" />
