### PR TITLE
Remove a redundant `suspend` modifier

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/NetworkService.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/NetworkService.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 public class NetworkService(public val httpClient: HttpClient, public val authApi: AuthApi) {
 
     public suspend inline operator fun <reified T : Any> invoke(
-        block: suspend () -> T,
+        block: () -> T,
     ): T = try {
         authApi.authIfNeeded()
         block()


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR removes a redundant `suspend` modifier and resolves the following build warning:

```
w: file:///***/conference-app-2023/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/NetworkService.kt:16:16 Redundant 'suspend' modifier: lambda parameters of suspend function type uses existing continuation.
```