### PR TITLE
Set end padding to title of the timetable item detail screen

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -19,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.model.MultiLangText
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -94,5 +96,6 @@ private fun ResizeableText(
             }
         },
         style = styles[styleIndex],
+        modifier = Modifier.padding(end = 16.dp),
     )
 }


### PR DESCRIPTION
## Issue
- close #642

## Overview (Required)
- Set end padding to title of the timetable item detail screen

## Links
- https://github.com/DroidKaigi/conference-app-2023/issues/642

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/80536544/64ad4d38-ce7b-4635-a755-8a7de6bd3373" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/80536544/e9675525-bf78-465d-bf37-1de084c2a755" width="300" />






