### PR TITLE
Add Screenshot Test for read more expansion of TimetableItemDetailScreen

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/FakeSessionsApiClient.kt
@@ -95,8 +95,8 @@ fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
                         en = "DroidKaigi App Architecture day$day room${room.name.en} index$index",
                     ),
                     speakers = listOf("1", "2"),
-                    description = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n"
-                       + "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
+                    description = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n" +
+                        "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
                     startsAt = start.toString(),
                     endsAt = end.toString(),
                     language = "JAPANESE",

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/FakeSessionsApiClient.kt
@@ -95,7 +95,8 @@ fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
                         en = "DroidKaigi App Architecture day$day room${room.name.en} index$index",
                     ),
                     speakers = listOf("1", "2"),
-                    description = "これはディスクリプションです。\nこれはディスクリプションです。",
+                    description = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n"
+                       + "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
                     startsAt = start.toString(),
                     endsAt = end.toString(),
                     language = "JAPANESE",

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableItemDetailScreenRobot.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
 import com.github.takahirom.roborazzi.Dump
@@ -15,6 +16,7 @@ import io.github.droidkaigi.confsched2023.data.sessions.response.SessionsAllResp
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.sessions.TimetableItemDetailScreen
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailBookmarkIconTestTag
+import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailReadMoreButtonTestTag
 import io.github.droidkaigi.confsched2023.testing.RobotTestRule
 import io.github.droidkaigi.confsched2023.testing.coroutines.runTestWithLogging
 import kotlinx.coroutines.test.TestDispatcher
@@ -53,6 +55,19 @@ class TimetableItemDetailScreenRobot @Inject constructor(
             .onNode(hasTestTag(TimetableItemDetailBookmarkIconTestTag))
             .performClick()
         waitUntilIdle()
+    }
+
+    fun scrollToDescription() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableItemDetailReadMoreButtonTestTag))
+            .performScrollTo()
+        scroll()
+    }
+
+    fun clickReadMoreButton() {
+        composeTestRule
+            .onNode(hasTestTag(TimetableItemDetailReadMoreButtonTestTag))
+            .performClick()
     }
 
     fun scroll() {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -54,6 +55,8 @@ import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
 import io.github.droidkaigi.confsched2023.ui.previewOverride
 import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
 import kotlinx.collections.immutable.PersistentList
+
+const val TimetableItemDetailReadMoreButtonTestTag = "TimetableItemDetailReadMoreButtonTestTag"
 
 @Composable
 fun TimetableItemDetailContent(
@@ -108,7 +111,9 @@ private fun DescriptionSection(
             if (!isExpanded) {
                 ReadMoreOutlinedButton(
                     onClick = { isExpanded = true },
-                    modifier = Modifier.padding(top = 16.dp, start = 16.dp, end = 16.dp),
+                    modifier = Modifier
+                        .testTag(TimetableItemDetailReadMoreButtonTestTag)
+                        .padding(top = 16.dp, start = 16.dp, end = 16.dp),
                 )
             }
             BorderLine(modifier = Modifier.padding(top = 24.dp))

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
@@ -69,6 +69,18 @@ class TimetableItemDetailScreenTest {
 
     @Test
     @Category(ScreenshotTests::class)
+    fun checkReadMoreExpansionShot() {
+        timetableItemDetailScreenRobot {
+            setupScreenContent()
+            scrollToDescription()
+            checkScreenCapture()
+            clickReadMoreButton()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
     fun checkScrollShot() {
         timetableItemDetailScreenRobot {
             setupScreenContent()


### PR DESCRIPTION
## Issue
- close #630

## Overview (Required)
- Added Screenshot Test for read more expansion of TimetableItemDetailScreen.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/52788246/2ea9ea51-af36-45d3-9376-32e5dcc8aa32" width="300" />
<img src="" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/52788246/c38301dc-c051-404e-ab63-851db7ea7d38" width="300" />
