### PR TITLE
Implement the onCalendarRegistrationClick in sessionScreens.

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -97,5 +97,6 @@ dependencies {
     implementation(libs.accompanistSystemUiController)
     implementation(libs.androidxBrowser)
     implementation(libs.androidxWindow)
+    implementation(libs.kermit)
     testImplementation(projects.core.testing)
 }

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.CalendarContract
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -30,6 +29,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.window.layout.DisplayFeature
+import co.touchlab.kermit.Logger
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.github.droidkaigi.confsched2023.about.aboutScreenRoute
 import io.github.droidkaigi.confsched2023.about.navigateAboutScreen
@@ -293,7 +293,7 @@ private class ExternalNavController(
         runCatching {
             context.startActivity(calendarIntent)
         }.onFailure {
-            Log.e("navigateToCalendarRegistration", "Fail startActivity", it)
+            Logger.e("Fail startActivity in navigateToCalendarRegistration", it)
         }
     }
 

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -123,6 +123,7 @@ private fun KaigiNavHost(
                 )
             },
             onLinkClick = externalNavController::navigate,
+            onCalendarRegistrationClick = externalNavController::navigateToCalendarRegistration,
         )
         searchScreen(
             onNavigationIconClick = {

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.provider.CalendarContract
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -20,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
+import androidx.core.os.bundleOf
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -56,6 +59,7 @@ import io.github.droidkaigi.confsched2023.model.AboutItem.Sponsors
 import io.github.droidkaigi.confsched2023.model.AboutItem.Staff
 import io.github.droidkaigi.confsched2023.model.AboutItem.X
 import io.github.droidkaigi.confsched2023.model.AboutItem.YouTube
+import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.sessions.navigateSearchScreen
 import io.github.droidkaigi.confsched2023.sessions.navigateTimetableScreen
 import io.github.droidkaigi.confsched2023.sessions.navigateToBookmarkScreen
@@ -265,6 +269,30 @@ private class ExternalNavController(
         }
         if (launched.not()) {
             navigateToCustomTab(context = context, uri = uri)
+        }
+    }
+
+    /**
+     * Navigate to Calendar Registration
+     * @param timeTableItem カレンダー登録に必要なタイムラインアイテムの情報
+     */
+    fun navigateToCalendarRegistration(timeTableItem: TimetableItem) {
+        val calendarIntent = Intent(Intent.ACTION_INSERT).apply {
+            data = CalendarContract.Events.CONTENT_URI
+            putExtras(
+                bundleOf(
+                    CalendarContract.EXTRA_EVENT_BEGIN_TIME to timeTableItem.startsAt.toEpochMilliseconds(),
+                    CalendarContract.EXTRA_EVENT_END_TIME to timeTableItem.endsAt.toEpochMilliseconds(),
+                    CalendarContract.Events.TITLE to "[${timeTableItem.room.name.currentLangTitle}] ${timeTableItem.title.currentLangTitle}",
+                    CalendarContract.Events.EVENT_LOCATION to timeTableItem.room.name.currentLangTitle,
+                ),
+            )
+        }
+
+        runCatching {
+            context.startActivity(calendarIntent)
+        }.onFailure {
+            Log.e("navigateToCalendarRegistration", "Fail startActivity", it)
         }
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -41,6 +41,7 @@ class TimetableItemDetailScreenRobot @Inject constructor(
                 TimetableItemDetailScreen(
                     onNavigationIconClick = { },
                     onLinkClick = { },
+                    onCalendarRegistrationClick = { },
                 )
             }
         }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -46,11 +46,13 @@ fun NavGraphBuilder.sessionScreens(
     onNavigationIconClick: () -> Unit,
     onTimetableItemClick: (TimetableItem) -> Unit,
     onLinkClick: (url: String) -> Unit,
+    onCalendarRegistrationClick: (TimetableItem) -> Unit,
 ) {
     composable(timetableItemDetailScreenRoute) {
         TimetableItemDetailScreen(
             onNavigationIconClick = onNavigationIconClick,
             onLinkClick = onLinkClick,
+            onCalendarRegistrationClick = onCalendarRegistrationClick,
         )
     }
     composable(bookmarkScreenRoute) {
@@ -76,6 +78,7 @@ fun NavController.navigateToTimetableItemDetailScreen(
 fun TimetableItemDetailScreen(
     onNavigationIconClick: () -> Unit,
     onLinkClick: (url: String) -> Unit,
+    onCalendarRegistrationClick: (TimetableItem) -> Unit,
     viewModel: TimetableItemDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -91,6 +94,7 @@ fun TimetableItemDetailScreen(
         onNavigationIconClick = onNavigationIconClick,
         onBookmarkClick = viewModel::onBookmarkClick,
         onLinkClick = onLinkClick,
+        onCalendarRegistrationClick = onCalendarRegistrationClick,
         snackbarHostState = snackbarHostState,
     )
 }
@@ -111,6 +115,7 @@ private fun TimetableItemDetailScreen(
     onNavigationIconClick: () -> Unit,
     onBookmarkClick: (TimetableItem) -> Unit,
     onLinkClick: (url: String) -> Unit,
+    onCalendarRegistrationClick: (TimetableItem) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -131,6 +136,7 @@ private fun TimetableItemDetailScreen(
                     timetableItem = uiState.timetableItem,
                     isBookmarked = uiState.isBookmarked,
                     onBookmarkClick = onBookmarkClick,
+                    onCalendarRegistrationClick = onCalendarRegistrationClick,
                 )
             }
         },
@@ -181,6 +187,7 @@ fun TimetableItemDetailScreenPreview() {
                     isBookMarked = !isBookMarked
                 },
                 onLinkClick = {},
+                onCalendarRegistrationClick = {},
                 snackbarHostState = SnackbarHostState(),
             )
         }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailBottomAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailBottomAppBar.kt
@@ -25,6 +25,7 @@ fun TimetableItemDetailBottomAppBar(
     timetableItem: TimetableItem,
     isBookmarked: Boolean,
     onBookmarkClick: (TimetableItem) -> Unit,
+    onCalendarRegistrationClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BottomAppBar(
@@ -36,7 +37,7 @@ fun TimetableItemDetailBottomAppBar(
                     contentDescription = SessionsStrings.Share.asString(),
                 )
             }
-            IconButton(onClick = { /*TODO*/ }) {
+            IconButton(onClick = { onCalendarRegistrationClick(timetableItem) }) {
                 Icon(
                     painter = painterResource(id = R.drawable.calendar_add_on),
                     contentDescription = SessionsStrings.AddToCalendar.asString(),


### PR DESCRIPTION
## Issue
- close #622

## Overview (Required)
- [Add navigateToCalendarRegistration.](https://github.com/DroidKaigi/conference-app-2023/pull/798/commits/39c82805a22f2ca83ce422e39c6fc493ac2dd2fc)
- [Implement the onCalendarRegistrationClick in sessionScreens.](https://github.com/DroidKaigi/conference-app-2023/pull/798/commits/358f53e86b5d77545bfd8df52968aa853718c555)

## Links
- 

## Video
 | After
 | :--:
 | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/9943053/c9e224bb-eb22-4249-b777-2d9e21a0a40f" width="300" />




