### PR TITLE
[feature/#663] Change type of mainScreenTabs param to PersistentList

### DIFF
--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -41,6 +41,7 @@ import io.github.droidkaigi.confsched2023.feature.main.R
 import io.github.droidkaigi.confsched2023.main.component.KaigiBottomBar
 import io.github.droidkaigi.confsched2023.main.strings.MainStrings
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
+import kotlinx.collections.immutable.toPersistentList
 
 const val mainScreenRoute = "main"
 const val MainScreenTestTag = "MainScreen"
@@ -147,7 +148,7 @@ private fun MainScreen(
     Scaffold(
         bottomBar = {
             KaigiBottomBar(
-                mainScreenTabs = MainScreenTab.entries.toList(),
+                mainScreenTabs = MainScreenTab.entries.toPersistentList(),
                 onTabSelected = { tab ->
                     onTabSelected(mainNestedNavController, tab)
                 },

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiBottomBar.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiBottomBar.kt
@@ -12,10 +12,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import io.github.droidkaigi.confsched2023.main.IconRepresentation.Drawable
 import io.github.droidkaigi.confsched2023.main.IconRepresentation.Vector
 import io.github.droidkaigi.confsched2023.main.MainScreenTab
+import kotlinx.collections.immutable.PersistentList
 
 @Composable
 fun KaigiBottomBar(
-    mainScreenTabs: List<MainScreenTab>,
+    mainScreenTabs: PersistentList<MainScreenTab>,
     onTabSelected: (MainScreenTab) -> Unit,
     currentTab: MainScreenTab,
     isEnableStamps: Boolean,


### PR DESCRIPTION
## Issue
- close #663 

## Overview (Required)
- Change type of mainScreenTabs param to PersistentList

## Experiment

- Apply persistent list

<img width="368" alt="스크린샷 2023-08-18 오후 2 17 37" src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/6d2ad762-ab66-4ba8-aa65-5b0398bcba1f">

Clicked all tab Items each and clicked first item multiple times

- Just using `List`

<img width="378" alt="스크린샷 2023-08-18 오후 2 18 24" src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/df61d54c-4428-404c-a68b-41ba3d2b34fa">

Surprisingly, I just clicked first ~ fourth item (not all tab items, not duplicated click). Nevertheless, items' recomposition count are much higher than above
