### PR TITLE
[iOS] update xcode version

### DIFF
--- a/.xcode-version
+++ b/.xcode-version
@@ -1,3 +1,1 @@
-# Follows following format
-# https://github.com/actions/runner-images/blob/main/images/macos/toolsets/toolset-13.json
-15.0.0-Beta.2+15A5161b
+15.0b6


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- The latest Xcode version is now 15.0 Beta 6, so updated the version in `.xcode-version`.
- https://developer.apple.com/documentation/xcode-release-notes

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />