### PR TITLE
Feature/update background color of the top area of the timetable screen

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -117,7 +118,7 @@ private fun TimetableScreen(
                 onBookmarkIconClick,
             )
         },
-        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        containerColor = Color.Transparent,
         contentWindowInsets = WindowInsets(0.dp),
     ) { innerPadding ->
         Box(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2023.sessions
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -7,11 +9,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -86,6 +88,17 @@ data class TimetableScreenUiState(
     val contentUiState: TimetableSheetUiState,
 )
 
+private val timetableTopBackgroundLight = Color(0xFFF6FFD3)
+private val timetableTopBackgroundDark = Color(0xFF2D4625)
+
+@Composable
+@ReadOnlyComposable
+private fun timetableTopBackground() = if (!isSystemInDarkTheme()) {
+    timetableTopBackgroundLight
+} else {
+    timetableTopBackgroundDark
+}
+
 @Composable
 private fun TimetableScreen(
     uiState: TimetableScreenUiState,
@@ -102,7 +115,8 @@ private fun TimetableScreen(
     Scaffold(
         modifier = modifier
             .testTag(TimetableScreenTestTag)
-            .nestedScroll(state.screenNestedScrollConnection),
+            .nestedScroll(state.screenNestedScrollConnection)
+            .background(timetableTopBackground()),
         snackbarHost = {
             SnackbarHost(
                 hostState = snackbarHostState,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions
 
+import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
@@ -25,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -132,7 +134,9 @@ private fun TimetableScreen(
     modifier: Modifier = Modifier,
 ) {
     val state = rememberTimetableScreenScrollState()
-
+    val gradientEndRatio =
+        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) 0.2f
+        else 0.5f
     Scaffold(
         modifier = modifier
             .testTag(TimetableScreenTestTag)
@@ -141,7 +145,7 @@ private fun TimetableScreen(
             .background(
                 Brush.verticalGradient(
                     0f to timetableTopGradient(),
-                    0.2f to Color.Transparent,
+                    gradientEndRatio to Color.Transparent,
                 )
             ),
         snackbarHost = {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -235,6 +236,7 @@ private fun PreviewTimetableScreen() {
             {},
             {},
             {},
+            Modifier.statusBarsPadding()
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
@@ -107,6 +108,17 @@ private fun timetableTopBackground() = if (!isSystemInDarkTheme()) {
     timetableTopBackgroundDark
 }
 
+private val timetableTopGradientLight = Color(0xFFA9E5FF)
+private val timetableTopGradientDark = Color(0xFF050D10)
+
+@Composable
+@ReadOnlyComposable
+private fun timetableTopGradient() = if (!isSystemInDarkTheme()) {
+    timetableTopGradientLight
+} else {
+    timetableTopGradientDark
+}
+
 @Composable
 private fun TimetableScreen(
     uiState: TimetableScreenUiState,
@@ -124,7 +136,13 @@ private fun TimetableScreen(
         modifier = modifier
             .testTag(TimetableScreenTestTag)
             .nestedScroll(state.screenNestedScrollConnection)
-            .background(timetableTopBackground()),
+            .background(timetableTopBackground())
+            .background(
+                Brush.verticalGradient(
+                    0f to timetableTopGradient(),
+                    0.2f to Color.Transparent,
+                )
+            ),
         snackbarHost = {
             SnackbarHost(
                 hostState = snackbarHostState,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2023.sessions
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
@@ -22,18 +24,24 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2023.model.DroidKaigi2023Day
+import io.github.droidkaigi.confsched2023.model.Timetable
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableTopArea
 import io.github.droidkaigi.confsched2023.sessions.component.rememberTimetableScreenScrollState
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableHeader
+import io.github.droidkaigi.confsched2023.sessions.section.TimetableListUiState
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableSheet
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableSheetUiState
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
+import kotlinx.collections.immutable.toPersistentMap
 import kotlin.math.roundToInt
 
 const val timetableScreenRoute = "timetable"
@@ -168,5 +176,47 @@ private fun TimetableScreen(
                 onFavoriteClick = onBookmarkClick,
             )
         }
+    }
+}
+
+@Preview(
+    uiMode = UI_MODE_NIGHT_NO,
+    showBackground = true,
+)
+@Composable
+fun PreviewTimetableScreenDark() {
+    PreviewTimetableScreen()
+}
+
+@Preview(
+    uiMode = UI_MODE_NIGHT_YES,
+    showBackground = true,
+)
+@Composable
+fun PreviewTimetableScreenLight() {
+    PreviewTimetableScreen()
+}
+
+@Composable
+private fun PreviewTimetableScreen() {
+    KaigiTheme {
+        TimetableScreen(
+            TimetableScreenUiState(
+                TimetableSheetUiState.ListTimetable(
+                    mapOf(
+                        DroidKaigi2023Day.Day1 to TimetableListUiState(
+                            mapOf<String, List<TimetableItem>>().toPersistentMap(),
+                            Timetable()
+                        )
+                    )
+                )
+            ),
+            SnackbarHostState(),
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -135,8 +135,11 @@ private fun TimetableScreen(
 ) {
     val state = rememberTimetableScreenScrollState()
     val gradientEndRatio =
-        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) 0.2f
-        else 0.5f
+        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            0.2f
+        } else {
+            0.5f
+        }
     Scaffold(
         modifier = modifier
             .testTag(TimetableScreenTestTag)
@@ -146,7 +149,7 @@ private fun TimetableScreen(
                 Brush.verticalGradient(
                     0f to timetableTopGradient(),
                     gradientEndRatio to Color.Transparent,
-                )
+                ),
             ),
         snackbarHost = {
             SnackbarHost(
@@ -229,10 +232,10 @@ private fun PreviewTimetableScreen() {
                     mapOf(
                         DroidKaigi2023Day.Day1 to TimetableListUiState(
                             mapOf<String, List<TimetableItem>>().toPersistentMap(),
-                            Timetable()
-                        )
-                    )
-                )
+                            Timetable(),
+                        ),
+                    ),
+                ),
             ),
             SnackbarHostState(),
             {},
@@ -240,7 +243,7 @@ private fun PreviewTimetableScreen() {
             {},
             {},
             {},
-            Modifier.statusBarsPadding()
+            Modifier.statusBarsPadding(),
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
@@ -34,7 +33,7 @@ fun TimetableTopArea(
 ) {
     TopAppBar(
         title = {
-            Image(
+            Icon(
                 painter = painterResource(id = R.drawable.icon_droidkaigi_logo),
                 contentDescription = null,
             )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -8,11 +8,11 @@ import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import io.github.droidkaigi.confsched2023.feature.sessions.R
@@ -70,7 +70,7 @@ fun TimetableTopArea(
             }
         },
         colors = TopAppBarDefaults.largeTopAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            containerColor = Color.Transparent,
         ),
     )
 }


### PR DESCRIPTION
## Issue
- close #560

## Overview (Required)
- update background color of the top area of the timetable screen
- TopAppBar title icon now change color in light and dark mode respectively.

## Link
- [Light](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56044-41124&mode=dev)
- [Dark](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56145-55124&mode=dev)

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/42033804/211707dd-7bde-46ae-b84d-9c6daddd0aa5" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/42033804/ac5e80b9-00aa-41dd-a0bc-cf8134696d50" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/42033804/c94151a0-4e2c-4bdd-b5e0-0f129c409c0f" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/42033804/bb18c2ef-729a-4866-b623-48e6e7ca5d24" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/42033804/7beca529-2d8b-4f58-97bf-b80db55c94c4" width="600" />


