### PR TITLE
Use `@OptionalExpectation` instead

### DIFF
--- a/core/common/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
+++ b/core/common/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
@@ -3,5 +3,5 @@ package io.github.droidkaigi.confsched2023.ui
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-actual typealias KmpHiltViewModel = HiltViewModel
-actual typealias KmpInject = Inject
+actual typealias HiltViewModel = HiltViewModel
+actual typealias Inject = Inject

--- a/core/common/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
+++ b/core/common/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
@@ -2,8 +2,8 @@ package io.github.droidkaigi.confsched2023.ui
 
 @OptIn(ExperimentalMultiplatform::class)
 @OptionalExpectation
-expect annotation class KmpHiltViewModel()
+expect annotation class HiltViewModel()
 
 @OptIn(ExperimentalMultiplatform::class)
 @OptionalExpectation
-expect annotation class KmpInject()
+expect annotation class Inject()

--- a/core/common/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
+++ b/core/common/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
@@ -1,4 +1,9 @@
 package io.github.droidkaigi.confsched2023.ui
 
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
 expect annotation class KmpHiltViewModel()
+
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
 expect annotation class KmpInject()

--- a/core/common/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
+++ b/core/common/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/Annotations.kt
@@ -1,4 +1,0 @@
-package io.github.droidkaigi.confsched2023.ui
-
-actual annotation class KmpHiltViewModel()
-actual annotation class KmpInject()

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Immutable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Immutable.kt
@@ -1,3 +1,5 @@
 package io.github.droidkaigi.confsched2023.model
 
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
 public expect annotation class Immutable()

--- a/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
+++ b/core/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2022/model/Immutable.kt
@@ -1,3 +1,0 @@
-package io.github.droidkaigi.confsched2023.model
-
-public actual annotation class Immutable

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsViewModel.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsViewModel.kt
@@ -1,8 +1,8 @@
 package io.github.droidkaigi.confsched2023.contributors
 
 import io.github.droidkaigi.confsched2023.model.ContributorsRepository
-import io.github.droidkaigi.confsched2023.ui.KmpHiltViewModel
-import io.github.droidkaigi.confsched2023.ui.KmpInject
+import io.github.droidkaigi.confsched2023.ui.HiltViewModel
+import io.github.droidkaigi.confsched2023.ui.Inject
 import io.github.droidkaigi.confsched2023.ui.KmpViewModel
 import io.github.droidkaigi.confsched2023.ui.buildUiState
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
@@ -11,8 +11,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 
-@KmpHiltViewModel
-class ContributorsViewModel @KmpInject constructor(
+@HiltViewModel
+class ContributorsViewModel @Inject constructor(
     contributorsRepository: ContributorsRepository
 ) : KmpViewModel() {
     private val contributors = contributorsRepository


### PR DESCRIPTION
## Issue
- No issue

## Overview (Required)
- Kotlin Multiplatform has an experimental [`@OptionalExpectation`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-optional-expectation/) annotation that makes the need not to implement the `expect` annotation on all platforms.
