### PR TITLE
[Android] remove border from room chips

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -85,11 +84,7 @@ fun BookmarkList(
                                     containerColor = roomChipBackgroundColor,
                                     labelColor = roomChipLabelColor,
                                 ),
-                                border = AssistChipDefaults.assistChipBorder(
-                                    borderColor = Color.Transparent,
-                                    disabledBorderColor = Color.Transparent,
-                                    borderWidth = 0.dp,
-                                ),
+                                border = null,
                             )
                             Spacer(modifier = Modifier.size(5.dp))
                             AssistChip(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
@@ -108,6 +108,7 @@ fun SearchList(
                                 containerColor = roomChipBackgroundColor,
                                 labelColor = roomChipLabelColor,
                             ),
+                            border = null,
                             onClick = { /* Do nothing */ },
                             label = {
                                 Text(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -85,6 +85,7 @@ fun TimetableList(
                                     containerColor = containerColor,
                                     labelColor = labelColor,
                                 ),
+                                border = null,
                                 onClick = { /* Do nothing */ },
                                 label = {
                                     Text(


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Room chips should not have border according to [Figma design](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&mode=design&t=cRRy12KoPFfTF5Kw-0), so just removed them.

## Links
- 

## Screenshot
Timetable | Bookmark | Search
:--: | :--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/dddb7b47-6df3-42fc-9a4b-533ecb634068" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/e891be53-e823-47b4-aa37-d7a609e25e66" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/04a0864a-54c0-4d41-9524-18a9d5cadfbf" width="300" />
