### PR TITLE
Fix background color of BookmarkScreen in dark theme

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/BookmarkScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -69,7 +68,6 @@ private fun BookmarkScreen(
                 onBackPressClick = onBackPressClick,
             )
         },
-        containerColor = Color(0xFFF8FAF6),
         contentWindowInsets = WindowInsets(0.dp),
     ) { padding ->
         BookmarkSheet(


### PR DESCRIPTION
## Issue
- close #764

## Overview (Required)
- Removed `containerColor` setting from Scaffold used in BookmarkScreen to accommodate dark theme
  - This will apply the `background` value defined in `DarkColors` in [Theme.kt](https://github.com/DroidKaigi/conference-app-2023/blob/main/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/Theme.kt) to the `BookmarkScreen` background color when in dark theme.

## Links
- [API Reference](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#Scaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,androidx.compose.material3.FabPosition,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.WindowInsets,kotlin.Function1))

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/25400773/b78ddc01-eddd-4bbd-abb7-ce816a246ccd" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/25400773/67c69bf4-60a2-42fe-86fd-c48348f1bdc6" width="300" />