### PR TITLE
Use `Locale.current` for `lang()`

### DIFF
--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/Lang.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/Lang.kt
@@ -1,7 +1,0 @@
-package io.github.droidkaigi.confsched2023.designsystem.strings
-
-import androidx.compose.ui.text.intl.Locale
-
-actual fun lang(): String {
-    return Locale.current.language
-}

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/StringsBindings.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/StringsBindings.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2023.designsystem.strings
 
-import androidx.compose.ui.text.intl.LocaleList
+import androidx.compose.ui.text.intl.Locale
 
 abstract class StringsBindings<T : Strings<T>>(
     vararg mapPairs: Pair<String, (T, StringsBindings<T>) -> String>,
@@ -20,7 +20,7 @@ abstract class StringsBindings<T : Strings<T>>(
     }
 }
 
-private fun lang(): String = LocaleList.current.localeList[0].language
+private fun lang(): String = Locale.current.language
 
 abstract class Strings<T : Strings<T>>(
     private val bindings: StringsBindings<T>,

--- a/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/StringsBindings.kt
+++ b/core/designsystem/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/strings/StringsBindings.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2023.designsystem.strings
 
+import androidx.compose.ui.text.intl.LocaleList
+
 abstract class StringsBindings<T : Strings<T>>(
     vararg mapPairs: Pair<String, (T, StringsBindings<T>) -> String>,
     val default: String,
@@ -18,7 +20,7 @@ abstract class StringsBindings<T : Strings<T>>(
     }
 }
 
-expect fun lang(): String
+private fun lang(): String = LocaleList.current.localeList[0].language
 
 abstract class Strings<T : Strings<T>>(
     private val bindings: StringsBindings<T>,

--- a/core/designsystem/src/iosMain/kotlin/io.github.droidkaigi.confsched2023.designsystem.strings/Lang.kt
+++ b/core/designsystem/src/iosMain/kotlin/io.github.droidkaigi.confsched2023.designsystem.strings/Lang.kt
@@ -1,9 +1,0 @@
-package io.github.droidkaigi.confsched2023.designsystem.strings
-
-import platform.Foundation.NSLocale
-import platform.Foundation.currentLocale
-import platform.Foundation.languageCode
-
-actual fun lang(): String {
-    return NSLocale.currentLocale.languageCode
-}


### PR DESCRIPTION
## Issue
- No issue

## Overview (Required)
- Compose Multiplatform has `Locale` mostly like Android's one. I think it's better than implementing with expect/actual.
![image](https://github.com/DroidKaigi/conference-app-2023/assets/5885032/92def372-b340-4a33-928e-12598f89c4f7)
