### PR TITLE
Fix wording of "supported languages" in English

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -96,7 +96,7 @@ public sealed class TimetableItem {
         val japanese = if (isJapaneseLocale) "日本語" else "Japanese"
         val english = if (isJapaneseLocale) "英語" else "English"
         val japaneseWithInterpretation =
-            if (isJapaneseLocale) "日本語 (英語通訳あり)" else "Japanese (with Japanese Interpretation)"
+            if (isJapaneseLocale) "日本語 (英語通訳あり)" else "Japanese (with English Interpretation)"
         val englishWithInterpretation =
             if (isJapaneseLocale) "英語 (日本語通訳あり)" else "English (with Japanese Interpretation)"
 


### PR DESCRIPTION
## Issue
- close #696

## Overview (Required)
- "日本語 (英語通訳あり)" is translated as "Japanese (with **Japanese** Interpretation)"
- in this pr, I fix it as "Japanese (with **English** Interpretation)"

## Links
- nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/4400e991-b136-49a6-a729-f5671d5748a7" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/c1d8bdfe-01aa-4842-a438-17cfc1165295" width="300" />

