### PR TITLE
Localize "minute" in Japanese

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -81,7 +81,7 @@ public sealed class TimetableItem {
     private val minutesString: String by lazy {
         val minutes = (endsAt - startsAt)
             .toComponents { minutes, _, _ -> minutes }
-        "${minutes}min"
+        "$minutes" + MultiLangText(jaTitle = "分", enTitle = "min").currentLangTitle
     }
 
     public val formattedDateTimeString: String by lazy {


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Use "分" instead of "min" in `TimetableItemDetailSummaryCard` when the system language is Japanese.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/e3be4554-ab0d-42db-8ca8-c99e1a9bb06b" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/2ac7a33a-9b20-4e29-9063-bb3f89f9eef0" width="300" />
