### PR TITLE
[iOS] Add missing 'Component' dependency to Sponsor target

### DIFF
--- a/app-ios/Modules/Package.swift
+++ b/app-ios/Modules/Package.swift
@@ -106,6 +106,7 @@ var package = Package(
             name: "Sponsor",
             dependencies: [
                 "Assets",
+                "Component",
                 "Model",
                 "shared",
                 "Theme",


### PR DESCRIPTION
## Issue
Nothing

## Overview (Required)
- add missing dependency (`Component`) to `Sponsor` target

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />