### PR TITLE
Update room colors accommodating Dark Theme

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Color.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Color.kt
@@ -72,6 +72,17 @@ val room_hall_c = Color(0xFF16525A)
 val room_hall_d = Color(0xFF5E5504)
 val room_hall_e = Color(0xFF78085F)
 
+val arcticfoxBlue = Color(0xFF0A57A4)
+val bumblebeeYellow = Color(0xFF5E5504)
+val chipmunkBrown = Color(0xFF552E21)
+val dolphinGreen = Color(0xFF026066)
+val electriceelGray = Color(0xFF494E5A)
+val arcticfoxBluePale = Color(0xFFB2D1FF)
+val bumblebeeYellowPale = Color(0xFFF0DF63)
+val chipmunkBrownPale = Color(0xFFE7BB92)
+val dolphinGreenPale = Color(0xFFB4DDDD)
+val electriceelGrayPale = Color(0xFFB8B9BD)
+
 val md_theme_light_floor_button_background = Color(0xFFFFFFFF)
 
 val md_theme_dark_floor_button_background = Color(0xFF000000)

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Color.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Color.kt
@@ -66,12 +66,6 @@ val md_theme_dark_scrim = Color(0xFF000000)
 
 val seed = Color(0xFF006C50)
 
-val room_hall_a = Color(0xFF483382)
-val room_hall_b = Color(0xFF005085)
-val room_hall_c = Color(0xFF16525A)
-val room_hall_d = Color(0xFF5E5504)
-val room_hall_e = Color(0xFF78085F)
-
 val arcticfoxBlue = Color(0xFF0A57A4)
 val bumblebeeYellow = Color(0xFF5E5504)
 val chipmunkBrown = Color(0xFF552E21)

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Theme.kt
@@ -92,6 +92,40 @@ fun floorButtonColors() = if (isSystemInDarkTheme()) {
     FloorButtonColorScheme.Light()
 }
 
+sealed interface HallColorScheme {
+    val hallA: Color
+    val hallB: Color
+    val hallC: Color
+    val hallD: Color
+    val hallE: Color
+    val hallText: Color
+
+    data object Light : HallColorScheme {
+        override val hallA: Color = arcticfoxBlue
+        override val hallB: Color = bumblebeeYellow
+        override val hallC: Color = chipmunkBrown
+        override val hallD: Color = dolphinGreen
+        override val hallE: Color = electriceelGray
+        override val hallText: Color = Color.White
+    }
+
+    data object Dark : HallColorScheme {
+        override val hallA: Color = arcticfoxBluePale
+        override val hallB: Color = bumblebeeYellowPale
+        override val hallC: Color = chipmunkBrownPale
+        override val hallD: Color = dolphinGreenPale
+        override val hallE: Color = electriceelGrayPale
+        override val hallText: Color = Color.Black
+    }
+}
+
+@Composable
+fun hallColors() = if (isSystemInDarkTheme()) {
+    HallColorScheme.Dark
+} else {
+    HallColorScheme.Light
+}
+
 @Composable
 fun KaigiTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -28,20 +28,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_a
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_b
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_c
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_d
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_e
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room4
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room5
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2023.model.fake
-import io.github.droidkaigi.confsched2023.model.type
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.ScheduleIcon
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.UserIcon
 import io.github.droidkaigi.confsched2023.ui.previewOverride
@@ -55,14 +44,7 @@ fun TimetableGridItem(
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val backgroundColor = when (timetableItem.room.type) {
-        Room1 -> room_hall_a
-        Room2 -> room_hall_b
-        Room3 -> room_hall_c
-        Room4 -> room_hall_d
-        Room5 -> room_hall_e
-        else -> Color.White
-    }
+    val backgroundColor = timetableItem.room.color
     Box(modifier.testTag(TimetableGridItemTestTag)) {
         Box(
             modifier = Modifier

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2023.designsystem.theme.hallColors
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2023.model.fake
@@ -46,35 +47,32 @@ fun TimetableGridItem(
 ) {
     val backgroundColor = timetableItem.room.color
     Box(modifier.testTag(TimetableGridItemTestTag)) {
-        Box(
+        Surface(
+            onClick = { onTimetableItemClick(timetableItem) },
+            shape = RoundedCornerShape(4.dp),
+            color = backgroundColor,
+            contentColor = hallColors().hallText,
             modifier = Modifier
                 .testTag(TimetableGridItemTestTag)
-                .background(
-                    color = backgroundColor,
-                    shape = RoundedCornerShape(4.dp),
-                )
-                .width(192.dp)
-                .clickable {
-                    onTimetableItemClick(timetableItem)
-                }
-                .padding(12.dp),
+                .width(192.dp),
         ) {
-            Column {
+            Column(
+                modifier = Modifier.padding(12.dp),
+            ) {
                 Text(
                     text = timetableItem.title.currentLangTitle,
-                    style = MaterialTheme.typography.labelLarge.copy(Color.White),
+                    style = MaterialTheme.typography.labelLarge,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Row(modifier = Modifier.height(16.dp)) {
                     Icon(
                         imageVector = Icons.Default.Schedule,
-                        tint = Color.White,
                         contentDescription = ScheduleIcon.asString(),
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
                         text = "${timetableItem.startsTimeString} - ${timetableItem.endsTimeString}",
-                        style = MaterialTheme.typography.bodySmall.copy(Color.White),
+                        style = MaterialTheme.typography.bodySmall,
                     )
                 }
 
@@ -97,7 +95,7 @@ fun TimetableGridItem(
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = speaker.name,
-                            style = MaterialTheme.typography.labelMedium.copy(Color.White),
+                            style = MaterialTheme.typography.labelMedium,
                         )
                     }
                 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableRoom.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableRoom.kt
@@ -1,11 +1,11 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
 import androidx.compose.ui.graphics.Color
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_a
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_b
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_c
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_d
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_e
+import io.github.droidkaigi.confsched2023.designsystem.theme.arcticfoxBlue
+import io.github.droidkaigi.confsched2023.designsystem.theme.bumblebeeYellow
+import io.github.droidkaigi.confsched2023.designsystem.theme.chipmunkBrown
+import io.github.droidkaigi.confsched2023.designsystem.theme.dolphinGreen
+import io.github.droidkaigi.confsched2023.designsystem.theme.electriceelGray
 import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
 import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
 import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
@@ -16,10 +16,10 @@ import io.github.droidkaigi.confsched2023.model.type
 
 internal val TimetableRoom.color: Color
     get() = when (type) {
-        Room1 -> room_hall_a
-        Room2 -> room_hall_b
-        Room3 -> room_hall_c
-        Room4 -> room_hall_d
-        Room5 -> room_hall_e
+        Room1 -> chipmunkBrown
+        Room2 -> arcticfoxBlue
+        Room3 -> bumblebeeYellow
+        Room4 -> dolphinGreen
+        Room5 -> electriceelGray
         else -> Color.White
     }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableRoom.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableRoom.kt
@@ -1,0 +1,25 @@
+package io.github.droidkaigi.confsched2023.sessions.component
+
+import androidx.compose.ui.graphics.Color
+import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_a
+import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_b
+import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_c
+import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_d
+import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_e
+import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
+import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
+import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
+import io.github.droidkaigi.confsched2023.model.RoomIndex.Room4
+import io.github.droidkaigi.confsched2023.model.RoomIndex.Room5
+import io.github.droidkaigi.confsched2023.model.TimetableRoom
+import io.github.droidkaigi.confsched2023.model.type
+
+internal val TimetableRoom.color: Color
+    get() = when (type) {
+        Room1 -> room_hall_a
+        Room2 -> room_hall_b
+        Room3 -> room_hall_c
+        Room4 -> room_hall_d
+        Room5 -> room_hall_e
+        else -> Color.White
+    }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableRoom.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableRoom.kt
@@ -1,11 +1,8 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import io.github.droidkaigi.confsched2023.designsystem.theme.arcticfoxBlue
-import io.github.droidkaigi.confsched2023.designsystem.theme.bumblebeeYellow
-import io.github.droidkaigi.confsched2023.designsystem.theme.chipmunkBrown
-import io.github.droidkaigi.confsched2023.designsystem.theme.dolphinGreen
-import io.github.droidkaigi.confsched2023.designsystem.theme.electriceelGray
+import io.github.droidkaigi.confsched2023.designsystem.theme.hallColors
 import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
 import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
 import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
@@ -15,11 +12,15 @@ import io.github.droidkaigi.confsched2023.model.TimetableRoom
 import io.github.droidkaigi.confsched2023.model.type
 
 internal val TimetableRoom.color: Color
-    get() = when (type) {
-        Room1 -> chipmunkBrown
-        Room2 -> arcticfoxBlue
-        Room3 -> bumblebeeYellow
-        Room4 -> dolphinGreen
-        Room5 -> electriceelGray
-        else -> Color.White
+    @Composable get() {
+        val colors = hallColors()
+
+        return when (type) {
+            Room1 -> colors.hallC
+            Room2 -> colors.hallA
+            Room3 -> colors.hallB
+            Room4 -> colors.hallD
+            Room5 -> colors.hallE
+            else -> Color.White
+        }
     }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
@@ -20,20 +20,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_a
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_b
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_c
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_d
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_e
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room4
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room5
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItemId
-import io.github.droidkaigi.confsched2023.model.type
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableListItem
+import io.github.droidkaigi.confsched2023.sessions.component.color
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.PersistentSet
 
@@ -78,14 +68,7 @@ fun BookmarkList(
                         timetableItem = timetableItem,
                         isBookmarked = bookmarkedTimetableItemIds.contains(timetableItem.id),
                         chipContent = {
-                            val roomChipBackgroundColor = when (timetableItem.room.type) {
-                                Room1 -> room_hall_a
-                                Room2 -> room_hall_b
-                                Room3 -> room_hall_c
-                                Room4 -> room_hall_d
-                                Room5 -> room_hall_e
-                                else -> Color.White
-                            }
+                            val roomChipBackgroundColor = timetableItem.room.color
                             AssistChip(
                                 onClick = { /*Do Nothing*/ },
                                 label = {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.droidkaigi.confsched2023.designsystem.theme.hallColors
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItemId
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableListItem
@@ -76,11 +77,11 @@ fun BookmarkList(
                                         timetableItem.room.name.currentLangTitle,
                                         fontWeight = FontWeight.Medium,
                                         fontSize = 12.sp,
-                                        color = Color.White,
                                     )
                                 },
                                 colors = AssistChipDefaults.assistChipColors(
                                     containerColor = roomChipBackgroundColor,
+                                    labelColor = hallColors().hallText,
                                 ),
                                 border = AssistChipDefaults.assistChipBorder(
                                     borderColor = Color.Transparent,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
@@ -22,11 +22,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.designsystem.theme.hallColors
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItemId
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
-import io.github.droidkaigi.confsched2023.sessions.component.color
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableListItem
+import io.github.droidkaigi.confsched2023.sessions.component.color
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentSet
 import java.util.Locale
@@ -103,13 +104,13 @@ fun SearchList(
                         SuggestionChip(
                             colors = SuggestionChipDefaults.suggestionChipColors(
                                 containerColor = timetableItem.room.color,
+                                labelColor = hallColors().hallText,
                             ),
                             onClick = { /* Do nothing */ },
                             label = {
                                 Text(
                                     text = timetableItem.room.name.currentLangTitle,
                                     style = MaterialTheme.typography.bodyMedium,
-                                    color = Color.White,
                                 )
                             },
                         )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
@@ -22,20 +22,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_a
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_b
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_c
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_d
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_e
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room4
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room5
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItemId
-import io.github.droidkaigi.confsched2023.model.type
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
+import io.github.droidkaigi.confsched2023.sessions.component.color
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableListItem
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentSet
@@ -112,14 +102,7 @@ fun SearchList(
 
                         SuggestionChip(
                             colors = SuggestionChipDefaults.suggestionChipColors(
-                                containerColor = when (timetableItem.room.type) {
-                                    Room1 -> room_hall_a
-                                    Room2 -> room_hall_b
-                                    Room3 -> room_hall_c
-                                    Room4 -> room_hall_d
-                                    Room5 -> room_hall_e
-                                    else -> Color.White
-                                },
+                                containerColor = timetableItem.room.color,
                             ),
                             onClick = { /* Do nothing */ },
                             label = {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -20,10 +20,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.designsystem.theme.hallColors
 import io.github.droidkaigi.confsched2023.model.Timetable
 import io.github.droidkaigi.confsched2023.model.TimetableItem
-import io.github.droidkaigi.confsched2023.sessions.component.color
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableListItem
+import io.github.droidkaigi.confsched2023.sessions.component.color
 import kotlinx.collections.immutable.PersistentMap
 
 const val TimetableListTestTag = "TimetableList"
@@ -79,13 +80,13 @@ fun TimetableList(
                             SuggestionChip(
                                 colors = SuggestionChipDefaults.suggestionChipColors(
                                     containerColor = timetableItem.room.color,
+                                    labelColor = hallColors().hallText,
                                 ),
                                 onClick = { /* Do nothing */ },
                                 label = {
                                     Text(
                                         text = timetableItem.room.name.currentLangTitle,
                                         style = MaterialTheme.typography.bodyMedium,
-                                        color = Color.White,
                                     )
                                 },
                             )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -20,19 +20,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_a
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_b
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_c
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_d
-import io.github.droidkaigi.confsched2023.designsystem.theme.room_hall_e
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room1
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room2
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room3
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room4
-import io.github.droidkaigi.confsched2023.model.RoomIndex.Room5
 import io.github.droidkaigi.confsched2023.model.Timetable
 import io.github.droidkaigi.confsched2023.model.TimetableItem
-import io.github.droidkaigi.confsched2023.model.type
+import io.github.droidkaigi.confsched2023.sessions.component.color
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableListItem
 import kotlinx.collections.immutable.PersistentMap
 
@@ -88,14 +78,7 @@ fun TimetableList(
 
                             SuggestionChip(
                                 colors = SuggestionChipDefaults.suggestionChipColors(
-                                    containerColor = when (timetableItem.room.type) {
-                                        Room1 -> room_hall_a
-                                        Room2 -> room_hall_b
-                                        Room3 -> room_hall_c
-                                        Room4 -> room_hall_d
-                                        Room5 -> room_hall_e
-                                        else -> Color.White
-                                    },
+                                    containerColor = timetableItem.room.color,
                                 ),
                                 onClick = { /* Do nothing */ },
                                 label = {


### PR DESCRIPTION
## Issue
- close #575

## Overview (Required)
1. The room colors are different from Figma ones.
   1. → updated the colors according to the Figma definitions.
2. Some of them are incorrectly mapped. (ex. Bumblebee, Dolphin)
   1. → extracted and updated the mapping logic to use it in common.
3. The colors don't accommodate Dark Theme.
   1. → defined [custom colors](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56081-60267&mode=design&t=2KnUjYN3lAL2dAvX-4) for the rooms.
   2. → introduced `HallColorScheme` reflecting the current mode.
   3. → used [`hallText` color](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56081-60264&mode=design&t=2KnUjYN3lAL2dAvX-4) for the content color of the room items.

## Links
- Figma: [DroidKaigi 2023 App UI/Styles](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56081-60248&mode=design&t=PXv9x7fY3I8fwZEF-4)

## Screenshot
Location | Before | After
:--: | :--: | :--:
Timetable (List) | ![main-timetable-list](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/c5ed7fea-34ce-48a6-8cc4-0bd1c9c904de) | ![changed-timetable-list](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/056539ea-2a19-42f1-ae10-65b4953e69fa)
Timetable (Grid) | ![main-timetable-grid-1](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/1b8e12a5-0528-4f69-9170-b2ed864fbc60) | ![changed-timetable-grid-1](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/2be5acea-84d8-492a-bf39-c69bca7ec3d8)
Bookmarks        | ![main-bookmarks](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/da363857-7fa4-46a4-be42-8b67f4ab409c) | ![changed-bookmarks](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/d898b483-d94a-4da4-a5a5-e01d6e7fc530)
Search           | ![main-search](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/cb525400-b184-424b-bccf-0c8c20cb344e) | ![changed-search](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/9065b622-94c4-45e1-b237-74b1b314e4a4)


## Screenshot (Dark)

Location | Before | After
:--: | :--: | :--:
Timetable (List) | ![main-dark-timetable-list](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/03fcdba4-d77d-47f6-8073-5650ae295998) | ![changed-dark-timetable-list](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/ec041572-c047-46fc-b1aa-7c35c936078f)
Timetable (Grid) | ![main-dark-timetable-grid-1](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/b3c9d0aa-244f-4929-9b7d-b103e478956d) | ![changed-dark-timetable-grid-1](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/a2ec7ce5-78f8-4caf-af3f-4f61ddd9c0ad)
Bookmarks        | ![main-dark-bookmarks](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/c9175c12-5946-4ced-9e25-63a1d880a78b) | ![changed-dark-bookmarks](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/bbb8af16-561a-4f1b-8348-0122504eb594)
Search           | ![main-dark-search](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/e1126c53-7d10-4a48-9f49-4a2f76073a27) | ![changed-dark-search](https://github.com/DroidKaigi/conference-app-2023/assets/47137677/440571be-b903-4c52-bd1b-02c4b22f34ab)
