### PR TITLE
:sparkles: Add codeInsightSettings.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ local.properties
 *.iml
 .idea/*
 !.idea/copyright
+!.idea/codeInsightSettings.xml
 # Keep the code styles.
 !/.idea/codeStyles
 /.idea/codeStyles/*

--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="JavaProjectCodeInsightSettings">
+        <excluded-names>
+            <name>java.lang.reflect.Modifier</name>
+            <name>java.nio.file.WatchEvent.Modifier</name>
+            <name>android.view.Surface</name>
+            <name>androidx.core.content.pm.ShortcutInfoCompat.Surface</name>
+            <name>org.w3c.dom.Text</name>
+            <name>android.widget.Button</name>
+            <name>android.graphics.drawable.Icon</name>
+            <name>android.inputmethodservice.Keyboard.Row</name>
+            <name>java.time.format.TextStyle</name>
+            <name>org.threeten.bp.format.TextStyle</name>
+            <name>android.text.Layout.Alignment</name>
+            <name>android.widget.GridLayout.Alignment</name>
+            <name>android.graphics.Canvas</name>
+            <name>android.graphics.Color</name>
+            <name>android.graphics.Paint</name>
+        </excluded-names>
+    </component>
+</project>


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Prevent suggestions that are not related to Jetpack Compose from appearing.
- As in the previous year, codeInsightSettings.xml was added.

## Links
- https://github.com/DroidKaigi/conference-app-2022/pull/336

## Movie

- before

https://github.com/DroidKaigi/conference-app-2023/assets/13657682/fae250d6-b272-4bf0-9c8d-8f5db25148e7

- after

https://github.com/DroidKaigi/conference-app-2023/assets/13657682/cd9e663c-ca7c-4026-bdbf-6f7c886dfee0


