### PR TITLE
Add License Description to About Screen

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
@@ -23,6 +23,7 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
     object License : AboutStrings()
     object PrivacyPolicy : AboutStrings()
     object AppVersion : AboutStrings()
+    object LicenceDescription : AboutStrings()
 
     private object Bindings : StringsBindings<AboutStrings>(
         Lang.Japanese to { item, _ ->
@@ -43,6 +44,7 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
                 License -> "ライセンス"
                 PrivacyPolicy -> "プライバシーポリシー"
                 AppVersion -> "アプリバージョン"
+                LicenceDescription -> "The Android robot is reproduced or modified from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License."
             }
         },
         Lang.English to { item, bindings ->
@@ -63,6 +65,7 @@ sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
                 License -> "License"
                 PrivacyPolicy -> "Privacy Policy"
                 AppVersion -> "App Version"
+                LicenceDescription -> bindings.defaultBinding(item, bindings)
             }
         },
         default = Lang.Japanese,

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutFooterLinks.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/component/AboutFooterLinks.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.about.component
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,6 +14,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.about.AboutStrings
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
@@ -23,6 +26,9 @@ import io.github.droidkaigi.confsched2023.feature.about.R.drawable
 const val AboutFooterLinksYouTubeItemTestTag = "AboutFooterLinksYouTubeItem"
 const val AboutFooterLinksXItemTestTag = "AboutFooterLinksXItem"
 const val AboutFooterLinksMediumItemTestTag = "AboutFooterLinksMediumItem"
+
+private val licenseDescriptionLight = Color(0xFF6D7256)
+private val licenseDescriptionDark = Color(0xFFFFFFFF)
 
 @Composable
 fun AboutFooterLinks(
@@ -71,6 +77,15 @@ fun AboutFooterLinks(
                 style = MaterialTheme.typography.labelLarge,
             )
         }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            modifier = Modifier.padding(horizontal = 12.dp),
+            text = AboutStrings.LicenceDescription.asString(),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            color = if (isSystemInDarkTheme()) licenseDescriptionDark else licenseDescriptionLight,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 


### PR DESCRIPTION
## Issue
- close #842 

## Overview (Required)
- I added License Description to About Screen, considering of dark mode.

## Links
- None

## Screenshot (Optional if screenshot test is present or unrelated to UI)
### Light Mode
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/105269911/f8e77523-48ee-4bc7-aedd-73f6c9e8ad4f" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/105269911/df601b2c-67ee-4ab2-b6a9-52a01487452c" width="300" />

### Dark Mode
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/105269911/ca486c3f-f1df-4296-9dcb-a1348e6f66b0" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/105269911/2ad3cb0c-8010-4fd8-a177-eff035d500b3" width="300" />