### PR TITLE
[iOS] add required dependency to timetable module

### DIFF
--- a/app-ios/Modules/Package.swift
+++ b/app-ios/Modules/Package.swift
@@ -131,6 +131,7 @@ var package = Package(
             name: "Timetable",
             dependencies: [
                 "Assets",
+                "Component",
                 "shared",
                 "Model",
                 "Theme",


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Build for iOS fails in my environment (not sure if it happens only my local though 🤔).
- The build issue has been resolved by adding the dependency to Component from Timetable.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />