### PR TITLE
Use the entries property instead of the values function of enum classes

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
@@ -47,7 +47,7 @@ public enum class DroidKaigi2023Day(
 
     public companion object {
         public fun ofOrNull(time: Instant): DroidKaigi2023Day? {
-            return values().firstOrNull {
+            return entries.firstOrNull {
                 time in it.start..it.end
             }
         }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Sponsor.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Sponsor.kt
@@ -20,7 +20,7 @@ public enum class Plan {
 
     public companion object {
         public fun ofOrNull(plan: String): Plan? {
-            return values().firstOrNull { it.name == plan }
+            return entries.firstOrNull { it.name == plan }
         }
     }
 

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableRoom.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableRoom.kt
@@ -8,4 +8,4 @@ public data class TimetableRoom(
 )
 
 val TimetableRoom.type: RoomIndex
-    get() = RoomIndex.values().getOrNull(sortIndex) ?: RoomIndex.Room1
+    get() = RoomIndex.entries.getOrNull(sortIndex) ?: RoomIndex.Room1

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -141,7 +141,7 @@ private fun MainScreen(
     Scaffold(
         bottomBar = {
             KaigiBottomBar(
-                mainScreenTabs = MainScreenTab.values().toList(),
+                mainScreenTabs = MainScreenTab.entries.toList(),
                 onTabSelected = { tab ->
                     onTabSelected(mainNestedNavController, tab)
                 },

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreenViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreenViewModel.kt
@@ -42,7 +42,7 @@ class BookmarkScreenViewModel @Inject constructor(
         )
 
     private val currentDayFilter = MutableStateFlow(
-        DroidKaigi2023Day.values().map { it },
+        DroidKaigi2023Day.entries.map { it },
     )
 
     val uiState: StateFlow<BookmarkScreenUiState> =
@@ -82,7 +82,7 @@ class BookmarkScreenViewModel @Inject constructor(
 
     fun onAllFilterChipClick() {
         currentDayFilter.update {
-            DroidKaigi2023Day.values().toList()
+            DroidKaigi2023Day.entries.toList()
         }
     }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenViewModel.kt
@@ -53,7 +53,7 @@ class TimetableScreenViewModel @Inject constructor(
         }
         if (uiType == TimetableUiType.List) {
             TimetableSheetUiState.ListTimetable(
-                DroidKaigi2023Day.values().associateWith { day ->
+                DroidKaigi2023Day.entries.associateWith { day ->
                     val sortAndGroupedTimetableItems = sessionTimetable.filtered(
                         Filters(
                             days = listOf(day),
@@ -73,7 +73,7 @@ class TimetableScreenViewModel @Inject constructor(
             )
         } else {
             TimetableSheetUiState.GridTimetable(
-                DroidKaigi2023Day.values().associateWith { day ->
+                DroidKaigi2023Day.entries.associateWith { day ->
                     TimetableGridUiState(
                         timetable = sessionTimetable.dayTimetable(day),
                     )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchFilter.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchFilter.kt
@@ -44,7 +44,7 @@ fun SearchFilter(
             isSelected = searchFilterUiState.isDaySelected,
             selectedDays = searchFilterUiState.selectedDays,
             selectedDaysValues = searchFilterUiState.selectedDaysValues,
-            kaigiDays = DroidKaigi2023Day.values().toList(),
+            kaigiDays = DroidKaigi2023Day.entries.toList(),
             onDaySelected = onDaySelected,
         )
         FilterCategoryChip(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -38,7 +38,7 @@ import kotlinx.collections.immutable.PersistentSet
 sealed interface BookmarkSheetUiState {
     val currentDayFilter: PersistentList<DroidKaigi2023Day>
     val isAll: Boolean
-        get() = currentDayFilter.size == DroidKaigi2023Day.values().size
+        get() = currentDayFilter.size == DroidKaigi2023Day.entries.size
     val isDayFirst: Boolean
         get() = currentDayFilter.size == 1 && currentDayFilter.first() == DroidKaigi2023Day.Day1
     val isDaySecond: Boolean

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
@@ -66,9 +66,9 @@ fun TimetableSheet(
         ) {
             TimetableTabRow(
                 tabState = timetableSheetContentScrollState.tabScrollState,
-                selectedTabIndex = DroidKaigi2023Day.values().indexOf(selectedDay),
+                selectedTabIndex = DroidKaigi2023Day.entries.indexOf(selectedDay),
             ) {
-                DroidKaigi2023Day.values().forEach { day ->
+                DroidKaigi2023Day.entries.forEach { day ->
                     TimetableTab(
                         day = day,
                         selected = day == selectedDay,


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Use the `entries` property instead of the `values()` function of enum classes for performance.

## Links
- https://kotlinlang.org/docs/whatsnew19.html#stable-data-objects-for-symmetry-with-data-classes