### PR TITLE
update: put proper padding to the end of the list in the side event l…

### DIFF
--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
@@ -136,7 +136,7 @@ private fun FloorMapScreen(
                                     1f to Color.Transparent,
                                 ),
                             )
-                            .padding(bottom = 56.dp),
+                            .padding(bottom = 72.dp),
                     )
                 }
                 FloorLevelSwitcher(


### PR DESCRIPTION
…ist.

## Issue
- close #741 

## Overview (Required)
- Put proper padding to the end of list in side event list

## Links
- 

## Screenshot

### Before
![Screenshot_20230819_162239](https://github.com/DroidKaigi/conference-app-2023/assets/85158805/1c61a7d6-8f8d-450f-963f-1b6e9000a198)



###  After
![Screenshot_20230819_162157](https://github.com/DroidKaigi/conference-app-2023/assets/85158805/fd8d4278-de0b-467b-bab4-c8425572a3e9)


<img src="" width="300" /> | <img src="" width="300" />