### PR TITLE
save TimetableSheet's selected day to bundle

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -49,7 +50,7 @@ fun TimetableSheet(
     onFavoriteClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedDay by remember { mutableStateOf(DroidKaigi2023Day.Day1) }
+    var selectedDay by rememberSaveable { mutableStateOf(DroidKaigi2023Day.Day1) }
     val corner by animateIntAsState(
         if (timetableScreenScrollState.isScreenLayoutCalculating || timetableScreenScrollState.isSheetExpandable) 40 else 0,
         label = "Timetable corner state",


### PR DESCRIPTION
## Issue
- close #597 

## Overview (Required)
- To prevent `selectedDay` from being removed by Navigation, I use `rememberSaveable` to save it to bundle

## Links
- 

## Screenshot
https://github.com/DroidKaigi/conference-app-2023/assets/85218317/6109725a-da60-4926-b42b-26494431a5ea