### PR TITLE
Feature/sponser list

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -112,6 +112,9 @@ private fun KaigiNavHost(
             onSponsorClick = { sponsor ->
                 TODO()
             },
+            onNavigationIconClick = {
+                navController.popBackStack()
+            },
         )
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/SponsorsScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/SponsorsScreenRobot.kt
@@ -30,6 +30,7 @@ class SponsorsScreenRobot @Inject constructor(
             KaigiTheme {
                 SponsorsScreen(
                     onSponsorClick = { },
+                    onNavigationIconClick = {}
                 )
             }
         }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -27,13 +27,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import io.github.droidkaigi.confsched2023.model.Plan
 import io.github.droidkaigi.confsched2023.model.Plan.GOLD
 import io.github.droidkaigi.confsched2023.model.Plan.PLATINUM
 import io.github.droidkaigi.confsched2023.model.Plan.SUPPORTER
 import io.github.droidkaigi.confsched2023.model.Sponsor
+import io.github.droidkaigi.confsched2023.sponsors.section.SponsorListUiState
 import io.github.droidkaigi.confsched2023.sponsors.section.sponsorList
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentMap
 
 const val sponsorsScreenRoute = "sponsors"
 fun NavGraphBuilder.sponsorsScreen(
@@ -76,7 +78,7 @@ fun SponsorsScreen(
 }
 
 data class SponsorsScreenUiState(
-    val sponsors: ImmutableList<Sponsor>,
+    val sponsorListUiStates: PersistentMap<Plan, SponsorListUiState>,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -119,26 +121,20 @@ private fun SponsorsScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(padding)
+                    .padding(horizontal = 16.dp)
             ){
                 sponsorList(
-                    title = SponsorsStrings.PlatinumSponsors,
-                    gridSize = 1,
+                    uiState = requireNotNull(uiState.sponsorListUiStates[PLATINUM]),
                     onSponsorClick = onSponsorClick,
-                    sponsorList = uiState.sponsors.filter { it.plan == PLATINUM }
                 )
                 sponsorList(
-                    title = SponsorsStrings.GoldSponsors,
-                    gridSize = 2,
+                    uiState = requireNotNull(uiState.sponsorListUiStates[GOLD]),
                     onSponsorClick = onSponsorClick,
-                    sponsorList = uiState.sponsors.filter { it.plan == GOLD }
                 )
                 sponsorList(
-                    title = SponsorsStrings.Supporters,
-                    gridSize = 3,
+                    uiState = requireNotNull(uiState.sponsorListUiStates[SUPPORTER]),
                     onSponsorClick = onSponsorClick,
-                    sponsorList = uiState.sponsors.filter { it.plan == SUPPORTER }
                 )
-
             }
         },
     )

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -1,32 +1,49 @@
 package io.github.droidkaigi.confsched2023.sponsors
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import io.github.droidkaigi.confsched2023.model.Plan.GOLD
+import io.github.droidkaigi.confsched2023.model.Plan.PLATINUM
+import io.github.droidkaigi.confsched2023.model.Plan.SUPPORTER
 import io.github.droidkaigi.confsched2023.model.Sponsor
+import io.github.droidkaigi.confsched2023.sponsors.section.sponsorList
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.ImmutableList
 
 const val sponsorsScreenRoute = "sponsors"
 fun NavGraphBuilder.sponsorsScreen(
     onSponsorClick: (Sponsor) -> Unit,
+    onNavigationIconClick: () -> Unit
 ) {
     composable(sponsorsScreenRoute) {
         SponsorsScreen(
             onSponsorClick = onSponsorClick,
+            onNavigationIconClick = onNavigationIconClick
         )
     }
 }
@@ -41,6 +58,7 @@ const val SponsorsScreenTestTag = "SponsorsScreen"
 fun SponsorsScreen(
     onSponsorClick: (Sponsor) -> Unit,
     viewModel: SponsorsScreenViewModel = hiltViewModel<SponsorsScreenViewModel>(),
+    onNavigationIconClick: () ->Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = SnackbarHostState()
@@ -53,6 +71,7 @@ fun SponsorsScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         onSponsorClick = onSponsorClick,
+        onBackClick = onNavigationIconClick
     )
 }
 
@@ -60,25 +79,66 @@ data class SponsorsScreenUiState(
     val sponsors: ImmutableList<Sponsor>,
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SponsorsScreen(
     uiState: SponsorsScreenUiState,
     snackbarHostState: SnackbarHostState,
     onSponsorClick: (Sponsor) -> Unit,
+    onBackClick: () -> Unit
 ) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val lazyListState = rememberLazyListState()
     Scaffold(
-        modifier = Modifier.testTag(SponsorsScreenTestTag),
+        topBar = {
+            LargeTopAppBar(
+                title = {
+                    Text(text = SponsorsStrings.Sponsor.asString())
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBackClick,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior
+            )
+        },
+        contentWindowInsets = WindowInsets(0.dp),
+        modifier = Modifier
+            .testTag(SponsorsScreenTestTag)
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->
-            Column(
-                Modifier
-                    .padding(padding),
-            ) {
-                Text(
-                    text = "Please implement SponsorsScreen!!!",
-                    style = MaterialTheme.typography.titleLarge,
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(padding)
+            ){
+                sponsorList(
+                    title = SponsorsStrings.PlatinumSponsors,
+                    gridSize = 1,
+                    onSponsorClick = onSponsorClick,
+                    sponsorList = uiState.sponsors.filter { it.plan == PLATINUM }
                 )
-                Text(text = "uiState.sponsors.size:" + uiState.sponsors.size)
+                sponsorList(
+                    title = SponsorsStrings.GoldSponsors,
+                    gridSize = 2,
+                    onSponsorClick = onSponsorClick,
+                    sponsorList = uiState.sponsors.filter { it.plan == GOLD }
+                )
+                sponsorList(
+                    title = SponsorsStrings.Supporters,
+                    gridSize = 3,
+                    onSponsorClick = onSponsorClick,
+                    sponsorList = uiState.sponsors.filter { it.plan == SUPPORTER }
+                )
+
             }
         },
     )

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -1,8 +1,11 @@
 package io.github.droidkaigi.confsched2023.sponsors
 
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
@@ -135,6 +138,9 @@ private fun SponsorsScreen(
                     uiState = requireNotNull(uiState.sponsorListUiStates[SUPPORTER]),
                     onSponsorClick = onSponsorClick,
                 )
+                item {
+                    Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+                }
             }
         },
     )

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
@@ -2,11 +2,19 @@ package io.github.droidkaigi.confsched2023.sponsors
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2023.model.Plan
+import io.github.droidkaigi.confsched2023.model.Plan.GOLD
+import io.github.droidkaigi.confsched2023.model.Plan.PLATINUM
+import io.github.droidkaigi.confsched2023.model.Plan.SUPPORTER
 import io.github.droidkaigi.confsched2023.model.SponsorsRepository
+import io.github.droidkaigi.confsched2023.sponsors.section.SponsorListUiState
 import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched2023.ui.buildUiState
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -27,8 +35,25 @@ class SponsorsScreenViewModel @Inject constructor(
         )
 
     val uiState: StateFlow<SponsorsScreenUiState> = buildUiState(sponsorsStateFlow) { sponsors ->
+
+        val sponsorListUiStates = Plan.values().associateWith { plan ->
+            SponsorListUiState(
+                title = when(plan){
+                    PLATINUM -> SponsorsStrings.PlatinumSponsors
+                    GOLD ->  SponsorsStrings.GoldSponsors
+                    SUPPORTER -> SponsorsStrings.Supporters
+                },
+                gridSize = when(plan){
+                    PLATINUM -> 1
+                    GOLD ->  2
+                    SUPPORTER -> 3
+                },
+                sponsorList = sponsors.filter { it.plan == plan }.toPersistentList()
+            )
+        }.toPersistentMap()
+
         SponsorsScreenUiState(
-            sponsors = sponsors,
+            sponsorListUiStates = sponsorListUiStates
         )
     }
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsStrings.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsStrings.kt
@@ -6,12 +6,27 @@ import io.github.droidkaigi.confsched2023.designsystem.strings.StringsBindings
 
 sealed class SponsorsStrings : Strings<SponsorsStrings>(Bindings) {
 
+    data object Sponsor: SponsorsStrings()
+    data object PlatinumSponsors: SponsorsStrings()
+    data object GoldSponsors: SponsorsStrings()
+    data object Supporters: SponsorsStrings()
+
     private object Bindings : StringsBindings<SponsorsStrings>(
         Lang.Japanese to { item, _ ->
-            TODO()
+            when(item){
+                Sponsor -> "スポンサー"
+                PlatinumSponsors -> "プラチナスポンサー"
+                GoldSponsors -> "ゴールドスポンサー"
+                Supporters -> "サポーター"
+            }
         },
-        Lang.English to { item, bindings ->
-            TODO()
+        Lang.English to { item, _ ->
+            when(item){
+                Sponsor -> "Sponsor"
+                PlatinumSponsors -> "PLATINUM SPONSOR"
+                GoldSponsors -> "GOLD SPONSOR"
+                Supporters -> "SUPPORTERS"
+            }
         },
         default = Lang.Japanese,
     )

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -1,0 +1,154 @@
+package io.github.droidkaigi.confsched2023.sponsors.section
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2023.model.Plan.GOLD
+import io.github.droidkaigi.confsched2023.model.Plan.PLATINUM
+import io.github.droidkaigi.confsched2023.model.Plan.SUPPORTER
+import io.github.droidkaigi.confsched2023.model.Sponsor
+import io.github.droidkaigi.confsched2023.model.fakes
+import io.github.droidkaigi.confsched2023.ui.previewOverride
+import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
+import kotlinx.collections.immutable.toPersistentList
+
+internal fun LazyListScope.sponsorList(
+    title: String,
+    gridSize: Int = 1,
+    onSponsorClick: (Sponsor) ->Unit,
+    sponsorList: List<Sponsor>
+){
+    val spacerSize = sponsorList.size % gridSize
+    val spacerList = List(spacerSize){ Spacer }
+
+    val gridItemList = mutableListOf<Any>().plus(sponsorList).plus(spacerList).toPersistentList()
+
+    item {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(vertical = 16.dp)
+        )
+    }
+
+    items(gridItemList.chunked(gridSize)) {chunkedList ->
+        Row {
+            chunkedList.forEachIndexed{ index, item ->
+                val padding = PaddingValues(
+                    top = 8.dp,
+                    bottom = 8.dp,
+                    start = if(index == 0) 0.dp else 6.dp,
+                    end = if(index == chunkedList.lastIndex) 0.dp else 6.dp
+                )
+                when(item){
+                    is Sponsor -> Image(
+                        painter = previewOverride(
+                            previewPainter = {
+                                rememberVectorPainter(image = Icons.Default.Image)
+                            }
+                        ) {
+                            rememberAsyncImagePainter(item.logo)
+                        },
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(padding)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable { onSponsorClick(item) }
+                            .weight(1f),
+                    )
+                    is Spacer -> Spacer(
+                        modifier = Modifier
+                            .padding(padding)
+                            .clip(RoundedCornerShape(8.dp))
+                            .weight(1f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private object Spacer
+
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Composable
+fun SponsorListPreview(){
+    KaigiTheme {
+        Surface {
+            LazyColumn{
+                sponsorList(
+                    gridSize = 1,
+                    title = "PLATINUM SPONSORS",
+                    onSponsorClick = {},
+                    sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }
+                )
+
+                sponsorList(
+                    gridSize = 2,
+                    title = "GOLD SPONSORS",
+                    onSponsorClick = {},
+                    sponsorList = Sponsor.fakes().filter { it.plan == GOLD }
+                )
+
+                sponsorList(
+                    gridSize = 3,
+                    title = "SUPPORTERS",
+                    onSponsorClick = {},
+                    sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }
+                )
+            }
+        }
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun SponsorListDarkModPreview(){
+    KaigiTheme {
+        Surface {
+            LazyColumn{
+                sponsorList(
+                    gridSize = 1,
+                    title = "PLATINUM SPONSORS",
+                    onSponsorClick = {},
+                    sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }
+                )
+
+                sponsorList(
+                    gridSize = 2,
+                    title = "GOLD SPONSORS",
+                    onSponsorClick = {},
+                    sponsorList = Sponsor.fakes().filter { it.plan == GOLD }
+                )
+
+                sponsorList(
+                    gridSize = 3,
+                    title = "SUPPORTERS",
+                    onSponsorClick = {},
+                    sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }
+                )
+            }
+        }
+    }
+}

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -28,12 +28,13 @@ import io.github.droidkaigi.confsched2023.model.Plan.PLATINUM
 import io.github.droidkaigi.confsched2023.model.Plan.SUPPORTER
 import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
+import io.github.droidkaigi.confsched2023.sponsors.SponsorsStrings
 import io.github.droidkaigi.confsched2023.ui.previewOverride
 import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
 import kotlinx.collections.immutable.toPersistentList
 
 internal fun LazyListScope.sponsorList(
-    title: String,
+    title: SponsorsStrings,
     gridSize: Int = 1,
     onSponsorClick: (Sponsor) ->Unit,
     sponsorList: List<Sponsor>
@@ -45,7 +46,7 @@ internal fun LazyListScope.sponsorList(
 
     item {
         Text(
-            text = title,
+            text = title.asString(),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(vertical = 16.dp)
         )
@@ -91,7 +92,8 @@ internal fun LazyListScope.sponsorList(
 private object Spacer
 
 
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(locale = "ja", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(locale = "en", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
 fun SponsorListPreview(){
     KaigiTheme {
@@ -99,21 +101,21 @@ fun SponsorListPreview(){
             LazyColumn{
                 sponsorList(
                     gridSize = 1,
-                    title = "PLATINUM SPONSORS",
+                    title = SponsorsStrings.PlatinumSponsors,
                     onSponsorClick = {},
                     sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }
                 )
 
                 sponsorList(
                     gridSize = 2,
-                    title = "GOLD SPONSORS",
+                    title = SponsorsStrings.GoldSponsors,
                     onSponsorClick = {},
                     sponsorList = Sponsor.fakes().filter { it.plan == GOLD }
                 )
 
                 sponsorList(
                     gridSize = 3,
-                    title = "SUPPORTERS",
+                    title = SponsorsStrings.Supporters,
                     onSponsorClick = {},
                     sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }
                 )
@@ -122,29 +124,30 @@ fun SponsorListPreview(){
     }
 }
 
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(locale = "ja", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(locale = "en", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
-fun SponsorListDarkModPreview(){
+fun SponsorListDarkModePreview(){
     KaigiTheme {
         Surface {
             LazyColumn{
                 sponsorList(
                     gridSize = 1,
-                    title = "PLATINUM SPONSORS",
+                    title = SponsorsStrings.PlatinumSponsors,
                     onSponsorClick = {},
                     sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }
                 )
 
                 sponsorList(
                     gridSize = 2,
-                    title = "GOLD SPONSORS",
+                    title = SponsorsStrings.GoldSponsors,
                     onSponsorClick = {},
                     sponsorList = Sponsor.fakes().filter { it.plan == GOLD }
                 )
 
                 sponsorList(
                     gridSize = 3,
-                    title = "SUPPORTERS",
+                    title = SponsorsStrings.Supporters,
                     onSponsorClick = {},
                     sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }
                 )

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/section/SponsorList.kt
@@ -31,28 +31,33 @@ import io.github.droidkaigi.confsched2023.model.fakes
 import io.github.droidkaigi.confsched2023.sponsors.SponsorsStrings
 import io.github.droidkaigi.confsched2023.ui.previewOverride
 import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
+data class SponsorListUiState(
+    val title: SponsorsStrings,
+    val gridSize: Int,
+    val sponsorList: PersistentList<Sponsor>,
+)
+
 internal fun LazyListScope.sponsorList(
-    title: SponsorsStrings,
-    gridSize: Int = 1,
+    uiState: SponsorListUiState,
     onSponsorClick: (Sponsor) ->Unit,
-    sponsorList: List<Sponsor>
 ){
-    val spacerSize = sponsorList.size % gridSize
+    val spacerSize = uiState.sponsorList.size % uiState.gridSize
     val spacerList = List(spacerSize){ Spacer }
 
-    val gridItemList = mutableListOf<Any>().plus(sponsorList).plus(spacerList).toPersistentList()
+    val gridItemList = mutableListOf<Any>().plus(uiState.sponsorList).plus(spacerList).toPersistentList()
 
     item {
         Text(
-            text = title.asString(),
+            text = uiState.title.asString(),
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(vertical = 16.dp)
         )
     }
 
-    items(gridItemList.chunked(gridSize)) {chunkedList ->
+    items(gridItemList.chunked(uiState.gridSize)) {chunkedList ->
         Row {
             chunkedList.forEachIndexed{ index, item ->
                 val padding = PaddingValues(
@@ -91,7 +96,6 @@ internal fun LazyListScope.sponsorList(
 
 private object Spacer
 
-
 @Preview(locale = "ja", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(locale = "en", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
@@ -100,24 +104,30 @@ fun SponsorListPreview(){
         Surface {
             LazyColumn{
                 sponsorList(
-                    gridSize = 1,
-                    title = SponsorsStrings.PlatinumSponsors,
+                    uiState = SponsorListUiState(
+                        title = SponsorsStrings.PlatinumSponsors,
+                        gridSize = 1,
+                        sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }.toPersistentList()
+                    ),
                     onSponsorClick = {},
-                    sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }
                 )
 
                 sponsorList(
-                    gridSize = 2,
-                    title = SponsorsStrings.GoldSponsors,
+                    uiState = SponsorListUiState(
+                        title = SponsorsStrings.PlatinumSponsors,
+                        gridSize = 1,
+                        sponsorList = Sponsor.fakes().filter { it.plan == GOLD }.toPersistentList()
+                    ),
                     onSponsorClick = {},
-                    sponsorList = Sponsor.fakes().filter { it.plan == GOLD }
                 )
 
                 sponsorList(
-                    gridSize = 3,
-                    title = SponsorsStrings.Supporters,
+                    uiState = SponsorListUiState(
+                        title = SponsorsStrings.PlatinumSponsors,
+                        gridSize = 1,
+                        sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }.toPersistentList()
+                    ),
                     onSponsorClick = {},
-                    sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }
                 )
             }
         }
@@ -132,24 +142,30 @@ fun SponsorListDarkModePreview(){
         Surface {
             LazyColumn{
                 sponsorList(
-                    gridSize = 1,
-                    title = SponsorsStrings.PlatinumSponsors,
+                    uiState = SponsorListUiState(
+                        title = SponsorsStrings.PlatinumSponsors,
+                        gridSize = 1,
+                        sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }.toPersistentList()
+                    ),
                     onSponsorClick = {},
-                    sponsorList = Sponsor.fakes().filter { it.plan == PLATINUM }
                 )
 
                 sponsorList(
-                    gridSize = 2,
-                    title = SponsorsStrings.GoldSponsors,
+                    uiState = SponsorListUiState(
+                        title = SponsorsStrings.PlatinumSponsors,
+                        gridSize = 1,
+                        sponsorList = Sponsor.fakes().filter { it.plan == GOLD }.toPersistentList()
+                    ),
                     onSponsorClick = {},
-                    sponsorList = Sponsor.fakes().filter { it.plan == GOLD }
                 )
 
                 sponsorList(
-                    gridSize = 3,
-                    title = SponsorsStrings.Supporters,
+                    uiState = SponsorListUiState(
+                        title = SponsorsStrings.PlatinumSponsors,
+                        gridSize = 1,
+                        sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }.toPersistentList()
+                    ),
                     onSponsorClick = {},
-                    sponsorList = Sponsor.fakes().filter { it.plan == SUPPORTER }
                 )
             }
         }


### PR DESCRIPTION
## Issue
- close #423

## Overview (Required)
- Sponsor list is displayed on the SponsorScreen.
- Added Popback to the SponsorScreen.
- Added sponsor strings

## Links
- https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?node-id=56147%3A49024&mode=dev

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/20397967/9a4ebdde-5fce-44ef-90ac-7ecdf7851a05" width="300" /> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/20397967/f17da864-6871-4a1d-acff-df210e6ddf61" width="300" ></video>





