### PR TITLE
Introduce PreviewParameter to FloorLevelSwitcher

### DIFF
--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorLevelSwitcher.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/FloorLevelSwitcher.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
@@ -108,28 +109,15 @@ private fun FloorLevelSwitcherButton(
     }
 }
 
-// TODO Use PreviewParameterProvider to display the Preview once the Linter issue is resolved.
-// https://github.com/DroidKaigi/conference-app-2023/pull/557#discussion_r1295780974
 @MultiThemePreviews
 @Composable
-fun FloorLevelSwitcherGroundPreview() {
+internal fun FloorLevelSwitcherPreview(
+    @PreviewParameter(PreviewFloorMapSwitcherFloorLevelProvider::class) floorLevel: FloorLevel,
+) {
     KaigiTheme {
         Surface {
             FloorLevelSwitcher(
-                selectingFloorLevel = FloorLevel.Ground,
-                onClickFloorLevelSwitcher = {},
-            )
-        }
-    }
-}
-
-@MultiThemePreviews
-@Composable
-fun FloorLevelSwitcherBasementPreview() {
-    KaigiTheme {
-        Surface {
-            FloorLevelSwitcher(
-                selectingFloorLevel = FloorLevel.Basement,
+                selectingFloorLevel = floorLevel,
                 onClickFloorLevelSwitcher = {},
             )
         }

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/PreviewFloorMapSwitcherFloorLevelProvider.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/PreviewFloorMapSwitcherFloorLevelProvider.kt
@@ -1,0 +1,9 @@
+package io.github.droidkaigi.confsched2023.floormap.component
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.github.droidkaigi.confsched2023.model.FloorLevel
+
+class PreviewFloorMapSwitcherFloorLevelProvider : PreviewParameterProvider<FloorLevel> {
+    override val values: Sequence<FloorLevel>
+        get() = FloorLevel.values().asSequence()
+}


### PR DESCRIPTION
## Issue
- close #824

## Overview (Required)
- use PreviewParameter to preview each floor's component instead of defining each preview function

## Links
- https://github.com/DroidKaigi/conference-app-2023/blob/main/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/PreviewTimeTableItemRoomProvider.kt
- https://github.com/DroidKaigi/conference-app-2023/blob/main/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt#L341-L355

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/0ceab79a-8d1e-46ea-8aa5-74f3d5fa0a5c" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/c8e6b6c1-7665-4c5d-8382-84780bc112fb" width="300" />

