### PR TITLE
modify session grid speaker text to fix bottom

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -127,7 +127,7 @@ fun TimetableGridItem(
             Spacer(
                 modifier = Modifier
                     .weight(1f)
-                    .defaultMinSize(minHeight = 8.dp)
+                    .defaultMinSize(minHeight = 8.dp),
             )
 
             // TODO: Dealing with more than one speaker

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -124,9 +124,10 @@ fun TimetableGridItem(
                 )
             }
 
-            Spacer(modifier = Modifier
-                .weight(1f)
-                .defaultMinSize(minHeight = 8.dp)
+            Spacer(
+                modifier = Modifier
+                    .weight(1f)
+                    .defaultMinSize(minHeight = 8.dp)
             )
 
             // TODO: Dealing with more than one speaker

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -123,7 +124,10 @@ fun TimetableGridItem(
                 )
             }
 
-            Spacer(modifier = Modifier.height(TimetableGridItemSizes.scheduleToSpeakerSpaceHeight))
+            Spacer(modifier = Modifier
+                .weight(1f)
+                .defaultMinSize(minHeight = 8.dp)
+            )
 
             // TODO: Dealing with more than one speaker
             if (speaker != null) {
@@ -178,7 +182,7 @@ private fun calculateFontSizeAndLineHeight(
         TimetableGridItemSizes.scheduleHeight.toPx()
     }
     val scheduleToSpeakerSpaceHeightPx = with(localDensity) {
-        TimetableGridItemSizes.scheduleToSpeakerSpaceHeight.toPx()
+        TimetableGridItemSizes.scheduleToSpeakerSpaceMinHeight.toPx()
     }
     val horizontalPaddingPx = with(localDensity) {
         (TimetableGridItemSizes.padding * 2).toPx()
@@ -283,7 +287,7 @@ object TimetableGridItemSizes {
     val padding = 12.dp
     val titleToScheduleSpaceHeight = 4.dp
     val scheduleHeight = 16.dp
-    val scheduleToSpeakerSpaceHeight = 16.dp
+    val scheduleToSpeakerSpaceMinHeight = 8.dp
     val speakerHeight = 32.dp
     val minTitleFontSize = 10.sp
     val middleTitleLineHeight = 16.sp // base on MaterialTheme.typography.labelSmall.lineHeight


### PR DESCRIPTION
## Issue
- close #731

## Overview (Required)
- fix the problem that a session speaker text was not fixed to bottom like in Figma.

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/41a4e497-0927-4c07-87af-05208e57da38" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/f76d83c6-3244-48cd-aa0a-06fcafbf6119" width="300" />
