### PR TITLE
Toggle icons when switching timetable style

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -37,6 +37,7 @@ import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.model.DroidKaigi2023Day
 import io.github.droidkaigi.confsched2023.model.Timetable
 import io.github.droidkaigi.confsched2023.model.TimetableItem
+import io.github.droidkaigi.confsched2023.model.TimetableUiType
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableTopArea
 import io.github.droidkaigi.confsched2023.sessions.component.rememberTimetableScreenScrollState
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableHeader
@@ -102,6 +103,7 @@ fun TimetableScreen(
 
 data class TimetableScreenUiState(
     val contentUiState: TimetableSheetUiState,
+    val timetableUiType: TimetableUiType,
 )
 
 private val timetableTopBackgroundLight = Color(0xFFF6FFD3)
@@ -165,6 +167,7 @@ private fun TimetableScreen(
         },
         topBar = {
             TimetableTopArea(
+                timetableUiType = uiState.timetableUiType,
                 onTimetableUiChangeClick,
                 onSearchClick,
                 onBookmarkIconClick,
@@ -223,6 +226,7 @@ fun PreviewTimetableScreenDark() {
                         ),
                     ),
                 ),
+                TimetableUiType.Grid,
             ),
             SnackbarHostState(),
             {},

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenViewModel.kt
@@ -87,6 +87,7 @@ class TimetableScreenViewModel @Inject constructor(
     ) { sessionListUiState ->
         TimetableScreenUiState(
             contentUiState = sessionListUiState,
+            timetableUiType = timetableUiTypeStateFlow.value,
         )
     }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -1,9 +1,10 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Bookmarks
+import androidx.compose.material.icons.outlined.GridView
+import androidx.compose.material.icons.outlined.ViewTimeline
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import io.github.droidkaigi.confsched2023.feature.sessions.R
+import io.github.droidkaigi.confsched2023.model.TimetableUiType
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.Bookmark
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.Search
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.Timetable
@@ -26,6 +28,7 @@ const val TimetableBookmarksIconTestTag = "TimetableBookmarksIconTestTag"
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun TimetableTopArea(
+    timetableUiType: TimetableUiType,
     onTimetableUiChangeClick: () -> Unit,
     onSearchClick: () -> Unit,
     onTopAreaBookmarkIconClick: () -> Unit,
@@ -63,7 +66,11 @@ fun TimetableTopArea(
                 onClick = { onTimetableUiChangeClick() },
             ) {
                 Icon(
-                    imageVector = Icons.Default.GridView,
+                    imageVector = if (timetableUiType != TimetableUiType.Grid) {
+                        Icons.Outlined.GridView
+                    } else {
+                        Icons.Outlined.ViewTimeline
+                    },
                     contentDescription = Timetable.asString(),
                 )
             }


### PR DESCRIPTION
## Issue
- close #379 

## Overview (Required)
- Implemented a timeline grid/list switching icon display.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/0028da7e-fbe4-4e82-952f-7f7eec2787c5" width="300" > | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/0dc84ce4-7cc9-4fbb-a465-2b78757d384d" width="300" >
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/1c57d683-4158-4371-8264-df3399d9a166" width="300" > | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/7c707904-ab47-455a-8e14-8fe738a40655" width="300" >
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/b47664a4-e995-4528-82fd-fbd6dbf8bf53" width="300" > | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/11ebf771-fc04-41fd-9f40-bafbbe6351e3" width="300" >
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/eaef5d54-7540-4778-a8ce-2eff883708ee" width="300" > | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3450119/924a888c-5bc2-4425-9d84-a7f818fe4a98" width="300" >
