### PR TITLE
[feature/robot_padding]: change robot padding

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -191,7 +191,7 @@ private fun TimetableScreen(
             TimetableSheet(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = 130.dp)
+                    .padding(top = 131.dp)
                     .layout { measurable, constraints ->
                         val placeable = measurable.measure(
                             constraints.copy(maxHeight = constraints.maxHeight - state.sheetScrollOffset.roundToInt()),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableHeader.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableHeader.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,11 +20,10 @@ import io.github.droidkaigi.confsched2023.feature.sessions.R
 @Composable
 fun TimetableHeader(modifier: Modifier = Modifier) {
     Row(
-        modifier = modifier
-            .height(168.dp),
+        modifier = modifier.wrapContentSize(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(Modifier.padding(start = 16.dp)) {
+        Column(Modifier.padding(horizontal = 16.dp)) {
             Text(text = "DroidKaigi\n2023", style = MaterialTheme.typography.displaySmall)
             Spacer(modifier = Modifier.height(2.dp))
             Text(
@@ -32,7 +32,7 @@ fun TimetableHeader(modifier: Modifier = Modifier) {
             )
         }
         Image(
-            modifier = Modifier.size(width = 212.dp, height = 168.dp),
+            modifier = Modifier.size(width = 185.dp, height = 169.dp),
             painter = painterResource(id = R.drawable.img_droid_kun_in_bath),
             contentDescription = null,
         )


### PR DESCRIPTION
## Issue
- close #830 

## Overview (Required)
- Change Robot Image Padding
- Change TimeTableHeader Padding

<img src="https://github.com/DroidKaigi/conference-app-2023/assets/93872496/9a7c99f9-ea4b-44df-9d4e-4c8e51511ac5" width="300" />

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/93872496/b34a5443-5ee6-453f-87c8-5778c6901a81" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/93872496/89009310-fb17-418f-9877-9bcd58e78fd2" width="300" />
