### PR TITLE
[iOS] Add vertical padding to AboutView

### DIFF
--- a/app-ios/Modules/Sources/About/AboutView.swift
+++ b/app-ios/Modules/Sources/About/AboutView.swift
@@ -129,9 +129,9 @@ public struct AboutView<ContributorView: View, SponsorView: View>: View {
     }
 }
 
- #Preview {
-     AboutView(
+#Preview {
+    AboutView(
         contributorViewProvider: {_ in EmptyView()},
         sponsorViewProvider: {_ in EmptyView()}
-     )
- }
+    )
+}

--- a/app-ios/Modules/Sources/About/AboutView.swift
+++ b/app-ios/Modules/Sources/About/AboutView.swift
@@ -114,7 +114,7 @@ public struct AboutView<ContributorView: View, SponsorView: View>: View {
                     Text(Bundle.main.formattedVersion)
                         .font(Font.system(size: 14, weight: .medium))
                 }
-                .padding(.horizontal, 16)
+                .padding(16)
             }
             .navigationTitle("About")
             .navigationDestination(for: AboutRouting.self) { routing in


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Add vertical padding to AboutView
  - Need to have vertical padding of 16pt
  - [Figma](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56147-41180&mode=dev)

## Links
- [Figma](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56147-41180&mode=dev)

## Screenshot

Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/52638834/0a7160a3-6a46-457c-927e-3aa916a50199" /> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/52638834/bd5b4c3e-784e-4328-80f2-806e7fb2028f" />


Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/52638834/1ee19c55-c452-45fe-b765-f62203b38476" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/52638834/2e6a6484-4442-4414-8a3e-6575ce84dddd" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/52638834/a7903773-ac5b-4900-a7f4-ffacc771897d" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/52638834/87efa2a6-eb26-4d85-b41c-b593316c6a70" width="300" />