### PR TITLE
Use gradlePluginPortal()

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -9,9 +9,7 @@ group = "io.github.droidkaigi.confsched2023.buildlogic"
 repositories {
     google()
     mavenCentral()
-    maven {
-        url = uri("https://plugins.gradle.org/m2/")
-    }
+    gradlePluginPortal()
 }
 
 // If we use jvmToolchain, we need to install JDK 11


### PR DESCRIPTION
## Issue
- none.

## Overview (Required)
- Use `gradlePluginPortal()` for simplicity.
