### PR TITLE
:wrench: Match the English text to that of the session details screen.

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
@@ -49,9 +49,9 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
             when (item) {
                 Title -> bindings.defaultBinding(item, bindings)
                 Description -> "DroidKaigi is a conference tailored for Android developers."
-                DateTitle -> "Date & Time"
+                DateTitle -> "Date"
                 DateDescription -> "2023.09.14(Thu) - 16(Sat) 3days"
-                PlaceTitle -> "Location"
+                PlaceTitle -> "Place"
                 PlaceDescription -> "Bellesalle Shibuya Garden"
                 is PlaceLink -> "View Map"
                 CreditsTitle -> bindings.defaultBinding(item, bindings)


### PR DESCRIPTION
## Issue
- none.

## Overview (Required)
- The English text on the AboutScreen and Session Details screens is misaligned, so we have made them match.

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/ca2b602a-64cf-484f-994f-4df3fed5cba9" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/f9f195d5-8e44-406c-b086-762f2d32576a" width="300" />