### PR TITLE
[iOS] Fix the alignment of the session message

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
@@ -37,6 +37,7 @@ struct TimetableListItemView: View {
                             Assets.Icons.error.swiftUIImage
                                 .renderingMode(.template)
                             Text(message.currentLangTitle)
+                                .multilineTextAlignment(.leading)
                                 .font(Font.system(size: 12, weight: .regular, design: .default))
                         }
                         .foregroundStyle(AssetColors.Error.error.swiftUIColor)


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR fixes the alignment of the session message on the timetable.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/f1ea49ca-602e-4d89-a23b-defeb06b2f9e" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/13252c80-205d-4319-bfd5-f3ea8df9fd00" width="300" />