### PR TITLE
Fix the build error by ShowKase

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -303,7 +303,7 @@ private fun ReadMoreOutlinedButton(
 
 @MultiLanguagePreviews
 @Composable
-private fun ReadMoreOutlinedButtonPreview() {
+fun ReadMoreOutlinedButtonPreview() {
     KaigiTheme {
         ReadMoreOutlinedButton(onClick = {})
     }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fixed because the app could not be built by enabling ShowKase
  - https://github.com/DroidKaigi/conference-app-2023/pull/605/files

## Links
- https://github.com/airbnb/Showkase/blob/master/README.md

## Screenshot
nothing