### PR TITLE
Make filters in bookmark scrollable

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
@@ -1,8 +1,11 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,7 +37,9 @@ fun BookmarkFilters(
     onDayThirdChipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier) {
+    Row(modifier
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp)) {
         BookmarkFilterChip(
             labelText = SessionsStrings.BookmarkFilterAllChip.asString(),
             isSelected = isAll,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkFilters.kt
@@ -37,9 +37,11 @@ fun BookmarkFilters(
     onDayThirdChipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier
+    Row(
+        modifier
             .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp)) {
+            .padding(horizontal = 16.dp),
+    ) {
         BookmarkFilterChip(
             labelText = SessionsStrings.BookmarkFilterAllChip.asString(),
             isSelected = isAll,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkSheet.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -84,7 +83,7 @@ fun BookmarkSheet(
             onDayFirstChipClick = onDayFirstChipClick,
             onDaySecondChipClick = onDaySecondChipClick,
             onDayThirdChipClick = onDayThirdChipClick,
-            modifier = Modifier.padding(start = 16.dp),
+            modifier = Modifier,
         )
         when (uiState) {
             is Empty -> {


### PR DESCRIPTION
## Issue
- close #823

## Overview (Required)
- Made filters in bookmark screen scrollable.

## Links
- 

## Movie

Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/3529042/1322135c-5696-426b-9297-bc5ffa245173" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/3529042/79d24294-7234-4f6d-981e-3bf54fc4e29e" width="300" >

