### PR TITLE
Adjust font size for session detail screen

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -162,7 +162,7 @@ private fun ArchiveSection(
     Column(modifier = modifier.padding(vertical = 24.dp, horizontal = 16.dp)) {
         Text(
             text = SessionsStrings.Archive.asString(),
-            style = MaterialTheme.typography.titleLarge
+            style = MaterialTheme.typography.titleLarge,
         )
         Row(
             modifier = Modifier

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -85,9 +85,9 @@ private fun TargetAudienceSection(targetAudienceString: String, modifier: Modifi
     Column(modifier = modifier) {
         Text(
             text = SessionsStrings.TargetAudience.asString(),
-            fontSize = 14.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+            style = MaterialTheme.typography.titleLarge,
         )
         Text(
             text = targetAudienceString,
@@ -107,9 +107,9 @@ private fun SpeakerSection(
     Column(modifier = modifier) {
         Text(
             text = SessionsStrings.Speaker.asString(),
-            fontSize = 14.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+            style = MaterialTheme.typography.titleLarge,
         )
         Spacer(modifier = Modifier.height(8.dp))
         speakers.forEach { speaker ->
@@ -162,7 +162,7 @@ private fun ArchiveSection(
     Column(modifier = modifier.padding(vertical = 24.dp, horizontal = 16.dp)) {
         Text(
             text = SessionsStrings.Archive.asString(),
-            fontSize = 14.sp,
+            style = MaterialTheme.typography.titleLarge
         )
         Row(
             modifier = Modifier

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -50,7 +50,7 @@ fun TimetableItemDetailScreenTopAppBar(
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 2,
                     styles = listOf(
-                        MaterialTheme.typography.headlineSmall,
+                        MaterialTheme.typography.headlineMedium,
                         MaterialTheme.typography.titleLarge,
                         MaterialTheme.typography.titleMedium,
                         MaterialTheme.typography.titleSmall,


### PR DESCRIPTION
## Issue
- close #562

## Overview (Required)
- The font size does not reflect the latest figma updates, so adjust it accordingly.

## Screenshot
Before | After
:--: | :--:
![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/8e07d3c3-1bf8-4e8f-aed4-79859148a585) | ![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/d385e2db-6624-4ec3-99c6-4e2c1eb1e2b5)  
![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/00f8d396-eb91-461b-8647-fb12b097235a)| ![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/01668b74-7e8d-48d0-b6fc-b9b2854eeec5)
![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/57a8ed0f-2a05-4a14-a96e-98e508f455bf)| ![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/32862922-f02a-451f-9f15-38fe0d163d41)
![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/3074c36b-901f-4fc1-8499-177b8ef4999e)|![image](https://github.com/DroidKaigi/conference-app-2023/assets/62137820/ed90bd73-c10c-4f7c-b8bd-4340d28005b0)



