### PR TITLE
moved StaffList to section package

### DIFF
--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/LoadingText.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/LoadingText.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched2023.sessions.component
+package io.github.droidkaigi.confsched2023.designsystem.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,8 +14,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 @Composable
-internal fun TimetableLoadingContent(
+fun LoadingText(
     modifier: Modifier = Modifier,
+    text: String = "Loading...",
 ) {
     Column(
         modifier = modifier,
@@ -29,7 +30,7 @@ internal fun TimetableLoadingContent(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = "Loading...",
+            text = text,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.bodyMedium,
             overflow = TextOverflow.Ellipsis,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -23,6 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import io.github.droidkaigi.confsched2023.designsystem.component.LoadingText
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
@@ -33,7 +34,6 @@ import io.github.droidkaigi.confsched2023.model.fake
 import io.github.droidkaigi.confsched2023.sessions.TimetableItemDetailScreenUiState.Loaded
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailBottomAppBar
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailScreenTopAppBar
-import io.github.droidkaigi.confsched2023.sessions.component.TimetableLoadingContent
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableItemDetail
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableItemDetailSectionUiState
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
@@ -143,7 +143,7 @@ private fun TimetableItemDetailScreen(
         ) {
             when (it) {
                 TimetableItemDetailScreenUiState.Loading -> {
-                    TimetableLoadingContent(
+                    LoadingText(
                         modifier = Modifier.fillMaxSize(),
                     )
                 }

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
@@ -9,11 +9,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -22,6 +25,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheet
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState
+import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 
 const val staffScreenRoute = "staff"
 
@@ -42,9 +46,16 @@ fun StaffScreen(
     viewModel: StaffScreenViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    SnackbarMessageEffect(
+        snackbarHostState = snackbarHostState,
+        userMessageStateHolder = viewModel.userMessageStateHolder,
+    )
 
     StaffScreen(
         uiState = uiState,
+        snackbarHostState = snackbarHostState,
         onStaffClick = onStaffClick,
         onBackClick = onBackClick,
     )
@@ -58,6 +69,7 @@ internal data class StaffScreenUiState(
 @Composable
 private fun StaffScreen(
     uiState: StaffScreenUiState,
+    snackbarHostState: SnackbarHostState,
     onStaffClick: (url: String) -> Unit,
     onBackClick: () -> Unit,
 ) {
@@ -77,6 +89,7 @@ private fun StaffScreen(
                 scrollBehavior = scrollBehavior,
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         StaffSheet(
             uiState = uiState.contentUiState,

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
@@ -1,10 +1,7 @@
 package io.github.droidkaigi.confsched2023.staff
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -23,8 +20,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import io.github.droidkaigi.confsched2023.model.Staff
-import kotlinx.collections.immutable.ImmutableList
+import io.github.droidkaigi.confsched2023.staff.section.StaffSheet
+import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState
 
 const val staffScreenRoute = "staff"
 
@@ -53,8 +50,8 @@ fun StaffScreen(
     )
 }
 
-data class StaffScreenUiState(
-    val staffs: ImmutableList<Staff>,
+internal data class StaffScreenUiState(
+    val contentUiState: StaffSheetUiState,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -81,32 +78,13 @@ private fun StaffScreen(
             )
         },
     ) { padding ->
-        StaffList(
-            staffs = uiState.staffs,
+        StaffSheet(
+            uiState = uiState.contentUiState,
             onStaffClick = onStaffClick,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
         )
-    }
-}
-
-@Composable
-private fun StaffList(
-    staffs: ImmutableList<Staff>,
-    onStaffClick: (url: String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(
-        modifier = modifier,
-    ) {
-        items(staffs) { staff ->
-            StaffListItem(
-                staff = staff,
-                onStaffClick = onStaffClick,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
     }
 }

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -61,6 +62,7 @@ fun StaffScreen(
     )
 }
 
+@Stable
 internal data class StaffScreenUiState(
     val contentUiState: StaffSheetUiState,
 )

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
@@ -2,9 +2,12 @@ package io.github.droidkaigi.confsched2023.staff
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2023.designsystem.strings.AppStrings
 import io.github.droidkaigi.confsched2023.model.StaffRepository
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState
+import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched2023.ui.buildUiState
+import io.github.droidkaigi.confsched2023.ui.handleErrorAndRetry
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,9 +17,14 @@ import javax.inject.Inject
 @HiltViewModel
 class StaffScreenViewModel @Inject constructor(
     staffRepository: StaffRepository,
-) : ViewModel() {
+    val userMessageStateHolder: UserMessageStateHolder,
+) : ViewModel(), UserMessageStateHolder by userMessageStateHolder {
 
     private val staffsStateFlow = staffRepository.staffs()
+        .handleErrorAndRetry(
+            AppStrings.Retry,
+            userMessageStateHolder,
+        )
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
@@ -32,8 +32,8 @@ class StaffScreenViewModel @Inject constructor(
         )
 
     internal val uiState: StateFlow<StaffScreenUiState> = buildUiState(staffsStateFlow) { staffs ->
-        when {
-            staffs == null -> StaffSheetUiState.Loading
+        when (staffs) {
+            null -> StaffSheetUiState.Loading
             else -> StaffSheetUiState.StaffList(
                 staffs = staffs,
             )

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
@@ -3,9 +3,9 @@ package io.github.droidkaigi.confsched2023.staff
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.droidkaigi.confsched2023.model.StaffRepository
+import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState
 import io.github.droidkaigi.confsched2023.ui.buildUiState
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -20,12 +20,24 @@ class StaffScreenViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = persistentListOf(),
+            initialValue = null,
         )
 
-    val uiState: StateFlow<StaffScreenUiState> = buildUiState(staffsStateFlow) { staffs ->
-        StaffScreenUiState(
-            staffs = staffs,
-        )
+    internal val uiState: StateFlow<StaffScreenUiState> = buildUiState(staffsStateFlow) { staffs ->
+        when {
+            staffs == null -> {
+                StaffSheetUiState.Loading
+            }
+
+            staffs.isEmpty() -> {
+                StaffSheetUiState.Empty
+            }
+
+            else -> {
+                StaffSheetUiState.StaffList(
+                    staffs = staffs,
+                )
+            }
+        }.run { StaffScreenUiState(this) }
     }
 }

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
@@ -34,7 +34,6 @@ class StaffScreenViewModel @Inject constructor(
     internal val uiState: StateFlow<StaffScreenUiState> = buildUiState(staffsStateFlow) { staffs ->
         when {
             staffs == null -> StaffSheetUiState.Loading
-            staffs.isEmpty() -> StaffSheetUiState.Empty
             else -> StaffSheetUiState.StaffList(
                 staffs = staffs,
             )

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreenViewModel.kt
@@ -25,19 +25,11 @@ class StaffScreenViewModel @Inject constructor(
 
     internal val uiState: StateFlow<StaffScreenUiState> = buildUiState(staffsStateFlow) { staffs ->
         when {
-            staffs == null -> {
-                StaffSheetUiState.Loading
-            }
-
-            staffs.isEmpty() -> {
-                StaffSheetUiState.Empty
-            }
-
-            else -> {
-                StaffSheetUiState.StaffList(
-                    staffs = staffs,
-                )
-            }
+            staffs == null -> StaffSheetUiState.Loading
+            staffs.isEmpty() -> StaffSheetUiState.Empty
+            else -> StaffSheetUiState.StaffList(
+                staffs = staffs,
+            )
         }.run { StaffScreenUiState(this) }
     }
 }

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/component/StaffListItem.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/component/StaffListItem.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched2023.staff
+package io.github.droidkaigi.confsched2023.staff.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/component/StaffListItem.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/component/StaffListItem.kt
@@ -30,7 +30,7 @@ import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
 private val staffIconShape = RoundedCornerShape(20.dp)
 
 @Composable
-fun StaffListItem(
+internal fun StaffListItem(
     staff: Staff,
     onStaffClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffList.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffList.kt
@@ -1,0 +1,29 @@
+package io.github.droidkaigi.confsched2023.staff.section
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.droidkaigi.confsched2023.model.Staff
+import io.github.droidkaigi.confsched2023.staff.StaffListItem
+import kotlinx.collections.immutable.ImmutableList
+
+@Composable
+internal fun StaffList(
+    staffs: ImmutableList<Staff>,
+    onStaffClick: (url: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+    ) {
+        items(staffs) { staff ->
+            StaffListItem(
+                staff = staff,
+                onStaffClick = onStaffClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffList.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffList.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import io.github.droidkaigi.confsched2023.model.Staff
-import io.github.droidkaigi.confsched2023.staff.StaffListItem
+import io.github.droidkaigi.confsched2023.staff.component.StaffListItem
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -19,13 +19,13 @@ import io.github.droidkaigi.confsched2023.model.Staff
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Empty
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Loading
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.StaffList
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 
 internal sealed interface StaffSheetUiState {
     data object Loading : StaffSheetUiState
     data object Empty : StaffSheetUiState
     data class StaffList(
-        val staffs: ImmutableList<Staff>,
+        val staffs: PersistentList<Staff>,
     ) : StaffSheetUiState
 }
 

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -38,13 +38,7 @@ internal fun StaffSheet(
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
             Loading -> LoadingContent(modifier = Modifier.fillMaxSize())
-            Empty -> {
-                Text(
-                    text = "empty",
-                    modifier = Modifier.testTag("empty"),
-                )
-            }
-
+            Empty -> EmptyView()
             is StaffList -> StaffList(
                 staffs = uiState.staffs,
                 onStaffClick = onStaffClick,
@@ -53,6 +47,14 @@ internal fun StaffSheet(
     }
 }
 
+// FIXME: This is a temporary view.
+@Composable
+private fun EmptyView() {
+    Text(
+        text = "empty",
+        modifier = Modifier.testTag("empty"),
+    )
+}
 
 // FIXME: It might be a good idea to move this Composable function to a common module somewhere. The same applies to TimetableLoadingContent as well.
 @Composable

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -1,19 +1,10 @@
 package io.github.droidkaigi.confsched2023.staff.section
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.designsystem.component.LoadingText
 import io.github.droidkaigi.confsched2023.model.Staff
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Loading
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.StaffList
@@ -34,36 +25,11 @@ internal fun StaffSheet(
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
-            Loading -> LoadingContent(modifier = Modifier.fillMaxSize())
+            Loading -> LoadingText(modifier = Modifier.fillMaxSize())
             is StaffList -> StaffList(
                 staffs = uiState.staffs,
                 onStaffClick = onStaffClick,
             )
         }
-    }
-}
-
-// FIXME: It might be a good idea to move this Composable function to a common module somewhere. The same applies to TimetableLoadingContent as well.
-@Composable
-private fun LoadingContent(
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(
-            space = 16.dp,
-            alignment = Alignment.CenterVertically,
-        ),
-    ) {
-        CircularProgressIndicator()
-
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            text = "Loading...",
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyMedium,
-            overflow = TextOverflow.Ellipsis,
-        )
     }
 }

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2023.staff.section
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import io.github.droidkaigi.confsched2023.designsystem.component.LoadingText
 import io.github.droidkaigi.confsched2023.model.Staff
@@ -10,6 +11,7 @@ import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Loadin
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.StaffList
 import kotlinx.collections.immutable.ImmutableList
 
+@Stable
 internal sealed interface StaffSheetUiState {
     data object Loading : StaffSheetUiState
     data class StaffList(

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -67,4 +67,3 @@ private fun LoadingContent(
         )
     }
 }
-

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -17,12 +17,12 @@ import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.model.Staff
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Loading
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.StaffList
-import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.ImmutableList
 
 internal sealed interface StaffSheetUiState {
     data object Loading : StaffSheetUiState
     data class StaffList(
-        val staffs: PersistentList<Staff>,
+        val staffs: ImmutableList<Staff>,
     ) : StaffSheetUiState
 }
 

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -16,14 +16,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.model.Staff
-import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Empty
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Loading
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.StaffList
 import kotlinx.collections.immutable.PersistentList
 
 internal sealed interface StaffSheetUiState {
     data object Loading : StaffSheetUiState
-    data object Empty : StaffSheetUiState
     data class StaffList(
         val staffs: PersistentList<Staff>,
     ) : StaffSheetUiState
@@ -38,22 +36,12 @@ internal fun StaffSheet(
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
             Loading -> LoadingContent(modifier = Modifier.fillMaxSize())
-            Empty -> EmptyView()
             is StaffList -> StaffList(
                 staffs = uiState.staffs,
                 onStaffClick = onStaffClick,
             )
         }
     }
-}
-
-// FIXME: This is a temporary view.
-@Composable
-private fun EmptyView() {
-    Text(
-        text = "empty",
-        modifier = Modifier.testTag("empty"),
-    )
 }
 
 // FIXME: It might be a good idea to move this Composable function to a common module somewhere. The same applies to TimetableLoadingContent as well.

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/section/StaffSheet.kt
@@ -1,0 +1,81 @@
+package io.github.droidkaigi.confsched2023.staff.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.model.Staff
+import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Empty
+import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.Loading
+import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState.StaffList
+import kotlinx.collections.immutable.ImmutableList
+
+internal sealed interface StaffSheetUiState {
+    data object Loading : StaffSheetUiState
+    data object Empty : StaffSheetUiState
+    data class StaffList(
+        val staffs: ImmutableList<Staff>,
+    ) : StaffSheetUiState
+}
+
+@Composable
+internal fun StaffSheet(
+    uiState: StaffSheetUiState,
+    modifier: Modifier = Modifier,
+    onStaffClick: (url: String) -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        when (uiState) {
+            Loading -> LoadingContent(modifier = Modifier.fillMaxSize())
+            Empty -> {
+                Text(
+                    text = "empty",
+                    modifier = Modifier.testTag("empty"),
+                )
+            }
+
+            is StaffList -> StaffList(
+                staffs = uiState.staffs,
+                onStaffClick = onStaffClick,
+            )
+        }
+    }
+}
+
+
+// FIXME: It might be a good idea to move this Composable function to a common module somewhere. The same applies to TimetableLoadingContent as well.
+@Composable
+private fun LoadingContent(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(
+            space = 16.dp,
+            alignment = Alignment.CenterVertically,
+        ),
+    ) {
+        CircularProgressIndicator()
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = "Loading...",
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyMedium,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2023/issues/714

## Overview (Required)
- Moved StaffList to section package, and moved StaffListItem to component package.
- Changed to display loading during staff retrieval.
- Added error handling during staff list retrieval.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/1450486/1efc6657-72a4-48bd-9331-f3080509925f" width="250" /> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/1450486/6d28a074-7c2e-453d-96e2-049133e4db69" width="250" />

### When in airplane mode.





https://github.com/DroidKaigi/conference-app-2023/assets/1450486/09eee24b-20fa-4d5a-b402-57c4c3984b2b








