### PR TITLE
Change Placeholder Image for Side Events

### DIFF
--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Celebration
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Person
@@ -133,7 +134,7 @@ fun FloorMapSideEventItem(
                             shape = RoundedCornerShape(16.dp),
                         ),
                     painter = previewOverride(
-                        previewPainter = { rememberVectorPainter(image = Icons.Default.Person) },
+                        previewPainter = { rememberVectorPainter(image = Icons.Default.Celebration) },
                         painter = { rememberAsyncImagePainter(url) },
                     ),
                     contentScale = ContentScale.Crop,

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorMapSideEventItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Celebration
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Link
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon


### PR DESCRIPTION
## Issue
- close #713 
## Overview (Required)
- I changed the placeholder image from "Person" to "Celebration" to convey the essence of the event.

## Links
- Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/69156255/036f7caa-eaa3-4f93-9b72-abc09f6cd198" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/69156255/c7e05ec3-e5d6-4014-b0b9-bcfaf4ddb422" width="300" />

