### PR TITLE
[feature/#460] Set NavigationRail when display expanded or device is tablet

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -94,5 +94,6 @@ dependencies {
     implementation(libs.composeHiltNavigtation)
     implementation(libs.accompanistSystemUiController)
     implementation(libs.androidxBrowser)
+    implementation(libs.androidxWindow)
     testImplementation(projects.core.testing)
 }

--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     implementation(projects.core.designsystem)
     implementation(libs.composeNavigation)
     implementation(libs.composeHiltNavigtation)
+    implementation(libs.composeMaterialWindowSize)
     implementation(libs.accompanistSystemUiController)
     implementation(libs.androidxBrowser)
     implementation(libs.androidxWindow)

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
@@ -25,6 +26,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.window.layout.DisplayFeature
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.github.droidkaigi.confsched2023.about.aboutScreenRoute
 import io.github.droidkaigi.confsched2023.about.navigateAboutScreen
@@ -69,9 +71,14 @@ import io.github.droidkaigi.confsched2023.staff.staffScreen
 import io.github.droidkaigi.confsched2023.stamps.navigateStampsScreen
 import io.github.droidkaigi.confsched2023.stamps.nestedStampsScreen
 import io.github.droidkaigi.confsched2023.stamps.stampsScreenRoute
+import kotlinx.collections.immutable.PersistentList
 
 @Composable
-fun KaigiApp(modifier: Modifier = Modifier) {
+fun KaigiApp(
+    windowSize: WindowSizeClass,
+    displayFeatures: PersistentList<DisplayFeature>,
+    modifier: Modifier = Modifier,
+) {
     KaigiTheme {
         val systemUiController = rememberSystemUiController()
         val useDarkIcons = !isSystemInDarkTheme()
@@ -85,13 +92,18 @@ fun KaigiApp(modifier: Modifier = Modifier) {
             modifier = modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,
         ) {
-            KaigiNavHost()
+            KaigiNavHost(
+                windowSize = windowSize,
+                displayFeatures = displayFeatures,
+            )
         }
     }
 }
 
 @Composable
 private fun KaigiNavHost(
+    windowSize: WindowSizeClass,
+    displayFeatures: PersistentList<DisplayFeature>,
     navController: NavHostController = rememberNavController(),
     externalNavController: ExternalNavController = rememberExternalNavController(),
 ) {
@@ -138,10 +150,14 @@ private fun KaigiNavHost(
 }
 
 private fun NavGraphBuilder.mainScreen(
+    windowSize: WindowSizeClass,
+    displayFeatures: PersistentList<DisplayFeature>,
     navController: NavHostController,
     externalNavController: ExternalNavController,
 ) {
     mainScreen(
+        windowSize = windowSize,
+        displayFeatures = displayFeatures,
         mainNestedGraphStateHolder = KaigiAppMainNestedGraphStateHolder(),
         mainNestedGraph = { mainNestedNavController, _ ->
             nestedSessionScreens(
@@ -222,6 +238,7 @@ class KaigiAppMainNestedGraphStateHolder : MainNestedGraphStateHolder {
                 launchSingleTop = true
                 restoreState = true
             }
+
             Badges -> mainNestedNavController.navigateStampsScreen()
         }
     }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -108,7 +108,7 @@ private fun KaigiNavHost(
     externalNavController: ExternalNavController = rememberExternalNavController(),
 ) {
     NavHostWithSharedAxisX(navController = navController, startDestination = mainScreenRoute) {
-        mainScreen(navController, externalNavController)
+        mainScreen(windowSize, displayFeatures, navController, externalNavController)
         sessionScreens(
             onNavigationIconClick = {
                 navController.popBackStack()

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/MainActivity.kt
@@ -3,18 +3,52 @@ package io.github.droidkaigi.confsched2023
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.core.view.WindowCompat
+import androidx.window.layout.DisplayFeature
+import androidx.window.layout.WindowInfoTracker
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
-            KaigiApp()
+            val windowSize = calculateWindowSizeClass(this)
+            val displayFeatures = calculateDisplayFeatures(this)
+            KaigiApp(
+                windowSize = windowSize,
+                displayFeatures = displayFeatures,
+            )
         }
     }
+}
+
+@Composable
+private fun calculateDisplayFeatures(activity: ComponentActivity): PersistentList<DisplayFeature> {
+    val windowLayoutInfo = remember(activity) {
+        WindowInfoTracker.getOrCreate(activity).windowLayoutInfo(activity)
+    }
+    val displayFeatures by produceState(
+        initialValue = persistentListOf(),
+        key1 = windowLayoutInfo,
+    ) {
+        windowLayoutInfo.collect { info ->
+            value = info.displayFeatures.toPersistentList()
+        }
+    }
+
+    return displayFeatures
 }

--- a/app-android/src/test/java/io/github/droidkaigi/confsched2023/KaigiAppTest.kt
+++ b/app-android/src/test/java/io/github/droidkaigi/confsched2023/KaigiAppTest.kt
@@ -39,6 +39,14 @@ class KaigiAppTest {
     }
 
     @Test
+    @Config(qualifiers = RobolectricDeviceQualifiers.MediumTablet)
+    fun checkMediumTabletLaunchShot() {
+        kaigiAppRobot {
+            capture()
+        }
+    }
+
+    @Test
     fun checkStartup() {
         kaigiAppRobot {
             timetableScreenRobot {

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.composeNavigation)
     implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
     implementation(libs.androidxActivityActivityCompose)
+    implementation(libs.androidxWindow)
     androidTestImplementation(libs.composeUiTestJunit4)
     debugImplementation(libs.composeUiTooling)
     debugImplementation(libs.composeUiTestManifest)

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
     implementation(libs.composeMaterial)
+    implementation(libs.composeMaterialWindowSize)
     implementation(libs.composeMaterialIcon)
     implementation(libs.composeUiToolingPreview)
     implementation(libs.composeNavigation)

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2023.main
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.FastOutLinearInEasing
@@ -10,7 +11,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -43,6 +46,7 @@ import io.github.droidkaigi.confsched2023.feature.main.R
 import io.github.droidkaigi.confsched2023.main.NavigationType.BOTTOM_NAVIGATION
 import io.github.droidkaigi.confsched2023.main.NavigationType.NAVIGATION_RAIL
 import io.github.droidkaigi.confsched2023.main.component.KaigiBottomBar
+import io.github.droidkaigi.confsched2023.main.component.KaigiNavigationRail
 import io.github.droidkaigi.confsched2023.main.strings.MainStrings
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.ImmutableList
@@ -103,6 +107,7 @@ fun MainScreen(
     MainScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
+        navigationType = navigationType,
         routeToTab = mainNestedGraphStateHolder::routeToTab,
         onTabSelected = mainNestedGraphStateHolder::onTabSelected,
         mainNestedNavGraph = mainNestedNavGraph,
@@ -161,6 +166,7 @@ data class MainScreenUiState(
 private fun MainScreen(
     uiState: MainScreenUiState,
     snackbarHostState: SnackbarHostState,
+    navigationType: NavigationType,
     routeToTab: String.() -> MainScreenTab?,
     onTabSelected: (NavController, MainScreenTab) -> Unit,
     mainNestedNavGraph: NavGraphBuilder.(NavController, PaddingValues) -> Unit,
@@ -168,9 +174,9 @@ private fun MainScreen(
     val mainNestedNavController = rememberNavController()
     val navBackStackEntry by mainNestedNavController.currentBackStackEntryAsState()
     val currentTab = navBackStackEntry?.destination?.route?.routeToTab()
-    Scaffold(
-        bottomBar = {
-            KaigiBottomBar(
+    Row(modifier = Modifier.fillMaxSize()) {
+        AnimatedVisibility(visible = navigationType == NAVIGATION_RAIL) {
+            KaigiNavigationRail(
                 mainScreenTabs = MainScreenTab.entries.toPersistentList(),
                 onTabSelected = { tab ->
                     onTabSelected(mainNestedNavController, tab)
@@ -178,17 +184,31 @@ private fun MainScreen(
                 currentTab = currentTab ?: MainScreenTab.Timetable,
                 isEnableStamps = uiState.isStampsEnabled,
             )
-        },
-        contentWindowInsets = WindowInsets(0.dp),
-    ) { padding ->
-        NavHost(
-            navController = mainNestedNavController,
-            startDestination = "timetable",
-            modifier = Modifier.padding(padding),
-            enterTransition = { materialFadeThroughIn() },
-            exitTransition = { materialFadeThroughOut() },
-        ) {
-            mainNestedNavGraph(mainNestedNavController, padding)
+        }
+        Scaffold(
+            bottomBar = {
+                AnimatedVisibility(visible = navigationType == BOTTOM_NAVIGATION) {
+                    KaigiBottomBar(
+                        mainScreenTabs = MainScreenTab.entries.toPersistentList(),
+                        onTabSelected = { tab ->
+                            onTabSelected(mainNestedNavController, tab)
+                        },
+                        currentTab = currentTab ?: MainScreenTab.Timetable,
+                        isEnableStamps = uiState.isStampsEnabled,
+                    )
+                }
+            },
+            contentWindowInsets = WindowInsets(0.dp),
+        ) { padding ->
+            NavHost(
+                navController = mainNestedNavController,
+                startDestination = "timetable",
+                modifier = Modifier.padding(padding),
+                enterTransition = { materialFadeThroughIn() },
+                exitTransition = { materialFadeThroughOut() },
+            ) {
+                mainNestedNavGraph(mainNestedNavController, padding)
+            }
         }
     }
 }

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -79,7 +79,7 @@ interface MainNestedGraphStateHolder {
 }
 
 enum class NavigationType {
-    BOTTOM_NAVIGATION, NAVIGATION_RAIL;
+    BOTTOM_NAVIGATION, NAVIGATION_RAIL
 }
 
 @Composable

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -36,21 +37,27 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.window.layout.DisplayFeature
 import io.github.droidkaigi.confsched2023.feature.main.R
 import io.github.droidkaigi.confsched2023.main.component.KaigiBottomBar
 import io.github.droidkaigi.confsched2023.main.strings.MainStrings
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
-import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 
 const val mainScreenRoute = "main"
 const val MainScreenTestTag = "MainScreen"
 
 fun NavGraphBuilder.mainScreen(
+    windowSize: WindowSizeClass,
+    displayFeatures: PersistentList<DisplayFeature>,
     mainNestedGraphStateHolder: MainNestedGraphStateHolder,
     mainNestedGraph: NavGraphBuilder.(mainNestedNavController: NavController, PaddingValues) -> Unit,
 ) {
     composable(mainScreenRoute) {
         MainScreen(
+            windowSize = windowSize,
+            displayFeatures = displayFeatures,
             mainNestedGraphStateHolder = mainNestedGraphStateHolder,
             mainNestedNavGraph = mainNestedGraph,
         )
@@ -65,6 +72,8 @@ interface MainNestedGraphStateHolder {
 
 @Composable
 fun MainScreen(
+    windowSize: WindowSizeClass,
+    displayFeatures: ImmutableList<DisplayFeature>,
     mainNestedGraphStateHolder: MainNestedGraphStateHolder,
     viewModel: MainScreenViewModel = hiltViewModel(),
     mainNestedNavGraph: NavGraphBuilder.(NavController, PaddingValues) -> Unit,

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -39,11 +40,14 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.window.layout.DisplayFeature
 import io.github.droidkaigi.confsched2023.feature.main.R
+import io.github.droidkaigi.confsched2023.main.NavigationType.BOTTOM_NAVIGATION
+import io.github.droidkaigi.confsched2023.main.NavigationType.NAVIGATION_RAIL
 import io.github.droidkaigi.confsched2023.main.component.KaigiBottomBar
 import io.github.droidkaigi.confsched2023.main.strings.MainStrings
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
 
 const val mainScreenRoute = "main"
 const val MainScreenTestTag = "MainScreen"
@@ -70,6 +74,10 @@ interface MainNestedGraphStateHolder {
     fun onTabSelected(mainNestedNavController: NavController, tab: MainScreenTab)
 }
 
+enum class NavigationType {
+    BOTTOM_NAVIGATION, NAVIGATION_RAIL;
+}
+
 @Composable
 fun MainScreen(
     windowSize: WindowSizeClass,
@@ -80,6 +88,13 @@ fun MainScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+
+    val navigationType: NavigationType = when (windowSize.widthSizeClass) {
+        WindowWidthSizeClass.Compact -> BOTTOM_NAVIGATION
+        WindowWidthSizeClass.Medium -> NAVIGATION_RAIL
+        WindowWidthSizeClass.Expanded -> NAVIGATION_RAIL
+        else -> BOTTOM_NAVIGATION
+    }
 
     SnackbarMessageEffect(
         snackbarHostState = snackbarHostState,

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/MainScreen.kt
@@ -66,7 +66,7 @@ interface MainNestedGraphStateHolder {
 @Composable
 fun MainScreen(
     mainNestedGraphStateHolder: MainNestedGraphStateHolder,
-    viewModel: MainScreenViewModel = hiltViewModel<MainScreenViewModel>(),
+    viewModel: MainScreenViewModel = hiltViewModel(),
     mainNestedNavGraph: NavGraphBuilder.(NavController, PaddingValues) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()

--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiNavigationRail.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/component/KaigiNavigationRail.kt
@@ -1,0 +1,72 @@
+package io.github.droidkaigi.confsched2023.main.component
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import io.github.droidkaigi.confsched2023.main.IconRepresentation.Drawable
+import io.github.droidkaigi.confsched2023.main.IconRepresentation.Vector
+import io.github.droidkaigi.confsched2023.main.MainScreenTab
+import kotlinx.collections.immutable.PersistentList
+
+@Composable
+fun KaigiNavigationRail(
+    mainScreenTabs: PersistentList<MainScreenTab>,
+    onTabSelected: (MainScreenTab) -> Unit,
+    currentTab: MainScreenTab,
+    isEnableStamps: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    NavigationRail(
+        modifier = modifier,
+    ) {
+        mainScreenTabs.forEach { tab ->
+            if (tab == MainScreenTab.Badges && isEnableStamps.not()) return@forEach
+            val selected = currentTab == tab
+            NavigationRailItem(
+                modifier = Modifier.testTag(tab.testTag),
+                selected = selected,
+                onClick = { onTabSelected(tab) },
+                icon = {
+                    if (selected) {
+                        when (val icon = tab.selectedIcon) {
+                            is Drawable -> Icon(
+                                painterResource(id = icon.drawableId),
+                                contentDescription = tab.contentDescription,
+                            )
+
+                            is Vector -> Icon(
+                                imageVector = icon.imageVector,
+                                contentDescription = tab.contentDescription,
+                            )
+                        }
+                    } else {
+                        when (val icon = tab.icon) {
+                            is Drawable -> Icon(
+                                painterResource(id = icon.drawableId),
+                                contentDescription = tab.contentDescription,
+                            )
+
+                            is Vector -> Icon(
+                                imageVector = icon.imageVector,
+                                contentDescription = tab.contentDescription,
+                            )
+                        }
+                    }
+                },
+                label = {
+                    Text(
+                        text = tab.label,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ composeUi = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 composeNavigation = { module = "androidx.navigation:navigation-compose", version = "2.7.0" }
 composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 composeMaterial = { module = "androidx.compose.material3:material3", version = "1.1.1" }
+composeMaterialWindowSize = { module = "androidx.compose.material3:material3-window-size-class", version = "1.1.1" }
 composeMaterialIcon = { module = "androidx.compose.material:material-icons-extended", version = "1.5.0" }
 composeUiToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 composeUiTestJunit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ androidxLifecycleLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-
 androidxActivityActivityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidxDatastoreDatastorePreferences = { module = "androidx.datastore:datastore-preferences-core", version = "1.1.0-alpha04" }
 androidxBrowser = { module = "androidx.browser:browser", version = "1.6.0" }
+androidxWindow = { module = "androidx.window:window", version = "1.1.0" }
 javaPoet = { module = "com.squareup:javapoet", version = "1.13.0" }
 
 # Data


### PR DESCRIPTION
## Overview (Required)
- Phase 1: Apply Navigation Rail when foldable device expanded(or device is tablet)
- I think UI test should be added to next PR, what do you think about it? 
  - If UI test is essential when ui is modified, I'll include UI test code in this.

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/51f5ddfa-48b1-433a-b6f4-9149cb633a66" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/54518925/3db71d75-fb9c-4124-ab08-d6dc015a0f4b" width="300" />