### PR TITLE
Add per-app language support.

### DIFF
--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.KaigiApp"
+        android:localeConfig="@xml/locales_config">
         tools:targetApi="tiramisu">
         <activity
             android:name=".MainActivity"

--- a/app-android/src/main/res/xml/locales_config.xml
+++ b/app-android/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+   <locale android:name="en-US"/>
+   <locale android:name="ja"/>
+</locale-config>
+


### PR DESCRIPTION
Fixes #618

A few thing to complement:

- I explicitly specify `ja` and `en-US` as they are indeed the supported languages.
- I did not resort to [automatic per-app language support](https://developer.android.com/guide/topics/resources/app-languages#auto-localeconfig) as it depends on AGP 8.1 which I just reverted in #614 :p

## Issue
- close #618

## Overview (Required)

See #618.

## Screenshot