### PR TITLE
Implement timetable loadging component

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -1,5 +1,11 @@
 package io.github.droidkaigi.confsched2023.sessions
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,6 +32,7 @@ import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetail
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailContent
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailScreenTopAppBar
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailSummaryCard
+import io.github.droidkaigi.confsched2023.sessions.component.TimetableLoadingContent
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 
 const val timetableItemDetailScreenRouteItemIdParameterName = "timetableItemId"
@@ -120,24 +127,32 @@ private fun TimetableItemDetailScreen(
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { innerPadding ->
-        when (uiState) {
-            TimetableItemDetailScreenUiState.Loading -> {
-                Text(text = "Loading")
-            }
+        AnimatedContent(
+            targetState = uiState,
+            transitionSpec = { fadeIn().togetherWith(fadeOut()) },
+            label = "TimetableItemDetailScreen",
+        ) {
+            when (it) {
+                TimetableItemDetailScreenUiState.Loading -> {
+                    TimetableLoadingContent(
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
 
-            is TimetableItemDetailScreenUiState.Loaded -> {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = innerPadding,
-                ) {
-                    item {
-                        TimetableItemDetailSummaryCard(
-                            timetableItem = uiState.timetableItem,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 20.dp),
-                        )
-                    }
-                    item {
-                        TimetableItemDetailContent(uiState = uiState.timetableItem)
+                is TimetableItemDetailScreenUiState.Loaded -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = innerPadding,
+                    ) {
+                        item {
+                            TimetableItemDetailSummaryCard(
+                                timetableItem = it.timetableItem,
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 20.dp),
+                            )
+                        }
+                        item {
+                            TimetableItemDetailContent(uiState = it.timetableItem)
+                        }
                     }
                 }
             }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -1,10 +1,8 @@
 package io.github.droidkaigi.confsched2023.sessions
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -13,7 +11,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableLoadingContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableLoadingContent.kt
@@ -1,0 +1,40 @@
+package io.github.droidkaigi.confsched2023.sessions.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextOverflow.Companion
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun TimetableLoadingContent(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(
+            space = 16.dp,
+            alignment = Alignment.CenterVertically,
+        )
+    ) {
+        CircularProgressIndicator()
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = "Loading...",
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyMedium,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableLoadingContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableLoadingContent.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.CircularProgressIndicator
@@ -12,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.style.TextOverflow.Companion
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -25,7 +23,7 @@ internal fun TimetableLoadingContent(
         verticalArrangement = Arrangement.spacedBy(
             space = 16.dp,
             alignment = Alignment.CenterVertically,
-        )
+        ),
     ) {
         CircularProgressIndicator()
 


### PR DESCRIPTION
## Issue
- close #621

## Overview (Required)
- Created `TimetableItemLoadingContent`
- I thought the transition between loading and idle screens was abrupt, so I added a fade animation.

## Screenshot
| Before | After | fade animation |
| :--: | :--: | - |
| <img src="https://user-images.githubusercontent.com/51113946/261287749-918c79e4-79eb-41f5-9154-2512c100b3de.png" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/46b926f4-e58b-4a50-8034-001f2b48296eb" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/3170bec6-d071-456a-88f1-37a0a1a97deb" width="300" /> |
