### PR TITLE
Replace TimetableList time border text to box

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -1,9 +1,12 @@
 package io.github.droidkaigi.confsched2023.sessions.section
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -11,6 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
@@ -94,7 +98,12 @@ fun TimetableList(
                             text = timetableItem.startsTimeString,
                             fontWeight = FontWeight.Medium,
                         )
-                        Text(text = "|")
+                        Box(
+                            modifier = Modifier
+                                .height(16.dp)
+                                .width(1.dp)
+                                .background(MaterialTheme.colorScheme.onSurfaceVariant)
+                        )
                         Text(
                             text = timetableItem.endsTimeString,
                         )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -92,7 +92,10 @@ fun TimetableList(
                     Spacer(modifier = Modifier.size(6.dp))
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
+                        verticalArrangement = Arrangement.spacedBy(
+                            space = 4.dp,
+                            alignment = Alignment.CenterVertically,
+                        )
                     ) {
                         Text(
                             text = timetableItem.startsTimeString,
@@ -100,7 +103,7 @@ fun TimetableList(
                         )
                         Box(
                             modifier = Modifier
-                                .height(16.dp)
+                                .height(12.dp)
                                 .width(1.dp)
                                 .background(MaterialTheme.colorScheme.onSurfaceVariant)
                         )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
@@ -95,7 +94,7 @@ fun TimetableList(
                         verticalArrangement = Arrangement.spacedBy(
                             space = 4.dp,
                             alignment = Alignment.CenterVertically,
-                        )
+                        ),
                     ) {
                         Text(
                             text = timetableItem.startsTimeString,
@@ -105,7 +104,7 @@ fun TimetableList(
                             modifier = Modifier
                                 .height(12.dp)
                                 .width(1.dp)
-                                .background(MaterialTheme.colorScheme.onSurfaceVariant)
+                                .background(MaterialTheme.colorScheme.onSurfaceVariant),
                         )
                         Text(
                             text = timetableItem.endsTimeString,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -102,9 +102,9 @@ fun TimetableList(
                         )
                         Box(
                             modifier = Modifier
-                                .height(12.dp)
-                                .width(1.dp)
-                                .background(MaterialTheme.colorScheme.onSurfaceVariant),
+                                .height(8.dp)
+                                .width(2.dp)
+                                .background(MaterialTheme.colorScheme.outlineVariant),
                         )
                         Text(
                             text = timetableItem.endsTimeString,


### PR DESCRIPTION
## Issue
- closes #840
- closes #833

## Overview (Required)
- Replace `TimetableList` time border text to box

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/45708639/262032415-47484ee4-76fa-4b97-8dfb-3474e2df40be.png" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/38a91db5-14e2-4b78-b9f3-9a8e29795699" width="300" />

