### PR TITLE
:recycle: Make session text selectable.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Description
@@ -82,22 +83,24 @@ private fun DescriptionSection(
 ) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
-    Column(modifier = modifier.animateContentSize()) {
-        Text(
-            text = description,
-            fontSize = 16.sp,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = if (isExpanded) Int.MAX_VALUE else 5,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-        )
-        if (!isExpanded) {
-            ReadMoreOutlinedButton(
-                onClick = { isExpanded = true },
-                modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+    SelectionContainer {
+        Column(modifier = modifier.animateContentSize()) {
+            Text(
+                text = description,
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = if (isExpanded) Int.MAX_VALUE else 5,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp),
             )
+            if (!isExpanded) {
+                ReadMoreOutlinedButton(
+                    onClick = { isExpanded = true },
+                    modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+                )
+            }
+            BorderLine(modifier = Modifier.padding(top = 24.dp))
         }
-        BorderLine(modifier = Modifier.padding(top = 24.dp))
     }
 }
 


### PR DESCRIPTION
## Issue
- close #607 

## Overview (Required)
- Session detail text can now be selected using SelectionContainer.
- I would have liked to implement a Context Menu other than Copy, but at this point it seems to be impossible with the standard features.

## Links
- https://developer.android.com/jetpack/compose/text?hl=ja
- https://issuetracker.google.com/issues/218266808

## Movie

https://github.com/DroidKaigi/conference-app-2023/assets/13657682/e4381c85-a36e-41a5-97ef-efd56f1dfacd