### PR TITLE
:recycle: ClickableLinkText was made common and used on each screen.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -106,6 +106,7 @@ private fun KaigiNavHost(
                     timetableItem.id,
                 )
             },
+            onLinkClick = externalNavController::navigate,
         )
         searchScreen(
             onNavigationIconClick = {

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
@@ -1,0 +1,109 @@
+package io.github.droidkaigi.confsched2023.designsystem.component
+
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+
+@Composable
+private fun findResults(
+    content: String,
+    regex: Regex,
+): Sequence<MatchResult> {
+    return remember(content) {
+        regex.findAll(content)
+    }
+}
+
+@Composable
+private fun getAnnotatedString(
+    content: String,
+    findUrlResults: Sequence<MatchResult>,
+): AnnotatedString {
+    return buildAnnotatedString {
+        pushStyle(
+            style = SpanStyle(
+                color = MaterialTheme.colorScheme.inverseSurface,
+            ),
+        )
+        append(content)
+        pop()
+
+        var lastIndex = 0
+        findUrlResults.forEach { matchResult ->
+            val startIndex = content.indexOf(
+                string = matchResult.value,
+                startIndex = lastIndex,
+            )
+            val endIndex = startIndex + matchResult.value.length
+            addStyle(
+                style = SpanStyle(
+                    color = MaterialTheme.colorScheme.primary,
+                    textDecoration = TextDecoration.Underline,
+                    fontWeight = FontWeight.Bold,
+                ),
+                start = startIndex,
+                end = endIndex,
+            )
+            addStringAnnotation(
+                tag = matchResult.value,
+                annotation = matchResult.value,
+                start = startIndex,
+                end = endIndex,
+            )
+
+            lastIndex = endIndex
+        }
+    }
+}
+
+/**
+ * Provides ClickableText with underline for the specified regex.
+ * When underlining a string other than a url, please specify the url as well.
+ *
+ * @param regex Specify a Regex to extract the string for which you want underlined text decoration
+ * @param url If the string to be extracted by regex is a string other than a URL, use this one.
+ */
+@Composable
+fun ClickableLinkText(
+    style: TextStyle,
+    content: String,
+    onLinkClick: (url: String) -> Unit,
+    regex: Regex,
+    url: String?,
+    modifier: Modifier = Modifier,
+) {
+    val findResults = findResults(
+        content = content,
+        regex = regex,
+    )
+
+    val annotatedString = getAnnotatedString(
+        content = content,
+        findUrlResults = findResults,
+    )
+
+    ClickableText(
+        modifier = modifier,
+        text = annotatedString,
+        style = style,
+        onClick = { offset ->
+            findResults.forEach { matchResult ->
+                annotatedString.getStringAnnotations(
+                    tag = matchResult.value,
+                    start = offset,
+                    end = offset,
+                ).firstOrNull()?.let {
+                    onLinkClick(url ?: matchResult.value)
+                }
+            }
+        },
+    )
+}

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 private fun findResults(
@@ -77,8 +78,10 @@ fun ClickableLinkText(
     content: String,
     onLinkClick: (url: String) -> Unit,
     regex: Regex,
-    url: String?,
     modifier: Modifier = Modifier,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+    url: String? = null,
 ) {
     val findResults = findResults(
         content = content,
@@ -94,6 +97,8 @@ fun ClickableLinkText(
         modifier = modifier,
         text = annotatedString,
         style = style,
+        overflow = overflow,
+        maxLines = maxLines,
         onClick = { offset ->
             findResults.forEach { matchResult ->
                 annotatedString.getStringAnnotations(

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -156,7 +156,7 @@ public fun Session.Companion.fake(): Session {
                 tagLine = "iOS Engineer",
             ),
         ).toPersistentList(),
-        description = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。",
+        description = "これはディスクリプションです。\nこれはディスクリプションです。\nhttps://github.com/DroidKaigi/conference-app-2023 これはURLです。\nこれはディスクリプションです。",
         message = MultiLangText(
             jaTitle = "このセッションは事情により中止となりました",
             enTitle = "This session has been cancelled due to circumstances.",

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -38,6 +38,7 @@ class TimetableItemDetailScreenRobot @Inject constructor(
             KaigiTheme {
                 TimetableItemDetailScreen(
                     onNavigationIconClick = { },
+                    onLinkClick = { },
                 )
             }
         }

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutDroidKaigiDetailSummaryCardRow.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
@@ -12,18 +11,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.about.AboutStrings
+import io.github.droidkaigi.confsched2023.designsystem.component.ClickableLinkText
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
@@ -57,96 +51,10 @@ fun AboutDroidKaigiDetailSummaryCardRow(
             style = MaterialTheme.typography.bodyMedium,
             content = content,
             onLinkClick = onLinkClick,
+            regex = AboutStrings.PlaceLink().asString().toRegex(),
+            url = AboutStrings.PlaceLink().url,
         )
     }
-}
-
-// TODO The following components can be commonized and made available on the session screen.
-@Composable
-private fun findResults(
-    content: String,
-    regex: Regex,
-): Sequence<MatchResult> {
-    return remember(content) {
-        regex.findAll(content)
-    }
-}
-
-@Composable
-private fun getAnnotatedString(
-    content: String,
-    findUrlResults: Sequence<MatchResult>,
-): AnnotatedString {
-    return buildAnnotatedString {
-        pushStyle(
-            style = SpanStyle(
-                color = MaterialTheme.colorScheme.inverseSurface,
-            ),
-        )
-        append(content)
-        pop()
-
-        var lastIndex = 0
-        findUrlResults.forEach { matchResult ->
-            val startIndex = content.indexOf(
-                string = matchResult.value,
-                startIndex = lastIndex,
-            )
-            val endIndex = startIndex + matchResult.value.length
-            addStyle(
-                style = SpanStyle(
-                    color = MaterialTheme.colorScheme.primary,
-                    textDecoration = TextDecoration.Underline,
-                    fontWeight = FontWeight.Bold,
-                ),
-                start = startIndex,
-                end = endIndex,
-            )
-            addStringAnnotation(
-                tag = matchResult.value,
-                annotation = matchResult.value,
-                start = startIndex,
-                end = endIndex,
-            )
-
-            lastIndex = endIndex
-        }
-    }
-}
-
-@Composable
-private fun ClickableLinkText(
-    style: TextStyle,
-    content: String,
-    onLinkClick: (url: String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val findResults = findResults(
-        content = content,
-        regex = AboutStrings.PlaceLink().asString().toRegex(),
-    )
-    val googleMapUrl = AboutStrings.PlaceLink().url
-    val annotatedString = getAnnotatedString(
-        content = content,
-        findUrlResults = findResults,
-    )
-
-    ClickableText(
-        modifier = modifier,
-        text = annotatedString,
-        style = style,
-        onClick = { offset ->
-            findResults.forEach { matchResult ->
-                annotatedString.getStringAnnotations(
-                    tag = matchResult.value,
-                    start = offset,
-                    end = offset,
-                ).firstOrNull()?.let {
-                    onLinkClick(googleMapUrl)
-                }
-            }
-        },
-    )
 }
 
 @MultiThemePreviews

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapStrings.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapStrings.kt
@@ -7,21 +7,23 @@ import io.github.droidkaigi.confsched2023.designsystem.strings.StringsBindings
 sealed class FloorMapStrings : Strings<FloorMapStrings>(Bindings) {
     data object Title : FloorMapStrings()
     data object FavoriteIcon : FloorMapStrings()
-    data object EventDetail : FloorMapStrings()
+    class EventDetail(
+        val url: String,
+    ) : FloorMapStrings()
 
     private object Bindings : StringsBindings<FloorMapStrings>(
         Lang.Japanese to { item, _ ->
             when (item) {
                 Title -> "Floor Map"
                 FavoriteIcon -> "お気に入りアイコン"
-                EventDetail -> "イベント詳細"
+                is EventDetail -> "イベント詳細"
             }
         },
         Lang.English to { item, bindings ->
             when (item) {
                 Title -> bindings.defaultBinding(item, bindings)
                 FavoriteIcon -> "Favorite icon"
-                EventDetail -> "Event detail"
+                is EventDetail -> "Event detail"
             }
         },
         default = Lang.Japanese,

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapStrings.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapStrings.kt
@@ -7,23 +7,21 @@ import io.github.droidkaigi.confsched2023.designsystem.strings.StringsBindings
 sealed class FloorMapStrings : Strings<FloorMapStrings>(Bindings) {
     data object Title : FloorMapStrings()
     data object FavoriteIcon : FloorMapStrings()
-    class EventDetail(
-        val url: String,
-    ) : FloorMapStrings()
+    data object EventDetail : FloorMapStrings()
 
     private object Bindings : StringsBindings<FloorMapStrings>(
         Lang.Japanese to { item, _ ->
             when (item) {
                 Title -> "Floor Map"
                 FavoriteIcon -> "お気に入りアイコン"
-                is EventDetail -> "イベント詳細"
+                EventDetail -> "イベント詳細"
             }
         },
         Lang.English to { item, bindings ->
             when (item) {
                 Title -> bindings.defaultBinding(item, bindings)
                 FavoriteIcon -> "Favorite icon"
-                is EventDetail -> "Event detail"
+                EventDetail -> "Event detail"
             }
         },
         default = Lang.Japanese,

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -101,7 +101,6 @@ fun FloorMapSideEventItem(
                     )
                 }
                 sideEvent.link?.let { link ->
-                    val content = EventDetail(link)
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
@@ -112,10 +111,10 @@ fun FloorMapSideEventItem(
                         Spacer(modifier = Modifier.width(8.dp))
                         ClickableLinkText(
                             style = MaterialTheme.typography.bodySmall,
-                            content = content.asString(),
+                            content = EventDetail.asString(),
                             onLinkClick = onSideEventClick,
-                            regex = content.asString().toRegex(),
-                            url = content.url,
+                            regex = EventDetail.asString().toRegex(),
+                            url = link,
                         )
                     }
                 }

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -119,7 +119,7 @@ fun FloorMapSideEventItem(
                     }
                 }
             }
-            sideEvent.imageLink?.let {
+            sideEvent.imageLink?.let { url ->
                 Image(
                     modifier = Modifier
                         .size(80.dp)
@@ -131,7 +131,7 @@ fun FloorMapSideEventItem(
                         ),
                     painter = previewOverride(
                         previewPainter = { rememberVectorPainter(image = Icons.Default.Person) },
-                        painter = { rememberAsyncImagePainter(sideEvent.imageLink!!) },
+                        painter = { rememberAsyncImagePainter(url) },
                     ),
                     contentScale = ContentScale.Crop,
                     contentDescription = "Side events image",

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -31,18 +31,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.designsystem.component.ClickableLinkText
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2023.floormap.FloorMapStrings
+import io.github.droidkaigi.confsched2023.floormap.FloorMapStrings.EventDetail
 import io.github.droidkaigi.confsched2023.floormap.FloorMapStrings.FavoriteIcon
 import io.github.droidkaigi.confsched2023.model.SideEvent
 import io.github.droidkaigi.confsched2023.model.SideEvent.Mark
@@ -105,7 +100,8 @@ fun FloorMapSideEventItem(
                         style = MaterialTheme.typography.bodySmall,
                     )
                 }
-                if (sideEvent.link != null) {
+                sideEvent.link?.let { link ->
+                    val content = EventDetail(link)
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
@@ -114,17 +110,17 @@ fun FloorMapSideEventItem(
                             modifier = Modifier.size(16.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = createAnnotatedEventDetailString(),
+                        ClickableLinkText(
                             style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.clickable {
-                                // todo open link
-                            },
+                            content = content.asString(),
+                            onLinkClick = onSideEventClick,
+                            regex = content.asString().toRegex(),
+                            url = content.url,
                         )
                     }
                 }
             }
-            if (sideEvent.imageLink != null) {
+            sideEvent.imageLink?.let {
                 Image(
                     modifier = Modifier
                         .size(80.dp)
@@ -157,25 +153,6 @@ private fun Mark.iconResAndColor(): Pair<ImageVector, Color> {
         Pink -> 0xFFDC369A
     }
     return icon to Color(colorLong)
-}
-
-@Composable
-private fun createAnnotatedEventDetailString(): AnnotatedString {
-    return buildAnnotatedString {
-        pushStringAnnotation(
-            tag = "URL",
-            annotation = FloorMapStrings.EventDetail.asString(),
-        )
-        withStyle(
-            SpanStyle(
-                color = MaterialTheme.colorScheme.primary,
-                textDecoration = TextDecoration.Underline,
-                fontWeight = FontWeight.Bold,
-            ),
-        ) {
-            append(FloorMapStrings.EventDetail.asString())
-        }
-    }
 }
 
 @MultiThemePreviews

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -37,8 +37,7 @@ import io.github.droidkaigi.confsched2023.designsystem.component.ClickableLinkTe
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2023.floormap.FloorMapStrings.EventDetail
-import io.github.droidkaigi.confsched2023.floormap.FloorMapStrings.FavoriteIcon
+import io.github.droidkaigi.confsched2023.floormap.FloorMapStrings
 import io.github.droidkaigi.confsched2023.model.SideEvent
 import io.github.droidkaigi.confsched2023.model.SideEvent.Mark
 import io.github.droidkaigi.confsched2023.model.SideEvent.Mark.Favorite
@@ -70,7 +69,7 @@ fun FloorMapSideEventItem(
                     val (iconVector, iconColor) = sideEvent.mark.iconResAndColor()
                     Icon(
                         imageVector = iconVector,
-                        contentDescription = FavoriteIcon.asString(),
+                        contentDescription = FloorMapStrings.FavoriteIcon.asString(),
                         tint = iconColor,
                         modifier = Modifier.size(16.dp),
                     )
@@ -91,7 +90,7 @@ fun FloorMapSideEventItem(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = Icons.Filled.Schedule,
-                        contentDescription = FavoriteIcon.asString(),
+                        contentDescription = FloorMapStrings.FavoriteIcon.asString(),
                         modifier = Modifier.size(16.dp),
                     )
                     Spacer(modifier = Modifier.width(8.dp))
@@ -105,15 +104,15 @@ fun FloorMapSideEventItem(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             imageVector = Icons.Filled.Link,
-                            contentDescription = FavoriteIcon.asString(),
+                            contentDescription = FloorMapStrings.FavoriteIcon.asString(),
                             modifier = Modifier.size(16.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         ClickableLinkText(
                             style = MaterialTheme.typography.bodySmall,
-                            content = EventDetail.asString(),
+                            content = FloorMapStrings.EventDetail.asString(),
                             onLinkClick = onSideEventClick,
-                            regex = EventDetail.asString().toRegex(),
+                            regex = FloorMapStrings.EventDetail.asString().toRegex(),
                             url = link,
                         )
                     }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -48,10 +48,12 @@ const val timetableItemDetailScreenRoute =
 fun NavGraphBuilder.sessionScreens(
     onNavigationIconClick: () -> Unit,
     onTimetableItemClick: (TimetableItem) -> Unit,
+    onLinkClick: (url: String) -> Unit,
 ) {
     composable(timetableItemDetailScreenRoute) {
         TimetableItemDetailScreen(
             onNavigationIconClick = onNavigationIconClick,
+            onLinkClick = onLinkClick,
         )
     }
     composable(bookmarkScreenRoute) {
@@ -76,6 +78,7 @@ fun NavController.navigateToTimetableItemDetailScreen(
 @Composable
 fun TimetableItemDetailScreen(
     onNavigationIconClick: () -> Unit,
+    onLinkClick: (url: String) -> Unit,
     viewModel: TimetableItemDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -90,6 +93,7 @@ fun TimetableItemDetailScreen(
         uiState = uiState,
         onNavigationIconClick = onNavigationIconClick,
         onBookmarkClick = viewModel::onBookmarkClick,
+        onLinkClick = onLinkClick,
         snackbarHostState = snackbarHostState,
     )
 }
@@ -108,6 +112,7 @@ private fun TimetableItemDetailScreen(
     uiState: TimetableItemDetailScreenUiState,
     onNavigationIconClick: () -> Unit,
     onBookmarkClick: (TimetableItem) -> Unit,
+    onLinkClick: (url: String) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -157,7 +162,10 @@ private fun TimetableItemDetailScreen(
                             )
                         }
                         item {
-                            TimetableItemDetailContent(uiState = it.timetableItem)
+                            TimetableItemDetailContent(
+                                uiState = it.timetableItem,
+                                onLinkClick = onLinkClick,
+                            )
                         }
                     }
                 }
@@ -183,6 +191,7 @@ fun TimetableItemDetailScreenPreview() {
                 onBookmarkClick = {
                     isBookMarked = !isBookMarked
                 },
+                onLinkClick = {},
                 snackbarHostState = SnackbarHostState(),
             )
         }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -40,13 +40,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.droidkaigi.confsched2023.designsystem.component.ClickableLinkText
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
+import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.designsystem.theme.md_theme_light_outline
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Special
 import io.github.droidkaigi.confsched2023.model.TimetableSpeaker
+import io.github.droidkaigi.confsched2023.model.fake
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
 import io.github.droidkaigi.confsched2023.ui.previewOverride
 import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
@@ -56,11 +59,15 @@ import kotlinx.collections.immutable.PersistentList
 fun TimetableItemDetailContent(
     uiState: TimetableItem,
     modifier: Modifier = Modifier,
+    onLinkClick: (url: String) -> Unit
 ) {
     Column(modifier = modifier) {
         when (uiState) {
             is Session -> {
-                DescriptionSection(description = uiState.description)
+                DescriptionSection(
+                    description = uiState.description,
+                    onLinkClick = onLinkClick,
+                )
                 TargetAudienceSection(targetAudienceString = uiState.targetAudience)
                 SpeakerSection(speakers = uiState.speakers)
                 ArchiveSection(
@@ -80,17 +87,20 @@ fun TimetableItemDetailContent(
 private fun DescriptionSection(
     description: String,
     modifier: Modifier = Modifier,
+    onLinkClick: (url: String) -> Unit,
 ) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     SelectionContainer {
         Column(modifier = modifier.animateContentSize()) {
-            Text(
-                text = description,
-                fontSize = 16.sp,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = if (isExpanded) Int.MAX_VALUE else 5,
+            ClickableLinkText(
+                style = MaterialTheme.typography.bodyLarge
+                    .copy(color = MaterialTheme.colorScheme.onSurface),
+                content = description,
+                onLinkClick = onLinkClick,
+                regex = "(https)(://[\\w/:%#$&?()~.=+\\-]+)".toRegex(),
                 overflow = TextOverflow.Ellipsis,
+                maxLines = if (isExpanded) Int.MAX_VALUE else 5,
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp),
             )
             if (!isExpanded) {
@@ -310,5 +320,18 @@ private fun ReadMoreOutlinedButton(
 fun ReadMoreOutlinedButtonPreview() {
     KaigiTheme {
         ReadMoreOutlinedButton(onClick = {})
+    }
+}
+
+@MultiThemePreviews
+@Composable
+fun DescriptionSectionPreview() {
+    KaigiTheme {
+        Surface {
+            DescriptionSection(
+                description = Session.fake().description,
+                onLinkClick = {},
+            )
+        }
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -59,7 +59,7 @@ import kotlinx.collections.immutable.PersistentList
 fun TimetableItemDetailContent(
     uiState: TimetableItem,
     modifier: Modifier = Modifier,
-    onLinkClick: (url: String) -> Unit
+    onLinkClick: (url: String) -> Unit,
 ) {
     Column(modifier = modifier) {
         when (uiState) {


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Commonized ClickableLinkText.
- The commonized parts were used in the following screens
1. Session Details Screen
2. Floor Map Screen
3. About Screen

## Movie

![after](https://github.com/DroidKaigi/conference-app-2023/assets/13657682/c04813a8-cb56-4967-be6a-e49e5bf47bb6)
