### PR TITLE
Add side event information of Ground floor

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2023.model
 
 import io.github.droidkaigi.confsched2023.model.FloorLevel.Basement
+import io.github.droidkaigi.confsched2023.model.FloorLevel.Ground
 import io.github.droidkaigi.confsched2023.model.SideEvent.Mark.Favorite
 import io.github.droidkaigi.confsched2023.model.SideEvent.MarkColor.Pink
 import kotlinx.collections.immutable.persistentListOf
@@ -69,6 +70,60 @@ val SideEvents = persistentListOf(
             enTitle = "App Fireside chat(This is demo event and will be deleted later)",
         ),
         floorLevel = Basement,
+        description = MultiLangText(
+            jaTitle = "地下一階でDroidKaigiアプリの開発について、開発者と一緒に語りましょう！(これは仮で後で消えます)",
+            enTitle = "(Basement)Let's talk about the development of the DroidKaigi app with the developers!(This is demo event and will be deleted later)",
+        ),
+        timeText = MultiLangText(
+            jaTitle = "DAY1-DAY2 10:00-11:00",
+            enTitle = "DAY1-DAY2 10:00-11:00",
+        ),
+        mark = Favorite,
+        link = "https://github.com/DroidKaigi/conference-app-2023",
+        imageLink = "https://2023.droidkaigi.jp/static/12059b53c8c9813a85c1c44f8692a2c0/img_04.jpg",
+    ),
+    SideEvent(
+        title = MultiLangText(
+            jaTitle = "アプリFiresideチャット(これは仮で後で消えます)",
+            enTitle = "App Fireside chat(This is demo event and will be deleted later)",
+        ),
+        floorLevel = Ground,
+        description = MultiLangText(
+            jaTitle = "地下一階でDroidKaigiアプリの開発について、開発者と一緒に語りましょう！(これは仮で後で消えます)",
+            enTitle = "(Basement)Let's talk about the development of the DroidKaigi app with the developers!(This is demo event and will be deleted later)",
+        ),
+        timeText = MultiLangText(
+            jaTitle = "DAY1-DAY2 10:00-11:00",
+            enTitle = "DAY1-DAY2 10:00-11:00",
+        ),
+        mark = Favorite,
+        link = "https://github.com/DroidKaigi/conference-app-2023",
+        imageLink = "https://2023.droidkaigi.jp/static/12059b53c8c9813a85c1c44f8692a2c0/img_04.jpg",
+    ),
+    SideEvent(
+        title = MultiLangText(
+            jaTitle = "アプリFiresideチャット(これは仮で後で消えます)",
+            enTitle = "App Fireside chat(This is demo event and will be deleted later)",
+        ),
+        floorLevel = Ground,
+        description = MultiLangText(
+            jaTitle = "地下一階でDroidKaigiアプリの開発について、開発者と一緒に語りましょう！(これは仮で後で消えます)",
+            enTitle = "(Basement)Let's talk about the development of the DroidKaigi app with the developers!(This is demo event and will be deleted later)",
+        ),
+        timeText = MultiLangText(
+            jaTitle = "DAY1-DAY2 10:00-11:00",
+            enTitle = "DAY1-DAY2 10:00-11:00",
+        ),
+        mark = Favorite,
+        link = null,
+        imageLink = null,
+    ),
+    SideEvent(
+        title = MultiLangText(
+            jaTitle = "アプリFiresideチャット(これは仮で後で消えます)",
+            enTitle = "App Fireside chat(This is demo event and will be deleted later)",
+        ),
+        floorLevel = Ground,
         description = MultiLangText(
             jaTitle = "地下一階でDroidKaigiアプリの開発について、開発者と一緒に語りましょう！(これは仮で後で消えます)",
             enTitle = "(Basement)Let's talk about the development of the DroidKaigi app with the developers!(This is demo event and will be deleted later)",


### PR DESCRIPTION
## Issue
- close #644 

## Overview (Required)
- Fixed the display of event information on the Ground Floor. The data shown is provisional.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/48178913/7a346ae6-c83f-4952-b192-5f2c8bf60e75" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/48178913/ee78b05f-744b-42fe-ad58-bd5e38c4a0d5" width="300" />