### PR TITLE
Add animation to description section

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -81,7 +82,7 @@ private fun DescriptionSection(
 ) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
-    Column(modifier = modifier) {
+    Column(modifier = modifier.animateContentSize(),) {
         Text(
             text = description,
             fontSize = 16.sp,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -82,7 +82,7 @@ private fun DescriptionSection(
 ) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
-    Column(modifier = modifier.animateContentSize(),) {
+    Column(modifier = modifier.animateContentSize()) {
         Text(
             text = description,
             fontSize = 16.sp,


### PR DESCRIPTION
## Issue
- closes #655

## Overview (Required)
- add `Modifier.animateContentSize` to description section for more user experience.


## Movie
https://github.com/DroidKaigi/conference-app-2023/assets/56629437/495b6215-26b1-46e7-b89b-3af99cdd6812

