### PR TITLE
Fix SearchList padding

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
@@ -50,7 +50,7 @@ fun SearchList(
         contentPadding = contentPaddingValues,
         modifier = modifier
             .imePadding()
-            .padding(end = 16.dp),
+            .padding(start = 16.dp),
     ) {
         itemsIndexed(searchListUiState.timetableItems) { index, timetableItem ->
             Row(modifier = Modifier.padding(top = 10.dp)) {


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fixed `SearchList` padding based on Figma's design
  - before : Set Padding to `end`
  - after : Set Padding to `start`

## Links
- Figma SearchList
  - https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=58036-78614&mode=dev

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/39705795/7e3158ba-0ff9-4069-a096-592d17c5a009" width="300" />|<img src="https://github.com/DroidKaigi/conference-app-2023/assets/39705795/d9dd32c1-5181-4fb5-81b2-ed8b62abb4d3" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/39705795/0f722cae-506c-4503-828a-1f6d6f0a969d" width="300" />|<img src="https://github.com/DroidKaigi/conference-app-2023/assets/39705795/f7e17475-66df-46c7-9a24-67f671ab92f0" width="300" />
