### PR TITLE
fix unnatural behavior of BookmarkFilterChip

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreenViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreenViewModel.kt
@@ -103,7 +103,7 @@ class BookmarkScreenViewModel @Inject constructor(
     private fun onDayChipClick(day: DroidKaigi2023Day) {
         currentDayFilter.update {
             when {
-                it.size == DroidKaigi2023Day.entries.size -> {
+                it.size == DroidKaigi2023Day.entries.size && allFilterChipSelected.value -> {
                     listOf(day)
                 }
 


### PR DESCRIPTION
## Issue
- related to #570

## Overview (Required)
- fix the problem I put in https://github.com/DroidKaigi/conference-app-2023/pull/692 .
when Day1, Day2, and Day3 are all selected, the natural expectation is that tapping any of them will unselect the selected one, but in fact only the one you tapped will remain selected.


## Screenshot

Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/87587734/f7371850-ca5f-4409-8ae1-8c6b858dc32c" width="300" /> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/87587734/f60037e4-8d1b-4341-9a23-1d411d462b07" width="300" />