### PR TITLE
[iOS] add custom color scheme for dark mode

### DIFF
--- a/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall A.colorset/Contents.json
+++ b/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall A.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xD1",
+          "red" : "0xB2"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall B.colorset/Contents.json
+++ b/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall B.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0xDF",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall C.colorset/Contents.json
+++ b/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall C.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x92",
+          "green" : "0xBB",
+          "red" : "0xE7"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall D.colorset/Contents.json
+++ b/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall D.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xDD",
+          "green" : "0xDD",
+          "red" : "0xB4"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall E.colorset/Contents.json
+++ b/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall E.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBD",
+          "green" : "0xB9",
+          "red" : "0xB8"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall Text.colorset/Contents.json
+++ b/app-ios/Modules/Sources/Theme/Resources/Colors.xcassets/Custom/Hall Text.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- The rest of https://github.com/DroidKaigi/conference-app-2023/pull/777

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/88f31bf8-9d12-4142-9a39-6186886f45af" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/0e4f93ee-05fa-4cc4-968c-e96e45e3e44f" width="300" />
