### PR TITLE
Improve contributing

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -6,7 +6,7 @@
 
 ### タスクの見つけ方
 
-タスク管理にGitHub Issueを使っています。こちらでコントリビュートしたいIssueをお探しください。[`welcome contribute` と `easy`のラベルがついているIssue](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy)は、初めてのコントリビュートにおすすめです。
+タスク管理にGitHub Issueを使っています。こちらでコントリビュートしたいIssueをお探しください。[`welcome contribute` と `easy`のラベルがついているIssue](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee)は、初めてのコントリビュートにおすすめです。
 
 IssueがないPull Requestでも大丈夫です。その場合はPull Requestに理由、原因、解決策などの詳細をご記入ください。
 

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -6,7 +6,7 @@
 
 ### タスクの見つけ方
 
-タスク管理にGitHub Issueを使っています。こちらでコントリビュートしたいIssueをお探しください。[`welcome contribute` と `easy`のラベルがついているIssue](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee)は、初めてのコントリビュートにおすすめです。
+タスク管理にGitHub Issueを使っています。こちらでコントリビュートしたいIssueをお探しください。[`welcome contribute` または `easy`のラベルがついているIssue](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee)は、初めてのコントリビュートにおすすめです。
 
 IssueがないPull Requestでも大丈夫です。その場合はPull Requestに理由、原因、解決策などの詳細をご記入ください。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome your contribution!
 
 ### Finding tasks
 
-We use GitHub issues to manage the tasks. Please check here for issues you would like to contribute to. [`welcome contribute` and `easy` are good labels](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy) to check for the first contribution.
+We use GitHub issues to manage the tasks. Please check here for issues you would like to contribute to. [`welcome contribute` and `easy` are good labels](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee) to check for the first contribution.
 
 Of course, we also accept Pull Requests which don't have an issue. However, in this case please make sure you explain the motivation, cause, solution, etc in the PR description.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome your contribution!
 
 ### Finding tasks
 
-We use GitHub issues to manage the tasks. Please check here for issues you would like to contribute to. [`welcome contribute` and `easy` are good labels](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee) to check for the first contribution.
+We use GitHub issues to manage the tasks. Please check here for issues you would like to contribute to. [`welcome contribute` or `easy` are good labels](https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee) to check for the first contribution.
 
 Of course, we also accept Pull Requests which don't have an issue. However, in this case please make sure you explain the motivation, cause, solution, etc in the PR description.
 


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- When we click on links to issues labeled as `welcome contribute` or `easy`, we want to find issues that haven't been assigned to anyone. Therefore, our query will include `no:assignee`.
- Note that we're searching for `welcome contribute` _OR_ `easy`, not both.

## Links
- none
 
## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5770480/c9b573a8-6bba-4756-86df-686372454780" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5770480/f2c27a8f-96a6-4694-bb40-de75cfc887e1" width="300" />
https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy | https://github.com/DroidKaigi/conference-app-2023/issues?q=is%3Aopen+is%3Aissue+label%3A%22welcome+contribute%22%2Ceasy+no%3Aassignee
