### PR TITLE
Modify about screen's title

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutScreen.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutScreen.kt
@@ -8,16 +8,24 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -73,6 +81,7 @@ fun AboutScreen(
 
 class AboutScreenUiState()
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AboutScreen(
     uiState: AboutScreenUiState,
@@ -81,8 +90,29 @@ private fun AboutScreen(
     versionName: String?,
     onLinkClick: (url: String) -> Unit,
 ) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     Scaffold(
         modifier = Modifier.testTag(AboutScreenTestTag),
+        topBar = {
+            TopAppBar(
+                title = {
+                    if (scrollBehavior.state.overlappedFraction == 0f) {
+                        Text(
+                            text = AboutStrings.Title.asString(),
+                            style = MaterialTheme.typography.headlineLarge,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    } else {
+                        Text(
+                            text = AboutStrings.Title.asString(),
+                            color = Color.Unspecified.copy(alpha = scrollBehavior.state.overlappedFraction),
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->
             LazyColumn(
@@ -91,7 +121,8 @@ private fun AboutScreen(
                         top = padding.calculateTopPadding(),
                         start = padding.calculateStartPadding(LocalLayoutDirection.current),
                         end = padding.calculateEndPadding(LocalLayoutDirection.current),
-                    ),
+                    )
+                    .nestedScroll(scrollBehavior.nestedScrollConnection),
             ) {
                 item {
                     AboutDroidKaigiDetail(

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetail.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetail.kt
@@ -26,28 +26,13 @@ fun AboutDroidKaigiDetail(
     Column(
         modifier = modifier,
     ) {
-        Text(
-            text = AboutStrings.Title.asString(),
-            style = MaterialTheme.typography.headlineLarge,
-            modifier = Modifier
-                .padding(
-                    start = 16.dp,
-                    top = 20.dp,
-                    end = 16.dp,
-                    bottom = 16.dp,
-                ),
-        )
         Image(
             painter = painterResource(id = R.drawable.img_about_key_visual),
             contentDescription = null,
             contentScale = ContentScale.FillWidth,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(
-                    start = 16.dp,
-                    end = 16.dp,
-                    bottom = 16.dp,
-                ),
+                .padding(16.dp),
         )
         Text(
             text = AboutStrings.Description.asString(),


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fixed the title of the About screen to match Figma's design when scrolling it's screen.

## Links
- [Figma](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56147%3A41182&mode=dev)

## Screenshot
Before | After | Figma
:--: | :--: | :--:
![before](https://github.com/DroidKaigi/conference-app-2023/assets/31027685/59fce79e-eb06-4f77-a45e-a20fbd022367) | ![after](https://github.com/DroidKaigi/conference-app-2023/assets/31027685/fc2ba769-9625-461e-a7cb-e312153474d3) | <img width="618" alt="スクリーンショット 2023-08-17 14 08 54" src="https://github.com/DroidKaigi/conference-app-2023/assets/31027685/866555d4-66a8-414d-97b6-0676a212467d">
