### PR TITLE
Add Accessibility ScreenShot Test for TimetableItemDetailScreen

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -78,8 +78,8 @@ class TimetableItemDetailScreenRobot @Inject constructor(
                 roborazziOptions = RoborazziOptions(
                     captureType = RoborazziOptions.CaptureType.Dump(
                         explanation = Dump.AccessibilityExplanation,
-                    )
-                )
+                    ),
+                ),
             )
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
+import com.github.takahirom.roborazzi.Dump
+import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
 import io.github.droidkaigi.confsched2023.data.sessions.fake
 import io.github.droidkaigi.confsched2023.data.sessions.response.SessionsAllResponse
@@ -67,6 +69,18 @@ class TimetableItemDetailScreenRobot @Inject constructor(
         composeTestRule
             .onNode(isRoot())
             .captureRoboImage()
+    }
+
+    fun checkAccessibilityCapture() {
+        composeTestRule
+            .onRoot()
+            .captureRoboImage(
+                roborazziOptions = RoborazziOptions(
+                    captureType = RoborazziOptions.CaptureType.Dump(
+                        explanation = Dump.AccessibilityExplanation,
+                    )
+                )
+            )
     }
 
     fun waitUntilIdle() {

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
@@ -50,6 +50,15 @@ class TimetableItemDetailScreenTest {
 
     @Test
     @Category(ScreenshotTests::class)
+    fun checkLaunchAccessibilityShot() {
+        timetableItemDetailScreenRobot {
+            setupScreenContent()
+            checkAccessibilityCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
     fun checkBookmarkToggleShot() {
         timetableItemDetailScreenRobot {
             setupScreenContent()


### PR DESCRIPTION
## Issue

- close #717

## Overview (Required)

- Add `checkLaunchAccessibilityShot()` method from Snippets
- Add Accessibility ScreenShot Test to `TimetableItemDetailScreen`
- Visualizing Accessibility
- Normally, you should look at screenshots to check for accessibility issues, but for this PR, if you can take a screenshot, it's OK

<details><summary>日本語</summary>

- スニペットから `checkLaunchAccessibilityShot()` メソッドを追加
- アクセシビリティスクリーンショットテストを `TimetableItemDetailScreen` へ追加
- アクセシビリティを可視化
- 本来はスクリーンショットを見てアクセシビリティに問題ないか確認すべきだが、本 PR ではスクリーンショットを撮れれば OK

</details>

## Links

- #561
- https://github.com/takahirom/roborazzi
- https://jakewharton.com/testing-robots/

## Screenshot

|`TimetableItemDetailScreenTest.checkLaunchAccessibilityShot.png`|
|:--:|
|<img src="https://github.com/DroidKaigi/conference-app-2023/assets/21194714/e212ba69-372a-4ea2-b508-d989e22bbe43" width="300" />|