### PR TITLE
chore: refactor gradle scripts

### DIFF
--- a/app-android/src/main/AndroidManifest.xml
+++ b/app-android/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".App"
         android:allowBackup="true"
@@ -11,21 +12,22 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.KaigiApp"
-        android:localeConfig="@xml/locales_config">
         tools:targetApi="tiramisu">
+
         <activity
             android:name=".MainActivity"
-            android:exported="true"
-            android:label="@string/app_name">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidComposePlugin.kt
@@ -11,24 +11,23 @@ class AndroidComposePlugin : Plugin<Project> {
             android {
                 buildFeatures.compose = true
                 composeOptions {
-                    kotlinCompilerExtensionVersion = libs.findLibrary("composeCompiler").get()
-                        .get().versionConstraint.requiredVersion
+                    kotlinCompilerExtensionVersion = libs.version("composeCompiler")
                 }
             }
             dependencies {
-                implementation(libs.findLibrary("androidxCoreKtx"))
-                implementation(libs.findLibrary("composeUi"))
-                implementation(libs.findLibrary("composeMaterial"))
-                implementation(libs.findLibrary("composeUiToolingPreview"))
-                implementation(libs.findLibrary("androidxLifecycleLifecycleRuntimeKtx"))
-                implementation(libs.findLibrary("androidxActivityActivityCompose"))
-                testImplementation(libs.findLibrary("junit"))
-                testImplementation(libs.findLibrary("androidxTestExtJunit"))
-                testImplementation(libs.findLibrary("androidxTestEspressoEspressoCore"))
-                testImplementation(libs.findLibrary("composeUiTestJunit4"))
-                debugImplementation(libs.findLibrary("composeUiTooling"))
-                debugImplementation(libs.findLibrary("composeUiTestManifest"))
-                lintChecks(libs.findLibrary("composeLintCheck"))
+                implementation(libs.library("androidxCoreKtx"))
+                implementation(libs.library("composeUi"))
+                implementation(libs.library("composeMaterial"))
+                implementation(libs.library("composeUiToolingPreview"))
+                implementation(libs.library("androidxLifecycleLifecycleRuntimeKtx"))
+                implementation(libs.library("androidxActivityActivityCompose"))
+                testImplementation(libs.library("junit"))
+                testImplementation(libs.library("androidxTestExtJunit"))
+                testImplementation(libs.library("androidxTestEspressoEspressoCore"))
+                testImplementation(libs.library("composeUiTestJunit4"))
+                debugImplementation(libs.library("composeUiTooling"))
+                debugImplementation(libs.library("composeUiTestManifest"))
+                lintChecks(libs.library("composeLintCheck"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidFirebasePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidFirebasePlugin.kt
@@ -22,9 +22,9 @@ class AndroidFirebasePlugin : Plugin<Project> {
                 }
             }
             dependencies {
-                implementation(libs.findLibrary("firebaseAuth"))
-                implementation(libs.findLibrary("firebaseCommon"))
-                implementation(libs.findLibrary("multiplatformFirebaseAuth"))
+                implementation(libs.library("firebaseAuth"))
+                implementation(libs.library("firebaseCommon"))
+                implementation(libs.library("multiplatformFirebaseAuth"))
             }
             extensions.configure<KaptExtension> {
                 correctErrorTypes = true

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidGradleDsl.kt
@@ -30,6 +30,7 @@ fun Project.setupAndroid() {
 
         defaultConfig {
             minSdk = 23
+            targetSdk = 33
         }
 
         compileOptions {
@@ -38,7 +39,7 @@ fun Project.setupAndroid() {
             isCoreLibraryDesugaringEnabled = true
         }
         dependencies {
-            add("coreLibraryDesugaring", libs.findLibrary("androidDesugarJdkLibs").get())
+            add("coreLibraryDesugaring", libs.library("androidDesugarJdkLibs"))
         }
         testOptions {
             unitTests {
@@ -59,7 +60,5 @@ fun Project.setupAndroid() {
             // for now
             sarifReport = false
         }
-
-        defaultConfig.targetSdk = 33
     }
 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidHiltPlugin.kt
@@ -23,12 +23,12 @@ class AndroidHiltPlugin : Plugin<Project> {
                 }
             }
             dependencies {
-                implementation(libs.findLibrary("daggerHiltAndroid"))
+                implementation(libs.library("daggerHiltAndroid"))
                 // https://issuetracker.google.com/issues/237567009
-                implementation(libs.findLibrary("androidxFragment"))
-                kapt(libs.findLibrary("daggerHiltAndroidCompiler"))
-                testImplementation(libs.findLibrary("daggerHiltAndroidTesting"))
-                kaptTest(libs.findLibrary("daggerHiltAndroidTesting"))
+                implementation(libs.library("androidxFragment"))
+                kapt(libs.library("daggerHiltAndroidCompiler"))
+                testImplementation(libs.library("daggerHiltAndroidTesting"))
+                kaptTest(libs.library("daggerHiltAndroidTesting"))
             }
             extensions.configure<KaptExtension> {
                 correctErrorTypes = true

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidKotlinPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidKotlinPlugin.kt
@@ -32,9 +32,9 @@ class AndroidKotlinPlugin : Plugin<Project> {
                 }
             }
             dependencies {
-                implementation(libs.findLibrary("kotlinxCoroutinesCore"))
+                implementation(libs.library("kotlinxCoroutinesCore"))
                 // Fix https://youtrack.jetbrains.com/issue/KT-41821
-                implementation(libs.findLibrary("kotlinxAtomicfu"))
+                implementation(libs.library("kotlinxAtomicfu"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidRoborazziPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidRoborazziPlugin.kt
@@ -29,15 +29,15 @@ class AndroidRoborazziPlugin : Plugin<Project> {
                 }
             }
             dependencies {
-                testImplementation(libs.findLibrary("androidxTestEspressoEspressoCore"))
-                testImplementation(libs.findLibrary("junit"))
-                testImplementation(libs.findLibrary("robolectric"))
-                testImplementation(libs.findLibrary("androidxTestExtJunit"))
-                testImplementation(libs.findLibrary("roborazzi"))
-                testImplementation(libs.findLibrary("roborazziCompose"))
+                testImplementation(libs.library("androidxTestEspressoEspressoCore"))
+                testImplementation(libs.library("junit"))
+                testImplementation(libs.library("robolectric"))
+                testImplementation(libs.library("androidxTestExtJunit"))
+                testImplementation(libs.library("roborazzi"))
+                testImplementation(libs.library("roborazziCompose"))
                 // For preview screenshot tests
-                implementation(libs.findLibrary("showkaseRuntime"))
-                ksp(libs.findLibrary("showkaseProcessor"))
+                implementation(libs.library("showkaseRuntime"))
+                ksp(libs.library("showkaseProcessor"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/GradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/GradleDsl.kt
@@ -1,56 +1,47 @@
 package io.github.droidkaigi.confsched2023.primitive
 
-import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import java.util.Optional
 
 fun DependencyHandlerScope.implementation(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("implementation", artifact.get())
+    add("implementation", artifact)
 }
 
 fun DependencyHandlerScope.debugImplementation(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("debugImplementation", artifact.get())
+    add("debugImplementation", artifact)
 }
 
 fun DependencyHandlerScope.androidTestImplementation(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("androidTestImplementation", artifact.get())
+    add("androidTestImplementation", artifact)
 }
 
 fun DependencyHandlerScope.testImplementation(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("testImplementation", artifact.get())
+    add("testImplementation", artifact)
 }
 
 fun DependencyHandlerScope.lintChecks(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("lintChecks", artifact.get())
+    add("lintChecks", artifact)
 }
 
 private fun DependencyHandlerScope.api(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("api", artifact.get())
+    add("api", artifact)
 }
 
 fun Project.java(action: JavaPluginExtension.() -> Unit) {
     extensions.configure(action)
 }
-
-val Project.libs get() = extensions.getByType<VersionCatalogsExtension>().named("libs")

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpAndroidHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpAndroidHiltPlugin.kt
@@ -19,18 +19,18 @@ class KmpAndroidHiltPlugin : Plugin<Project> {
                 sourceSets.getByName("androidMain") {
                     val kaptConfiguration = configurations["kapt"]
                     kaptConfiguration.dependencies.add(
-                        libs.findLibrary("daggerHiltAndroidCompiler").map {
+                        libs.library("daggerHiltAndroidCompiler").let {
                             DefaultExternalModuleDependency(
-                                it.get().module.group,
-                                it.get().module.name,
-                                it.get().versionConstraint.requiredVersion
+                                it.module.group,
+                                it.module.name,
+                                it.versionConstraint.requiredVersion
                             )
-                        }.get()
+                        }
                     )
                     dependencies {
-                        implementation(libs.findLibrary("daggerHiltAndroid").get())
+                        implementation(libs.library("daggerHiltAndroid"))
                         // https://issuetracker.google.com/issues/237567009
-                        implementation(libs.findLibrary("androidxFragment").get())
+                        implementation(libs.library("androidxFragment"))
                     }
                 }
             }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpAndroidShowkasePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpAndroidShowkasePlugin.kt
@@ -3,24 +3,23 @@ package io.github.droidkaigi.confsched2023.primitive
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.get
 
 @Suppress("unused")
 class KmpAndroidShowkasePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply(libs.findPlugin("kspGradlePlugin").get().get().pluginId)
+                apply(libs.plugin("kspGradlePlugin").pluginId)
             }
             kotlin {
                 sourceSets.getByName("androidMain") {
                     dependencies {
-                        implementation(libs.findLibrary("showkaseRuntime").get())
+                        implementation(libs.library("showkaseRuntime"))
                     }
                 }
             }
             dependencies {
-                this.add("kspAndroid", libs.findLibrary("showkaseProcessor").get())
+                add("kspAndroid", libs.library("showkaseProcessor"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpComposePlugin.kt
@@ -14,14 +14,13 @@ class KmpComposePlugin : Plugin<Project> {
             android {
                 buildFeatures.compose = true
                 composeOptions {
-                    kotlinCompilerExtensionVersion = libs.findLibrary("composeCompiler").get()
-                        .get().versionConstraint.requiredVersion
+                    kotlinCompilerExtensionVersion = libs.version("composeCompiler")
                 }
             }
             val compose = extensions.get("compose") as org.jetbrains.compose.ComposeExtension
             kotlin {
                 with(sourceSets) {
-                    get("commonMain").apply {
+                    getByName("commonMain").apply {
                         dependencies {
                             implementation(compose.dependencies.runtime)
                             implementation(compose.dependencies.foundation)
@@ -30,11 +29,11 @@ class KmpComposePlugin : Plugin<Project> {
                             implementation(compose.dependencies.components.resources)
                         }
                     }
-                    get("androidMain").apply {
+                    getByName("androidMain").apply {
                         dependencies {
-                            implementation(libs.findLibrary("androidxActivityActivityCompose").get())
-                            implementation(libs.findLibrary("androidxLifecycleLifecycleRuntimeKtx").get())
-                            implementation(libs.findLibrary("composeUiToolingPreview").get())
+                            implementation(libs.library("androidxActivityActivityCompose"))
+                            implementation(libs.library("androidxLifecycleLifecycleRuntimeKtx"))
+                            implementation(libs.library("composeUiToolingPreview"))
                         }
                     }
                 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpIosPlugin.kt
@@ -8,21 +8,12 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import java.util.Properties
 
 @Suppress("unused")
 class KmpIosPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             kotlin {
-                val activeArch = Arch.findByArch(
-                    rootProject.layout.projectDirectory.file("local.properties").asFile.takeIf { it.exists() }
-                        ?.let {
-                            Properties().apply {
-                                load(it.reader(Charsets.UTF_8))
-                            }.getProperty("arch")
-                        } ?: System.getenv("arch")
-                )
                 when (activeArch) {
                     ARM -> iosSimulatorArm64()
                     X86 -> iosX64()
@@ -33,25 +24,18 @@ class KmpIosPlugin : Plugin<Project> {
                     }
                 }
                 with(sourceSets) {
-                    val iosSourceSets = listOf(
-                        "iosArm64",
-                        "iosX64",
-                        "iosSimulatorArm64",
-                    )
                     create("iosMain") {
                         dependsOn(getByName("commonMain"))
-                    }
-                    iosSourceSets.forEach { iosSourceSet ->
-                        maybeCreate(iosSourceSet + "Main")
-                            .dependsOn(getByName("iosMain"))
+                        maybeCreate("iosArm64Main").dependsOn(this)
+                        maybeCreate("iosX64Main").dependsOn(this)
+                        maybeCreate("iosSimulatorArm64Main").dependsOn(this)
                     }
 
                     create("iosTest") {
                         dependsOn(getByName("commonTest"))
-                    }
-                    iosSourceSets.forEach { iosSourceSet ->
-                        maybeCreate(iosSourceSet + "Test")
-                            .dependsOn(getByName("iosTest"))
+                        maybeCreate("iosArm64Test").dependsOn(this)
+                        maybeCreate("iosX64Test").dependsOn(this)
+                        maybeCreate("iosSimulatorArm64Test").dependsOn(this)
                     }
                 }
 
@@ -61,19 +45,6 @@ class KmpIosPlugin : Plugin<Project> {
                     compilations["main"].kotlinOptions.freeCompilerArgs += "-Xexport-kdoc"
                 }
             }
-        }
-    }
-}
-
-enum class Arch(val arch: String?) {
-    ARM("arm64"),
-    X86("x86_64"),
-    ALL(null),
-    ;
-
-    companion object {
-        fun findByArch(arch: String?): Arch {
-            return values().firstOrNull { it.arch == arch } ?: ALL
         }
     }
 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpKtorfitPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpKtorfitPlugin.kt
@@ -1,11 +1,13 @@
 package io.github.droidkaigi.confsched2023.primitive
 
+import io.github.droidkaigi.confsched2023.primitive.Arch.ALL
+import io.github.droidkaigi.confsched2023.primitive.Arch.ARM
+import io.github.droidkaigi.confsched2023.primitive.Arch.X86
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getByName
 
 @Suppress("unused")
 class KmpKtorfitPlugin : Plugin<Project> {
@@ -16,11 +18,11 @@ class KmpKtorfitPlugin : Plugin<Project> {
                 apply("de.jensklingenberg.ktorfit")
             }
             kotlin {
-                android()
+                androidTarget()
             }
 
             configure<de.jensklingenberg.ktorfit.gradle.KtorfitGradleConfiguration> {
-                version = "1.4.1"
+                version = "1.5.0"
             }
 
             kotlin {
@@ -33,16 +35,20 @@ class KmpKtorfitPlugin : Plugin<Project> {
             dependencies {
                 this.add(
                     "kspCommonMainMetadata",
-                    "de.jensklingenberg.ktorfit:ktorfit-ksp:1.4.1"
+                    "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0"
                 )
-                this.add("kspAndroid", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.4.1")
-                val iosSourceSets = listOf(
-                    "IosArm64",
-                    "IosX64",
-                    "IosSimulatorArm64",
-                )
-                iosSourceSets.forEach {
-                    this.add("ksp$it", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.4.1")
+                this.add("kspAndroid", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0")
+                val iosConfigs = when (activeArch) {
+                    ARM -> listOf("IosSimulatorArm64")
+                    X86 -> listOf("IosX64")
+                    ALL -> listOf(
+                        "IosArm64",
+                        "IosX64",
+                        "IosSimulatorArm64",
+                    )
+                }
+                iosConfigs.forEach {
+                    this.add("ksp$it", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0")
                 }
             }
         }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpKtorfitPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpKtorfitPlugin.kt
@@ -14,18 +14,18 @@ class KmpKtorfitPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply(libs.findPlugin("kspGradlePlugin").get().get().pluginId)
+                apply(libs.plugin("kspGradlePlugin").pluginId)
                 apply("de.jensklingenberg.ktorfit")
             }
 
             configure<de.jensklingenberg.ktorfit.gradle.KtorfitGradleConfiguration> {
-                version = "1.5.0"
+                version = libs.library("ktorfitKsp").versionConstraint.requiredVersion
             }
 
             kotlin {
-                sourceSets.get("commonMain").apply {
+                sourceSets["commonMain"].apply {
                     dependencies {
-                        implementation(libs.findLibrary("ktorfitLib").get())
+                        implementation(libs.library("ktorfitLib"))
                     }
                 }
             }
@@ -40,8 +40,8 @@ class KmpKtorfitPlugin : Plugin<Project> {
                         "IosSimulatorArm64",
                     )
                 }
-                listOf("CommonMainMetadata", "Android") + iosConfigs.forEach {
-                    add("ksp$it", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0")
+                (listOf("CommonMainMetadata", "Android") + iosConfigs).forEach {
+                    add("ksp$it", libs.library("ktorfitKsp"))
                 }
             }
         }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpKtorfitPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KmpKtorfitPlugin.kt
@@ -17,9 +17,6 @@ class KmpKtorfitPlugin : Plugin<Project> {
                 apply(libs.findPlugin("kspGradlePlugin").get().get().pluginId)
                 apply("de.jensklingenberg.ktorfit")
             }
-            kotlin {
-                androidTarget()
-            }
 
             configure<de.jensklingenberg.ktorfit.gradle.KtorfitGradleConfiguration> {
                 version = "1.5.0"
@@ -32,12 +29,8 @@ class KmpKtorfitPlugin : Plugin<Project> {
                     }
                 }
             }
+
             dependencies {
-                this.add(
-                    "kspCommonMainMetadata",
-                    "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0"
-                )
-                this.add("kspAndroid", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0")
                 val iosConfigs = when (activeArch) {
                     ARM -> listOf("IosSimulatorArm64")
                     X86 -> listOf("IosX64")
@@ -47,8 +40,8 @@ class KmpKtorfitPlugin : Plugin<Project> {
                         "IosSimulatorArm64",
                     )
                 }
-                iosConfigs.forEach {
-                    this.add("ksp$it", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0")
+                listOf("CommonMainMetadata", "Android") + iosConfigs.forEach {
+                    add("ksp$it", "de.jensklingenberg.ktorfit:ktorfit-ksp:1.5.0")
                 }
             }
         }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KotlinGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KotlinGradleDsl.kt
@@ -3,17 +3,13 @@ package io.github.droidkaigi.confsched2023.primitive
 import com.android.build.gradle.TestedExtension
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
-import java.awt.AWTEventMulticaster.add
-import java.util.Optional
 
 fun DependencyHandlerScope.kapt(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("kapt", artifact.get())
+    add("kapt", artifact)
 }
 
 fun TestedExtension.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
@@ -21,13 +17,13 @@ fun TestedExtension.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
 }
 
 fun DependencyHandlerScope.ksp(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("ksp", artifact.get())
+    add("ksp", artifact)
 }
 
 fun DependencyHandlerScope.kaptTest(
-    artifact: Optional<Provider<MinimalExternalModuleDependency>>
+    artifact: MinimalExternalModuleDependency,
 ) {
-    add("kaptTest", artifact.get())
+    add("kaptTest", artifact)
 }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/SourceSet.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/SourceSet.kt
@@ -1,0 +1,27 @@
+package io.github.droidkaigi.confsched2023.primitive
+
+import org.gradle.api.Project
+import java.util.Properties
+
+enum class Arch(val arch: String?) {
+    ARM("arm64"),
+    X86("x86_64"),
+    ALL(null),
+    ;
+
+    companion object {
+        fun findByArch(arch: String?): Arch {
+            return values().firstOrNull { it.arch == arch } ?: ALL
+        }
+    }
+}
+
+val Project.activeArch
+    get() = Arch.findByArch(
+        rootProject.layout.projectDirectory.file("local.properties").asFile.takeIf { it.exists() }
+            ?.let {
+                Properties().apply {
+                    load(it.reader(Charsets.UTF_8))
+                }.getProperty("arch")
+            } ?: System.getenv("arch")
+    )

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/VersionCatalogDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/VersionCatalogDsl.kt
@@ -1,0 +1,28 @@
+package io.github.droidkaigi.confsched2023.primitive
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.plugin.use.PluginDependency
+
+internal val Project.libs: VersionCatalog
+    get() = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+internal fun VersionCatalog.version(name: String): String {
+    return findVersion(name).get().requiredVersion
+}
+
+internal fun VersionCatalog.library(name: String): MinimalExternalModuleDependency {
+    return findLibrary(name).get().get()
+}
+
+internal fun VersionCatalog.plugin(name: String): PluginDependency {
+    return findPlugin(name).get().get()
+}
+
+internal fun VersionCatalog.bundle(name: String): ExternalModuleDependencyBundle {
+    return findBundle(name).get().get()
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -9,9 +9,10 @@ plugins {
 }
 
 android.namespace = "io.github.droidkaigi.confsched2023.core.data"
+
 kotlin {
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(projects.core.model)
                 implementation(projects.core.common)
@@ -26,8 +27,9 @@ kotlin {
                 implementation(libs.kermit)
             }
         }
-        val androidMain by getting {
-            dependsOn(commonMain)
+
+        androidMain {
+            dependsOn(getByName("commonMain"))
             dependencies {
                 implementation(libs.ktorClientOkHttp)
                 implementation(libs.okHttpLoggingInterceptor)
@@ -35,12 +37,12 @@ kotlin {
                 implementation(libs.firebaseRemoteConfig)
             }
         }
-        val iosMain by getting {
+
+        iosMain {
+            dependsOn(getByName("commonMain"))
             dependencies {
                 implementation(libs.ktorClientDarwin)
             }
         }
     }
-}
-dependencies {
 }

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.github.droidkaigi.confsched2023.primitive.libs
-
 plugins {
     id("droidkaigi.primitive.kmp")
     id("droidkaigi.primitive.kmp.android")
@@ -17,12 +15,12 @@ kotlin {
         commonMain {
             dependencies {
                 // Fix https://youtrack.jetbrains.com/issue/KT-41821
-                implementation(libs.findLibrary("kotlinxAtomicfu").get())
+                implementation(libs.kotlinxAtomicfu)
             }
         }
     }
 }
 
 dependencies {
-    lintChecks(libs.findLibrary("composeLintCheck").get())
+    lintChecks(libs.composeLintCheck)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,7 @@ firebaseAuth = { module = "com.google.firebase:firebase-auth" }
 firebaseRemoteConfig = { module = "dev.gitlive:firebase-config", version = "1.8.1" }
 
 ktorfitLib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
+ktorfitKsp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit" }
 
 # Debug
 


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Ktorfit plugin breaks arch filter, so I fixed it
- create version catalog dsl, to remove redundant `get()` call
  - ktorfit ksp plugin didn't match ktorfit library, so replaced plugin to match version catalog

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />