### PR TITLE
Change archive section visibility

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableAsset.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableAsset.kt
@@ -5,5 +5,5 @@ public data class TimetableAsset(
     val slideUrl: String?,
 ) {
     val isAvailable: Boolean
-        get() = videoUrl != null || slideUrl != null
+        get() = !videoUrl.isNullOrBlank() && !slideUrl.isNullOrBlank()
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -70,10 +70,12 @@ fun TimetableItemDetailContent(
                 )
                 TargetAudienceSection(targetAudienceString = uiState.targetAudience)
                 SpeakerSection(speakers = uiState.speakers)
-                ArchiveSection(
-                    onViewDocumentClick = {},
-                    onWatchVideoClick = {},
-                )
+                if (uiState.asset.isAvailable) {
+                    ArchiveSection(
+                        onViewDocumentClick = {},
+                        onWatchVideoClick = {},
+                    )
+                }
             }
 
             is Special -> {


### PR DESCRIPTION
## Issue
- close #375

## Overview (Required)
- Change archive to hide if video's url or slide's url is blank or null

## Links
- [Figma](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?node-id=54902%3A40324)

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/51881691/834e6670-9b70-40b5-908f-f74b25daaebc" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/51881691/70b8ab9d-dbda-4dbe-9acd-81e60570ffc5" width="300" />