### PR TITLE
Stores `viewModelScope` in `KmpViewModel` on iOS

### DIFF
--- a/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/KmpViewModel.kt
+++ b/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/KmpViewModel.kt
@@ -5,8 +5,8 @@ import kotlinx.coroutines.MainScope
 
 actual abstract class KmpViewModel {
     // TODO: Cancel scope
-    internal val internalViewModelScope: CoroutineScope = MainScope()
+    internal val viewModelScope: CoroutineScope = MainScope()
 }
 
 actual val KmpViewModel.viewModelScope: CoroutineScope
-    get() = internalViewModelScope
+    get() = viewModelScope

--- a/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/KmpViewModel.kt
+++ b/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/KmpViewModel.kt
@@ -3,7 +3,10 @@ package io.github.droidkaigi.confsched2023.ui
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 
-actual abstract class KmpViewModel
-actual val KmpViewModel.viewModelScope: CoroutineScope
+actual abstract class KmpViewModel {
     // TODO: Cancel scope
-    get() = MainScope()
+    internal val internalViewModelScope: CoroutineScope = MainScope()
+}
+
+actual val KmpViewModel.viewModelScope: CoroutineScope
+    get() = internalViewModelScope


### PR DESCRIPTION
## Issue
- No issue

## Overview (Required)
- I found that `KmpViewModel.viewModelScope` is a computed property on iOS, making a new instance per accessing to `viewModelScope`. Since the scope is different each time it is accessed, it causes unintended behavior.
- The TODO comment has been left because I couldn't find a solution.
