### PR TITLE
[iOS] Improve the linting performance

### DIFF
--- a/app-ios/.swiftlint.yml
+++ b/app-ios/.swiftlint.yml
@@ -7,10 +7,11 @@ opt_in_rules:
   - file_header
   - sorted_imports
 
-excluded:
-  - .build
-  - Modules/.build
+included:
+  - App/DroidKaigi2023
   - Modules/Package.swift
+  - Modules/Sources
+  - Modules/Tests
 
 identifier_name:
   min_length: 2


### PR DESCRIPTION
## Issue
- close #587

## Overview (Required)
- Excluding files in the current SwiftLint has a performance issue.
  This PR lists included files instead of excluded files and tries to improve the linting performance.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/4232f008-239c-4d94-bbb2-9f49035b709d" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/7d0b920c-b2cf-455c-8b23-24d03d017e22" width="300" />