### PR TITLE
Fix stamp icon on bottom navigation bar

### DIFF
--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -13,11 +13,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Approval
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.outlined.Approval
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Info
@@ -112,8 +110,8 @@ enum class MainScreenTab(
         contentDescription = MainStrings.FloorMap.asString(),
     ),
     Badges(
-        icon = IconRepresentation.Vector(Icons.Outlined.Approval),
-        selectedIcon = IconRepresentation.Vector(Icons.Filled.Approval),
+        icon = IconRepresentation.Drawable(drawableId = R.drawable.icon_stamp_outline),
+        selectedIcon = IconRepresentation.Drawable(drawableId = R.drawable.icon_stamp_fill),
         label = MainStrings.Stamps.asString(),
         contentDescription = MainStrings.Stamps.asString(),
     ),

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -93,38 +93,38 @@ sealed class IconRepresentation {
 }
 
 enum class MainScreenTab(
-    val icon: ImageVector,
+    val icon: IconRepresentation,
     val selectedIcon: IconRepresentation,
     val label: String,
     val contentDescription: String,
     val testTag: String = "mainScreenTab:$label",
 ) {
     Timetable(
-        icon = Icons.Outlined.CalendarMonth,
+        icon = IconRepresentation.Vector(Icons.Outlined.CalendarMonth),
         selectedIcon = IconRepresentation.Vector(Icons.Filled.CalendarMonth),
         label = MainStrings.Timetable.asString(),
         contentDescription = MainStrings.Timetable.asString(),
     ),
     FloorMap(
-        icon = Icons.Outlined.Map,
+        icon = IconRepresentation.Vector(Icons.Outlined.Map),
         selectedIcon = IconRepresentation.Drawable(drawableId = R.drawable.icon_map_fill),
         label = MainStrings.FloorMap.asString(),
         contentDescription = MainStrings.FloorMap.asString(),
     ),
     Badges(
-        icon = Icons.Outlined.Approval,
+        icon = IconRepresentation.Vector(Icons.Outlined.Approval),
         selectedIcon = IconRepresentation.Vector(Icons.Filled.Approval),
         label = MainStrings.Stamps.asString(),
         contentDescription = MainStrings.Stamps.asString(),
     ),
     About(
-        icon = Icons.Outlined.Info,
+        icon = IconRepresentation.Vector(Icons.Outlined.Info),
         selectedIcon = IconRepresentation.Vector(Icons.Filled.Info),
         label = MainStrings.About.asString(),
         contentDescription = MainStrings.About.asString(),
     ),
     Contributor(
-        icon = Icons.Outlined.Group,
+        icon = IconRepresentation.Vector(Icons.Outlined.Group),
         selectedIcon = IconRepresentation.Vector(Icons.Filled.Group),
         label = MainStrings.Contributors.asString(),
         contentDescription = MainStrings.Contributors.asString(),

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiBottomBar.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiBottomBar.kt
@@ -46,10 +46,17 @@ fun KaigiBottomBar(
                             )
                         }
                     } else {
-                        Icon(
-                            imageVector = tab.icon,
-                            contentDescription = tab.contentDescription,
-                        )
+                        when (val icon = tab.icon) {
+                            is Drawable -> Icon(
+                                painterResource(id = icon.drawableId),
+                                contentDescription = tab.contentDescription,
+                            )
+
+                            is Vector -> Icon(
+                                imageVector = icon.imageVector,
+                                contentDescription = tab.contentDescription,
+                            )
+                        }
                     }
                 },
                 label = {

--- a/feature/main/src/main/res/drawable/icon_stamp_fill.xml
+++ b/feature/main/src/main/res/drawable/icon_stamp_fill.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,-1h24v24h-24z"/>
+    <path
+        android:pathData="M7.98,6.403C7.473,3.866 9.413,1.5 12,1.5C14.587,1.5 16.527,3.866 16.019,6.403L14,16.5L10,16.5L7.98,6.403Z"
+        android:fillColor="#092017"/>
+    <path
+        android:pathData="M3,16.5C3,15.395 3.895,14.5 5,14.5L19,14.5C20.105,14.5 21,15.395 21,16.5L21,20.5C21,21.052 20.552,21.5 20,21.5L4,21.5C3.448,21.5 3,21.052 3,20.5L3,16.5Z"
+        android:fillColor="#092017"/>
+  </group>
+</vector>

--- a/feature/main/src/main/res/drawable/icon_stamp_outline.xml
+++ b/feature/main/src/main/res/drawable/icon_stamp_outline.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M12,1.5C9.284,1.5 7.207,3.921 7.62,6.606L8.834,14.5H5C3.895,14.5 3,15.395 3,16.5V20.5C3,21.052 3.448,21.5 4,21.5H20C20.552,21.5 21,21.052 21,20.5V16.5C21,15.395 20.105,14.5 19,14.5H15.166L16.38,6.606C16.793,3.921 14.716,1.5 12,1.5ZM13.142,14.5L14.403,6.301C14.63,4.828 13.49,3.5 12,3.5C10.51,3.5 9.37,4.828 9.597,6.301L10.858,14.5H12H13.142ZM19,16.5V19.5H5V16.5H12H19Z"
+        android:fillColor="#404944"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Changed the Stamp icon on the bottom navigation bar to match Figma's design.
  - Changed IconRepresentation to be used for both icons and selectedIcon
  - Stamp: Wrong Icon -> Drawable Vector

## Links
- 

## Screenshot
Before | After
:--: | :--:
![スクリーンショット 2023-08-19 2 25 53](https://github.com/DroidKaigi/conference-app-2023/assets/7846521/f310006a-1814-46c6-a369-65b2ff7e0ef3)|![スクリーンショット 2023-08-19 2 38 38](https://github.com/DroidKaigi/conference-app-2023/assets/7846521/8a2b8939-ddaa-45d3-9a80-79fe239798a8)
![スクリーンショット 2023-08-19 2 26 00](https://github.com/DroidKaigi/conference-app-2023/assets/7846521/9509029b-193c-4b93-80aa-c1a9eea4402e)|![スクリーンショット 2023-08-19 2 24 42](https://github.com/DroidKaigi/conference-app-2023/assets/7846521/2ab1288e-4aba-4188-ac6b-db25f9f5ce59)



