### PR TITLE
Show image if FloorMapSideEventItem's image link exists

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
@@ -43,7 +43,7 @@ val SideEvents = persistentListOf(
         ),
         mark = Favorite,
         link = "https://github.com/DroidKaigi/conference-app-2023",
-        imageLink = "https://2023.droidkaigi.jp/static/12059b53c8c9813a85c1c44f8692a2c0/img_04.jpg"
+        imageLink = "https://2023.droidkaigi.jp/static/12059b53c8c9813a85c1c44f8692a2c0/img_04.jpg",
     ),
     SideEvent(
         title = MultiLangText(

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
@@ -12,6 +12,7 @@ public data class SideEvent(
     val floorLevel: FloorLevel,
     val mark: Mark,
     val link: String?,
+    val imageLink: String?,
 ) {
 
     enum class Mark(val color: MarkColor) {
@@ -42,6 +43,7 @@ val SideEvents = persistentListOf(
         ),
         mark = Favorite,
         link = "https://github.com/DroidKaigi/conference-app-2023",
+        imageLink = "https://2023.droidkaigi.jp/static/12059b53c8c9813a85c1c44f8692a2c0/img_04.jpg"
     ),
     SideEvent(
         title = MultiLangText(
@@ -59,6 +61,7 @@ val SideEvents = persistentListOf(
         ),
         mark = Favorite,
         link = null,
+        imageLink = null,
     ),
     SideEvent(
         title = MultiLangText(
@@ -76,5 +79,6 @@ val SideEvents = persistentListOf(
         ),
         mark = Favorite,
         link = "https://github.com/DroidKaigi/conference-app-2023",
+        imageLink = "https://2023.droidkaigi.jp/static/12059b53c8c9813a85c1c44f8692a2c0/img_04.jpg",
     ),
 )

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
@@ -28,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -46,6 +48,7 @@ import io.github.droidkaigi.confsched2023.model.SideEvent.Mark
 import io.github.droidkaigi.confsched2023.model.SideEvent.Mark.Favorite
 import io.github.droidkaigi.confsched2023.model.SideEvent.MarkColor.Pink
 import io.github.droidkaigi.confsched2023.model.SideEvents
+import io.github.droidkaigi.confsched2023.ui.previewOverride
 import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
 
 @Composable
@@ -128,7 +131,10 @@ fun FloorMapSideEventItem(
                             color = MaterialTheme.colorScheme.outline,
                             shape = RoundedCornerShape(16.dp),
                         ),
-                    painter = rememberAsyncImagePainter(sideEvent.imageLink!!),
+                    painter = previewOverride(
+                        previewPainter = { rememberVectorPainter(image = Icons.Default.Person) },
+                        painter = { rememberAsyncImagePainter(sideEvent.imageLink!!) },
+                    ),
                     contentScale = ContentScale.Crop,
                     contentDescription = "Side events image",
                 )

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -1,13 +1,18 @@
 package io.github.droidkaigi.confsched2023.floormap.component
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Link
@@ -20,8 +25,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.ContentScale.Companion
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -39,6 +47,7 @@ import io.github.droidkaigi.confsched2023.model.SideEvent.Mark
 import io.github.droidkaigi.confsched2023.model.SideEvent.Mark.Favorite
 import io.github.droidkaigi.confsched2023.model.SideEvent.MarkColor.Pink
 import io.github.droidkaigi.confsched2023.model.SideEvents
+import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
 
 @Composable
 fun FloorMapSideEventItem(
@@ -52,55 +61,77 @@ fun FloorMapSideEventItem(
             .padding(horizontal = 16.dp),
     ) {
         Spacer(modifier = Modifier.height(16.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            val (iconVector, iconColor) = sideEvent.mark.iconResAndColor()
-            Icon(
-                imageVector = iconVector,
-                contentDescription = FavoriteIcon.asString(),
-                tint = iconColor,
-                modifier = Modifier.size(16.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = sideEvent.title.currentLangTitle,
-                style = MaterialTheme.typography.labelLarge,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = sideEvent.description.currentLangTitle,
-            style = MaterialTheme.typography.bodyMedium,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.Filled.Schedule,
-                contentDescription = FavoriteIcon.asString(),
-                modifier = Modifier.size(16.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = sideEvent.timeText.currentLangTitle,
-                style = MaterialTheme.typography.bodySmall,
-            )
-        }
-        if (sideEvent.link != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Filled.Link,
-                    contentDescription = FavoriteIcon.asString(),
-                    modifier = Modifier.size(16.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    val (iconVector, iconColor) = sideEvent.mark.iconResAndColor()
+                    Icon(
+                        imageVector = iconVector,
+                        contentDescription = FavoriteIcon.asString(),
+                        tint = iconColor,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = sideEvent.title.currentLangTitle,
+                        style = MaterialTheme.typography.labelLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = createAnnotatedEventDetailString(),
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.clickable {
-                        // todo open link
-                    },
+                    text = sideEvent.description.currentLangTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Filled.Schedule,
+                        contentDescription = FavoriteIcon.asString(),
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = sideEvent.timeText.currentLangTitle,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                if (sideEvent.link != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.Link,
+                            contentDescription = FavoriteIcon.asString(),
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = createAnnotatedEventDetailString(),
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.clickable {
+                                // todo open link
+                            },
+                        )
+                    }
+                }
+            }
+            if (sideEvent.imageLink != null) {
+                Image(
+                    modifier = Modifier
+                        .size(80.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(16.dp),
+                        ),
+                    painter = rememberAsyncImagePainter(sideEvent.imageLink!!),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = "Side events image",
                 )
             }
         }

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.ContentScale.Companion
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -63,7 +62,7 @@ fun FloorMapSideEventItem(
         Spacer(modifier = Modifier.height(16.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## Issue
- closes #646

## Overview (Required)
- Added `ImageUrl` field to SideEvent data class
- Added dummy data for ImageUrl
- Added Image composable to be displayed when there is an ImageUrl

## Question
- Is `SideEvent` currently only dummy data?
- If there is something like DesignDoc, I will follow it, but...

## Screenshot
Before | After | figma
:--: | :--: | - 
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/dc96341a-7adb-4c56-8e8c-c7c001125ef8" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/c085c81a-3660-43e0-8c2c-8e7b983af5fa" width="300" /> | <img src="https://user-images.githubusercontent.com/45708639/261336968-1fb015ca-4d7c-496c-b50f-31c0fe3b5efb.png" width="300" />