### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -10,15 +10,6 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.composeMaterialIcon)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }

--- a/feature/floor-map/build.gradle.kts
+++ b/feature/floor-map/build.gradle.kts
@@ -10,15 +10,6 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.composeMaterialIcon)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -10,18 +10,9 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
     implementation(libs.composeMaterialWindowSize)
     implementation(libs.composeMaterialIcon)
-    implementation(libs.composeUiToolingPreview)
     implementation(libs.composeNavigation)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.androidxWindow)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }

--- a/feature/sessions/build.gradle.kts
+++ b/feature/sessions/build.gradle.kts
@@ -10,16 +10,7 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.composeMaterialIcon)
     implementation(libs.composeShimmer)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }

--- a/feature/sponsors/build.gradle.kts
+++ b/feature/sponsors/build.gradle.kts
@@ -10,15 +10,6 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.composeMaterialIcon)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }

--- a/feature/staff/build.gradle.kts
+++ b/feature/staff/build.gradle.kts
@@ -10,15 +10,6 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.composeMaterialIcon)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }

--- a/feature/stamps/build.gradle.kts
+++ b/feature/stamps/build.gradle.kts
@@ -10,15 +10,6 @@ dependencies {
     implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
-    implementation(libs.androidxCoreKtx)
-    implementation(libs.composeUi)
     implementation(libs.composeHiltNavigtation)
-    implementation(libs.composeMaterial)
-    implementation(libs.composeUiToolingPreview)
-    implementation(libs.androidxLifecycleLifecycleRuntimeKtx)
-    implementation(libs.androidxActivityActivityCompose)
     implementation(libs.composeMaterialIcon)
-    androidTestImplementation(libs.composeUiTestJunit4)
-    debugImplementation(libs.composeUiTooling)
-    debugImplementation(libs.composeUiTestManifest)
 }


### PR DESCRIPTION
## Issue

none

## Overview (Required)

I learned that the build-logic module can declare a set of settings that can be commonly used in a project as a plugin.
Then, realized that I was declaring duplicate dependencies in the modules that use those plugins.
So I removed the duplicate declarations in the various modules.

Question: It appears that `libs.composeHiltNavigtation` and `libs.composeMaterialIcon` declare a dependency in all modules that use `androidfeature` plugin. Should these be included in AndroidComposePlugin?

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />