### PR TITLE
:wrench: Fixed speaker icon size smaller than current.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableListItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableListItem.kt
@@ -131,7 +131,7 @@ fun TimetableListItem(
                         },
                         contentDescription = null,
                         modifier = Modifier
-                            .size(40.dp)
+                            .size(32.dp)
                             .clip(RoundedCornerShape(12.dp))
                             .border(
                                 BorderStroke(1.dp, md_theme_light_outline),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableShimmerListItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableShimmerListItem.kt
@@ -56,7 +56,7 @@ fun TimetableShimmerListItem(modifier: Modifier = Modifier) {
             //  Shimmer effect on bottom(right)
             Box(
                 modifier = Modifier
-                    .height(40.dp)
+                    .height(32.dp)
                     .width(80.dp)
                     .shimmer(shimmerInstance)
                     .background(Color.LightGray),


### PR DESCRIPTION
## Issue
- close #831 

## Overview (Required)
- Speaker icon size was changed from 40dp to 32dp according to Figma

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/a3012dde-6690-45b4-8d2a-8c705c2ac596" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/5286e933-c41d-4fa4-8c5d-c7cb97eec1f6" width="300" />