### PR TITLE
Add expandable text with Read More Button

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SessionsStrings.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SessionsStrings.kt
@@ -32,6 +32,7 @@ sealed class SessionsStrings : Strings<SessionsStrings>(Bindings) {
     data object WatchVideo : SessionsStrings()
     data object Speaker : SessionsStrings()
     data object TargetAudience : SessionsStrings()
+    data object ReadMore : SessionsStrings()
     private object Bindings : StringsBindings<SessionsStrings>(
         Lang.Japanese to { item, _ ->
             when (item) {
@@ -62,6 +63,7 @@ sealed class SessionsStrings : Strings<SessionsStrings>(Bindings) {
                 TargetAudience -> "対象者"
                 WatchVideo -> "動画を見る"
                 Speaker -> "スピーカー"
+                ReadMore -> "続きを読む"
             }
         },
         Lang.English to { item, bindings ->
@@ -93,6 +95,7 @@ sealed class SessionsStrings : Strings<SessionsStrings>(Bindings) {
                 WatchVideo -> "Watch Video"
                 Speaker -> "Speaker"
                 TargetAudience -> "Target Audience"
+                ReadMore -> "Read More"
             }
         },
         default = Lang.Japanese,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -90,10 +90,12 @@ private fun DescriptionSection(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp),
         )
-        ReadMoreOutlinedButton(
-            onClick = { isExpanded = !isExpanded },
-            modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
-        )
+        if (!isExpanded) {
+            ReadMoreOutlinedButton(
+                onClick = { isExpanded = !isExpanded },
+                modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+            )
+        }
         BorderLine(modifier = Modifier.padding(top = 24.dp))
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -24,12 +24,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -73,17 +78,20 @@ fun TimetableItemDetailContent(
 private fun DescriptionSection(
     description: String,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit = {},
 ) {
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
+
     Column(modifier = modifier) {
         Text(
             text = description,
             fontSize = 16.sp,
             color = MaterialTheme.colorScheme.onSurface,
+            maxLines = if (isExpanded) Int.MAX_VALUE else 5,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp),
         )
         ReadMoreOutlinedButton(
-            onClick = onClick,
+            onClick = { isExpanded = !isExpanded },
             modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp)
         )
         BorderLine(modifier = Modifier.padding(top = 24.dp))

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
+import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.designsystem.theme.md_theme_light_outline
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
@@ -68,13 +70,21 @@ fun TimetableItemDetailContent(
 }
 
 @Composable
-private fun DescriptionSection(description: String, modifier: Modifier = Modifier) {
+private fun DescriptionSection(
+    description: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
     Column(modifier = modifier) {
         Text(
             text = description,
             fontSize = 16.sp,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+        )
+        ReadMoreOutlinedButton(
+            onClick = onClick,
+            modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp)
         )
         BorderLine(modifier = Modifier.padding(top = 24.dp))
     }
@@ -255,4 +265,36 @@ private fun BorderLine(modifier: Modifier = Modifier) {
             .height(1.dp)
             .background(MaterialTheme.colorScheme.outlineVariant),
     )
+}
+
+@Composable
+private fun ReadMoreOutlinedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(100.dp),
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outline
+        ),
+        onClick = onClick
+    ) {
+        Text(
+            modifier = Modifier.padding(vertical = 10.dp),
+            text = SessionsStrings.ReadMore.asString(),
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@MultiLanguagePreviews
+@Composable
+private fun ReadMoreOutlinedButtonPreview() {
+    KaigiTheme {
+        ReadMoreOutlinedButton(onClick = {})
+    }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -92,7 +92,7 @@ private fun DescriptionSection(
         )
         ReadMoreOutlinedButton(
             onClick = { isExpanded = !isExpanded },
-            modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp)
+            modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
         )
         BorderLine(modifier = Modifier.padding(top = 24.dp))
     }
@@ -285,16 +285,16 @@ private fun ReadMoreOutlinedButton(
         shape = RoundedCornerShape(100.dp),
         border = BorderStroke(
             width = 1.dp,
-            color = MaterialTheme.colorScheme.outline
+            color = MaterialTheme.colorScheme.outline,
         ),
-        onClick = onClick
+        onClick = onClick,
     ) {
         Text(
             modifier = Modifier.padding(vertical = 10.dp),
             text = SessionsStrings.ReadMore.asString(),
             fontSize = 14.sp,
             textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.primary
+            color = MaterialTheme.colorScheme.primary,
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #544 

## Overview (Required)
- add `ReadMoreOutlinedButton`
- Make `DescriptionSection` stateful for handle expandable text

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/51078673/f3af6a4c-e245-48a4-aef7-e293dfb29979" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/51078673/05fa6ec5-a0f4-4432-9b65-bcc0a5e0ae97" width="300" />
