### PR TITLE
Rename StampsList

### DIFF
--- a/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsScreen.kt
+++ b/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsScreen.kt
@@ -18,7 +18,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import io.github.droidkaigi.confsched2023.model.Stamp
-import io.github.droidkaigi.confsched2023.stamps.section.StampsList
+import io.github.droidkaigi.confsched2023.stamps.section.StampList
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.ImmutableList
 
@@ -77,7 +77,7 @@ private fun StampsScreen(
         content = { padding ->
             val layoutDirection = LocalLayoutDirection.current
 
-            StampsList(
+            StampList(
                 stamps = uiState.stamps,
                 onStampsClick = onStampsClick,
                 modifier = Modifier.padding(

--- a/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/section/StampList.kt
+++ b/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/section/StampList.kt
@@ -19,7 +19,7 @@ private const val SingleItemSpanCount = 2
 private const val DoubleItemSpanCount = 2 / 2
 
 @Composable
-fun StampsList(
+fun StampList(
     stamps: ImmutableList<Stamp>,
     onStampsClick: () -> Unit,
     modifier: Modifier = Modifier,


### PR DESCRIPTION
## Issue
- close #726

## Overview (Required)
- Given that the name 'StampsList' seems to imply a list returning multiple data sets, I've changed it to 'StampList'.
