### PR TITLE
Feature/339 add timetableitemdetailcontent compose preview

### DIFF
--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
@@ -59,12 +59,12 @@ object MultiLanguagePreviewDefinition {
 
     object Japanese {
         const val Name = "Japanese"
-        const val Locale = "ja_JP"
+        const val Locale = "ja"
     }
 
     object English {
         const val Name = "English"
-        const val Locale = "en_US"
+        const val Locale = "en"
     }
 }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -337,3 +337,17 @@ fun DescriptionSectionPreview() {
         }
     }
 }
+
+@MultiThemePreviews
+@MultiLanguagePreviews
+@Composable
+fun TimetableItemDetailContentPreview() {
+    KaigiTheme {
+        Surface {
+            TimetableItemDetailContent(
+                uiState = Session.fake(),
+                onLinkClick = {}
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- close #339  

## Overview (Required)
- Add TimeTableItemDetailContent preview.
Preview patterns are DarkMode, LightMode, Japanese and English.

## Links
- https://developer.android.com/jetpack/compose/tooling/previews

## Screenshot
![image](https://github.com/DroidKaigi/conference-app-2023/assets/60098120/066553ff-0583-47d0-9995-38e89394d8aa)