### PR TITLE
Update Font Size for Empty View of Bookmark Screen

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SessionsStrings.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SessionsStrings.kt
@@ -47,7 +47,7 @@ sealed class SessionsStrings : Strings<SessionsStrings>(Bindings) {
                 BookmarkFilterAllChip -> "全て"
                 is SearchResultNotFound -> "「${item.missedWord}」と一致する検索結果がありません"
                 SearchPlaceHolder -> "気になる技術を入力"
-                BookmarkedItemNotFound -> "登録されたセッションがありません"
+                BookmarkedItemNotFound -> "登録されたセッションが\nありません"
                 BookmarkedItemNotFoundSideNote -> "気になるセッションをブックマークに追加して\n集めてみましょう！"
                 Share -> "共有"
                 AddToCalendar -> "カレンダーに追加"

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Modifier.Companion
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -70,9 +71,7 @@ fun BookmarkSheet(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(start = 16.dp),
+        modifier = modifier.fillMaxSize(),
     ) {
         BookmarkFilters(
             isAll = uiState.isAll,
@@ -83,6 +82,7 @@ fun BookmarkSheet(
             onDayFirstChipClick = onDayFirstChipClick,
             onDaySecondChipClick = onDaySecondChipClick,
             onDayThirdChipClick = onDayThirdChipClick,
+            modifier = Modifier.padding(start = 16.dp),
         )
         when (uiState) {
             is Empty -> {
@@ -126,9 +126,9 @@ private fun EmptyView() {
         Spacer(modifier = Modifier.height(24.dp))
         Text(
             text = BookmarkedItemNotFound.asString(),
-            fontSize = 16.sp,
+            fontSize = 22.sp,
             fontWeight = FontWeight.Medium,
-            lineHeight = 24.sp,
+            lineHeight = 28.sp,
             color = MaterialTheme.colorScheme.onSurface,
         )
         Spacer(modifier = Modifier.size(8.dp))

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.Modifier.Companion
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -130,6 +130,7 @@ private fun EmptyView() {
             fontWeight = FontWeight.Medium,
             lineHeight = 28.sp,
             color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.size(8.dp))
         Text(


### PR DESCRIPTION
## Issue
- close #568 

## Overview (Required)
- The font size for empty view in book mark screen is different from Figma, so I updated it.
- The setting of padding is not so elegant, so I fixed it.

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/105269911/d5330479-f821-4635-8ebc-828d29d7b202" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/105269911/f5e1b108-510b-4606-8ed4-66ce525dea3e" width="300" />