### PR TITLE
[iOS] Add Dynamic Tab Animation in TimetableDayHeader.

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
@@ -15,9 +15,7 @@ struct TimetableDayHeader: View {
 
     // Define all button count to calculate holizontal position for capsule rectangle
     private var buttonsCount: Int {
-        [DroidKaigi2023Day]
-            .fromKotlinArray(DroidKaigi2023Day.values())
-            .count
+        Int(DroidKaigi2023Day.values().size)
     }
 
     var body: some View {

--- a/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
@@ -69,16 +69,7 @@ struct TimetableDayHeader: View {
     }
 
     private func getIndexBySelectedDay() -> Int {
-        switch selectedDay {
-        case .day1:
-            return 0
-        case .day2:
-            return 1
-        case .day3:
-            return 2
-        default:
-            return 1
-        }
+        Int(selectedDay.ordinal)
     }
 
     private func calculateButtonWidth(deviceWidth: CGFloat) -> CGFloat {

--- a/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
@@ -8,6 +8,18 @@ struct TimetableDayHeader: View {
     let selectedDay: DroidKaigi2023Day
     let onSelect: (DroidKaigi2023Day) -> Void
 
+    // Define margin values to calculate holizontal position for capsule rectangle
+    private let buttonAreaLeadingMargin = 16.0
+    private let buttonTrailingMargin = 16.0
+    private let betweenButtonMargin = 8.0
+
+    // Define all button count to calculate holizontal position for capsule rectangle
+    private var buttonsCount: Int {
+        [DroidKaigi2023Day]
+            .fromKotlinArray(DroidKaigi2023Day.values())
+            .count
+    }
+
     var body: some View {
         ZStack {
             AssetColors.Surface.surface.swiftUIColor
@@ -41,30 +53,43 @@ struct TimetableDayHeader: View {
                 GeometryReader { geometry in
                     Capsule()
                         .fill(AssetColors.Primary.primary.swiftUIColor)
-                        .frame(width: calcButtonWidth(width: geometry.size.width), height: 56)
-                        .offset(x: calcDynamicTabHorizontalOffset(width: geometry.size.width), y: 10)
+                        .frame(width: calculateButtonWidth(deviceWidth: geometry.size.width), height: 56)
+                        .offset(x: calculateDynamicTabHorizontalOffset(deviceWidth: geometry.size.width), y: 10)
                         .animation(.easeInOut(duration: 0.16), value: selectedDay)
                 }
             }
         }
     }
 
-    private func calcDynamicTabHorizontalOffset(width: CGFloat) -> CGFloat {
-        let buttonAreaWidth = calcButtonWidth(width: width)
+    private func calculateDynamicTabHorizontalOffset(deviceWidth: CGFloat) -> CGFloat {
+        let buttonAreaWidth = calculateButtonWidth(deviceWidth: deviceWidth)
+        // Get the index value corresponding to `selectedDay` and use it for calculation
+        let indexBySelectedDay = getIndexBySelectedDay()
+        return buttonAreaLeadingMargin + (betweenButtonMargin + buttonAreaWidth) * CGFloat(indexBySelectedDay)
+    }
+
+    private func getIndexBySelectedDay() -> Int {
         switch selectedDay {
         case .day1:
-            return 16.0
+            return 0
         case .day2:
-            return 24.0 + buttonAreaWidth
+            return 1
         case .day3:
-            return 32.0 + buttonAreaWidth * 2
+            return 2
         default:
-            return 24.0 + buttonAreaWidth
+            return 1
         }
     }
 
-    private func calcButtonWidth(width: CGFloat) -> CGFloat {
-        (width - 48.0) / 3.0
+    private func calculateButtonWidth(deviceWidth: CGFloat) -> CGFloat {
+        // Calculate button width considering related margins
+        let excludeTotalMagin = calculateExcludeTotalMagin()
+        return (deviceWidth - excludeTotalMagin) / CGFloat(buttonsCount)
+    }
+
+    private func calculateExcludeTotalMagin() -> CGFloat {
+        let totalBetweenButtonMargin = betweenButtonMargin * CGFloat(buttonsCount - 1)
+        return buttonAreaLeadingMargin + buttonTrailingMargin + totalBetweenButtonMargin
     }
 }
 

--- a/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
@@ -9,39 +9,62 @@ struct TimetableDayHeader: View {
     let onSelect: (DroidKaigi2023Day) -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            ForEach(
-                [DroidKaigi2023Day].fromKotlinArray(DroidKaigi2023Day.values()),
-                id: \.ordinal
-            ) { (day: DroidKaigi2023Day) in
-                Button {
-                    onSelect(day)
-                } label: {
-                    VStack(spacing: 0) {
-                        Text(day.name)
-                            .font(Font.system(size: 12, weight: .semibold))
-                        Text("\(day.dayOfMonth)")
-                            .font(Font.system(size: 24, weight: .semibold))
-                            .frame(height: 32)
+        ZStack {
+            AssetColors.Surface.surface.swiftUIColor
+            HStack(spacing: 8) {
+                ForEach(
+                    [DroidKaigi2023Day].fromKotlinArray(DroidKaigi2023Day.values()),
+                    id: \.ordinal
+                ) { (day: DroidKaigi2023Day) in
+                    Button {
+                        onSelect(day)
+                    } label: {
+                        VStack(spacing: 0) {
+                            Text(day.name)
+                                .font(Font.system(size: 12, weight: .semibold))
+                            Text("\(day.dayOfMonth)")
+                                .font(Font.system(size: 24, weight: .semibold))
+                                .frame(height: 32)
+                        }
+                        .padding(4)
+                        .frame(maxWidth: .infinity)
+                        .foregroundStyle(
+                            selectedDay == day
+                            ? AssetColors.Primary.onPrimary.swiftUIColor
+                            : AssetColors.Surface.onSurfaceVariant.swiftUIColor)
                     }
-                    .padding(4)
-                    .frame(maxWidth: .infinity)
-                    .foregroundStyle(
-                        selectedDay == day
-                        ? AssetColors.Primary.onPrimary.swiftUIColor
-                        : AssetColors.Surface.onSurfaceVariant.swiftUIColor)
-                    .background(
-                        selectedDay == day
-                        ? AssetColors.Primary.primary.swiftUIColor
-                        : Color.clear
-                    )
-                    .clipShape(Capsule())
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(alignment: .center) {
+                GeometryReader { geometry in
+                    Capsule()
+                        .fill(AssetColors.Primary.primary.swiftUIColor)
+                        .frame(width: calcButtonWidth(width: geometry.size.width), height: 56)
+                        .offset(x: calcDynamicTabHorizontalOffset(width: geometry.size.width), y: 10)
+                        .animation(.easeInOut(duration: 0.16), value: selectedDay)
                 }
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(AssetColors.Surface.surface.swiftUIColor)
+    }
+
+    private func calcDynamicTabHorizontalOffset(width: CGFloat) -> CGFloat {
+        let buttonAreaWidth = calcButtonWidth(width: width)
+        switch selectedDay {
+        case .day1:
+            return 16.0
+        case .day2:
+            return 24.0 + buttonAreaWidth
+        case .day3:
+            return 32.0 + buttonAreaWidth * 2
+        default:
+            return 24.0 + buttonAreaWidth
+        }
+    }
+
+    private func calcButtonWidth(width: CGFloat) -> CGFloat {
+        (width - 48.0) / 3.0
     }
 }
 


### PR DESCRIPTION
## Issue

https://github.com/DroidKaigi/conference-app-2023/issues/769

## Overview

In Android app, the date selection displayed in the header View element was accompanied by an animation.
But in the iOS app it didn't exist so I added it.

__【Summary】__

- Wrap the entire View element with `ZStack`.
- For the rectangular part of the background, the horizontal position and width are calculated using `GeometryReader`.
- Adjusted so that the background moves animation when switching dates.

## Links

Motivation: https://twitter.com/fumiyasac/status/1692857247829987802

## Screenshot

__【Movie】__

https://github.com/DroidKaigi/conference-app-2023/assets/949561/b8fc2231-a14d-4c1e-83d4-8e6527e24be5

__【iPhone】__

※ iPhone14 Pro Simulator

| Portrait |
| :--: |
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/f1236bc4-cc6f-4d8c-903d-a59cc3120f26" width="390" /> |

| Landscape |
| :--: |
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/265b84af-8745-4d46-87f6-d7b0469e7e34" width="884" /> |

__【iPad】__

※ iPad mini (6th generation) Simulator

| Portrait |
| :--: |
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/45496e50-ac38-44e4-8530-b7a9f4f9b6ab" width="768" /> |

| Landscape |
| :--: |
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/b5a3b367-ec49-46ac-a931-e3d9ad714554" width="1024" /> |