### PR TITLE
[iOS] Use cached image

### DIFF
--- a/app-ios/Modules/Sources/Component/CacheAsyncImage.swift
+++ b/app-ios/Modules/Sources/Component/CacheAsyncImage.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+public struct CacheAsyncImage<Content, PlaceHolder>: View where Content: View, PlaceHolder: View {
+    
+    private let url: URL?
+    private let scale: CGFloat
+    private let contentImage: (Image) -> Content
+    private let placeholder: () -> PlaceHolder
+    
+    public init(
+        url: URL?,
+        scale: CGFloat = 1.0,
+        contentImage: @escaping (Image) -> Content,
+        placeholder: @escaping () -> PlaceHolder
+    ) {
+        self.url = url
+        self.scale = scale
+        self.contentImage = contentImage
+        self.placeholder = placeholder
+    }
+    
+    public var body: some View {
+        if let cachedImage = ImageCache[url] {
+            contentImage(cachedImage)
+        } else {
+            AsyncImage(
+                url: url,
+                scale: scale,
+                content: { image in
+                    cacheAndRender(image: image)
+                },
+                placeholder: placeholder
+            )
+        }
+    }
+}
+
+private extension CacheAsyncImage {
+    func cacheAndRender(image: Image) -> some View {
+        ImageCache[url] = image
+        return contentImage(image)
+    }
+}
+
+private class ImageCache {
+    static private var cache: [URL: Image] = [:]
+    
+    static subscript(url: URL?) -> Image? {
+        get {
+            guard let url else { return nil }
+            return Self.cache[url]
+        }
+        set {
+            guard let url else { return }
+            Self.cache[url] = newValue
+        }
+    }
+}
+
+#Preview {
+    CacheAsyncImage(
+        url: URL(string: "https://avatars.githubusercontent.com/u/10727543?s=48&v=4")!,
+        scale: 1.0
+    ) { image in
+        image.resizable()
+            .frame(width: 24, height: 24)
+        } placeholder: {
+            Color.gray
+                .frame(width: 24, height: 24)
+                .cornerRadius(12)
+        }
+
+}

--- a/app-ios/Modules/Sources/Component/PersonLabel.swift
+++ b/app-ios/Modules/Sources/Component/PersonLabel.swift
@@ -15,7 +15,7 @@ public struct PersonLabel: View {
     public var body: some View {
         HStack(alignment: .center, spacing: 24) {
             HStack(spacing: -8) {
-                AsyncImage(url: URL(string: iconUrlString)) { image in
+                CacheAsyncImage(url: URL(string: iconUrlString)) { image in
                     image.resizable()
                 } placeholder: {
                     Color.gray

--- a/app-ios/Modules/Sources/Session/SessionView.swift
+++ b/app-ios/Modules/Sources/Session/SessionView.swift
@@ -121,7 +121,7 @@ public struct SessionView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(viewModel.timetableItem.speakers, id: \.id) { speaker in
                             HStack(spacing: 24) {
-                                AsyncImage(url: URL(string: speaker.iconUrl)) { image in
+                                CacheAsyncImage(url: URL(string: speaker.iconUrl)) { image in
                                     image.resizable()
                                 } placeholder: {
                                     Color.gray

--- a/app-ios/Modules/Sources/Sponsor/SponsorGridView.swift
+++ b/app-ios/Modules/Sources/Sponsor/SponsorGridView.swift
@@ -1,3 +1,4 @@
+import Component
 import Model
 import shared
 import SwiftUI
@@ -37,7 +38,7 @@ struct SponsorItemView: View {
             Button {
                 action()
             } label: {
-                AsyncImage(url: URL(string: sponsor.logo)) { image in
+                CacheAsyncImage(url: URL(string: sponsor.logo)) { image in
                     image
                         .resizable()
                         .frame(minWidth: 0, maxWidth: .infinity)

--- a/app-ios/Modules/Sources/Timetable/PersonLabel.swift
+++ b/app-ios/Modules/Sources/Timetable/PersonLabel.swift
@@ -1,3 +1,4 @@
+import Component
 import shared
 import SwiftUI
 import Theme
@@ -9,7 +10,7 @@ struct PersonLabel: View {
         HStack(alignment: .center, spacing: 8) {
             HStack(spacing: -8) {
                 ForEach(speakers.map(\.iconUrl), id: \.self) { iconUrl in
-                    AsyncImage(url: URL(string: iconUrl)) { image in
+                    CacheAsyncImage(url: URL(string: iconUrl)) { image in
                         image.resizable()
                     } placeholder: {
                         Color.gray


### PR DESCRIPTION
## Issue
- close #456 

## Overview (Required)
- Add CacheAsyncImage
- Use CacheAsyncImage instead of AsyncImage

## Screenshot
- No change for UI presentation
 
Before | After 
:--: | :--: 
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13119930/29285d1f-8284-4ba7-8c14-2ac30d2e21d2" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13119930/c6c05e50-0d6b-4856-ae80-b86213cb27df" width="300" /> |