### PR TITLE
add font scale shot test in TimetableItemDetailScreenTest

### DIFF
--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
@@ -82,4 +82,34 @@ class TimetableItemDetailScreenTest {
             checkScreenCapture()
         }
     }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 0.5f)
+    fun smallFontScaleShot() {
+        timetableItemDetailScreenRobot {
+            setupScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 1.5f)
+    fun largeFontScaleShot() {
+        timetableItemDetailScreenRobot {
+            setupScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 2.0f)
+    fun hugeFontScaleShot() {
+        timetableItemDetailScreenRobot {
+            setupScreenContent()
+            checkScreenCapture()
+        }
+    }
 }


### PR DESCRIPTION
## Issue
- #464 

## Overview (Required)
- Added tests with font scale of 0.5f, 1.5f and 2f to TimetableItemDetailScreenTest