### PR TITLE
Add padding to the left of time in the timetable to follow Figma

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -55,7 +55,7 @@ fun TimetableList(
     ) {
         uiState.timetableItemMap.forEach { (_, timetableItems) ->
             itemsIndexed(timetableItems) { index, timetableItem ->
-                Row(modifier = Modifier.padding(top = 10.dp)) {
+                Row(modifier = Modifier.padding(start = 16.dp, top = 10.dp)) {
                     Column(
                         modifier = Modifier.width(58.dp),
                         verticalArrangement = Arrangement.Center,


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Add padding to the left of time in the timetable to follow Figma.

## Links
- https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?node-id=54568%3A36963&mode=dev

## Screenshot
Before | After | Figma
:--: | :--: | :--: |
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/15e8bfa0-aa05-45d0-92e4-f464d300a96c" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/0b123a09-ca93-4f0b-aacd-cb1b72c2e2d6" width="300" />  | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/1a6dccbc-f8ee-441a-ad55-158c594b5da2" width="300" /> 