### PR TITLE
Workaround: Inject annotation values to screenshot testing environment at runtime through predefined constants

### DIFF
--- a/app-android/src/test/java/io/github/droidkaigi/confsched2023/PreviewTest.kt
+++ b/app-android/src/test/java/io/github/droidkaigi/confsched2023/PreviewTest.kt
@@ -1,10 +1,18 @@
 package io.github.droidkaigi.confsched2023
 
+import android.content.res.Configuration
+import android.os.LocaleList
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalConfiguration
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
+import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviewDefinition
+import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviewDefinition
+import io.github.droidkaigi.confsched2023.designsystem.preview.ShowkaseMultiplePreviewsWorkaround
 import io.github.droidkaigi.confsched2023.testing.category.ScreenshotTests
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -12,6 +20,7 @@ import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import java.util.Locale
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
@@ -30,8 +39,72 @@ class PreviewTest(
         captureRoboImage(
             filePath,
         ) {
-            showkaseBrowserComponent.component()
+            ProvidesPreviewValues(group = showkaseBrowserComponent.group, componentKey = showkaseBrowserComponent.componentKey) {
+                showkaseBrowserComponent.component()
+            }
         }
+    }
+
+    @Suppress("TestFunctionName")
+    @ShowkaseMultiplePreviewsWorkaround
+    @Composable
+    private fun ProvidesPreviewValues(group: String, componentKey: String, content: @Composable () -> Unit) {
+        val components = componentKey.split("-")
+
+        val appliers = arrayListOf<(Configuration) -> Unit>()
+
+        when (group) {
+            MultiLanguagePreviewDefinition.Group -> {
+                appliers += { c ->
+                    c.setLocales(newLocales(baseLocales = c.locales, components = components))
+                }
+            }
+            MultiThemePreviewDefinition.Group -> {
+                appliers += { c ->
+                    c.uiMode = newUiMode(baseUiMode = c.uiMode, components = components)
+                }
+            }
+        }
+
+        val newConfiguration = appliers.fold(LocalConfiguration.current) { c, a -> c.apply(a) }
+
+        CompositionLocalProvider(LocalConfiguration provides newConfiguration) {
+            // Notify locale changes to lang() through the following invocation.
+            LocaleList.setDefault(LocalConfiguration.current.locales)
+
+            content()
+        }
+    }
+
+    @ShowkaseMultiplePreviewsWorkaround
+    private fun newLocales(baseLocales: LocaleList, components: List<String>): LocaleList {
+        val locale = when {
+            MultiLanguagePreviewDefinition.English.Name in components -> {
+                MultiLanguagePreviewDefinition.English.Locale
+            }
+            MultiLanguagePreviewDefinition.Japanese.Name in components -> {
+                MultiLanguagePreviewDefinition.Japanese.Locale
+            }
+            else -> return baseLocales
+        }
+
+        return LocaleList(Locale.getAvailableLocales().first { it.toString() == locale })
+    }
+
+    @ShowkaseMultiplePreviewsWorkaround
+    private fun newUiMode(baseUiMode: Int, components: List<String>): Int {
+        val nightMode = when {
+            MultiThemePreviewDefinition.DarkMode.Name in components -> {
+                MultiThemePreviewDefinition.DarkMode.UiMode
+            }
+            MultiThemePreviewDefinition.LightMode.Name in components -> {
+                MultiThemePreviewDefinition.LightMode.UiMode
+            }
+            else -> baseUiMode
+        }
+
+        val currentNightMode = baseUiMode and Configuration.UI_MODE_NIGHT_MASK
+        return baseUiMode xor currentNightMode or nightMode
     }
 
     companion object {

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
@@ -1,34 +1,84 @@
 package io.github.droidkaigi.confsched2023.designsystem.preview
 
 import android.content.res.Configuration
+import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.tooling.preview.Preview
+import kotlin.annotation.AnnotationRetention.SOURCE
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+
+/**
+ * Annotate workaround entities for https://github.com/DroidKaigi/conference-app-2023/issues/627
+ */
+@VisibleForTesting
+@Retention(SOURCE)
+@Target(CLASS, FUNCTION)
+annotation class ShowkaseMultiplePreviewsWorkaround
+
+/**
+ * Definitions for MultiThemePreviews
+ */
+@VisibleForTesting
+@ShowkaseMultiplePreviewsWorkaround
+object MultiThemePreviewDefinition {
+    const val Group = "Theme"
+
+    object DarkMode {
+        const val Name = "DarkMode"
+        const val UiMode = Configuration.UI_MODE_NIGHT_YES
+    }
+
+    object LightMode {
+        const val Name = "LightMode"
+        const val UiMode = Configuration.UI_MODE_NIGHT_NO
+    }
+}
 
 /**
  * Annotation for previewing multiple themes.
  */
 @Preview(
-    name = "Light Mode",
-    group = "Theme",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    name = MultiThemePreviewDefinition.LightMode.Name,
+    group = MultiThemePreviewDefinition.Group,
+    uiMode = MultiThemePreviewDefinition.LightMode.UiMode,
 )
 @Preview(
-    name = "Dark Mode",
-    group = "Theme",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = MultiThemePreviewDefinition.DarkMode.Name,
+    group = MultiThemePreviewDefinition.Group,
+    uiMode = MultiThemePreviewDefinition.DarkMode.UiMode,
 )
 annotation class MultiThemePreviews
+
+/**
+ * Definitions for MultiLanguagePreviews
+ */
+@VisibleForTesting
+@ShowkaseMultiplePreviewsWorkaround
+object MultiLanguagePreviewDefinition {
+    const val Group = "Language"
+
+    object Japanese {
+        const val Name = "Japanese"
+        const val Locale = "ja_JP"
+    }
+
+    object English {
+        const val Name = "English"
+        const val Locale = "en_US"
+    }
+}
 
 /**
  * Annotation for previewing multiple languages.
  */
 @Preview(
-    name = "Japanese",
-    group = "Language",
-    locale = "ja",
+    name = MultiLanguagePreviewDefinition.Japanese.Name,
+    group = MultiLanguagePreviewDefinition.Group,
+    locale = MultiLanguagePreviewDefinition.Japanese.Locale,
 )
 @Preview(
-    name = "English",
-    group = "Language",
-    locale = "en",
+    name = MultiLanguagePreviewDefinition.English.Name,
+    group = MultiLanguagePreviewDefinition.Group,
+    locale = MultiLanguagePreviewDefinition.English.Locale,
 )
 annotation class MultiLanguagePreviews


### PR DESCRIPTION
## Issue
- close #627 

## Overview (Required)

- Showkase should pick up and propagete these values even if custom previews are repeated reflective annotations. But no. Custom annotations and repeated annotations may not be fully supported yet.
- This workaround just estimates preview configurations from a group and a component key. Yes, this may be fragile a little bit.

## Links
- https://github.com/DroidKaigi/conference-app-2023/issues/627
- https://github.com/airbnb/Showkase/commit/d15c1f87cd802c26670bc119ce38e5f9da46691a

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />