### PR TITLE
Add Accessibility ScreenShot Test for TimetableScreen

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
@@ -5,9 +5,12 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
+import com.github.takahirom.roborazzi.Dump
+import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
 import io.github.droidkaigi.confsched2023.data.sessions.FakeSessionsApiClient
 import io.github.droidkaigi.confsched2023.data.sessions.SessionsApiClient
@@ -133,6 +136,18 @@ class TimetableScreenRobot @Inject constructor(
         composeTestRule
             .onNode(hasTestTag(TimetableScreenTestTag))
             .captureRoboImage()
+    }
+
+    fun checkAccessibilityCapture() {
+        composeTestRule
+            .onRoot()
+            .captureRoboImage(
+                roborazziOptions = RoborazziOptions(
+                    captureType = RoborazziOptions.CaptureType.Dump(
+                        explanation = Dump.AccessibilityExplanation,
+                    ),
+                ),
+            )
     }
 
     fun waitUntilIdle() {

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenTest.kt
@@ -60,6 +60,15 @@ class TimetableScreenTest {
 
     @Test
     @Category(ScreenshotTests::class)
+    fun checkLaunchAccessibilityShot() {
+        timetableScreenRobot {
+            setupTimetableScreenContent()
+            checkAccessibilityCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
     fun checkBookmarkToggleShot() {
         timetableScreenRobot {
             setupTimetableScreenContent()


### PR DESCRIPTION
## Issue
- close #444 

## Overview (Required)
- Add `checkLaunchAccessibilityShot()` method from Snippets. Add Accessibility ScreenShot Test to TimetableScreen.

## Links
- 

## Screenshot
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/85218317/be4c8d3c-08b4-48d8-964e-48edd252660c" width="300" />