### PR TITLE
Change build timeout time to 60 min

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
 
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue
- close #722 

## Overview (Required)
- Change build timeout time to 60 min

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />