### PR TITLE
Remove duplicate padding on SearchList

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt
@@ -58,9 +58,7 @@ fun SearchList(
     LazyColumn(
         state = scrollState,
         contentPadding = contentPaddingValues,
-        modifier = modifier
-            .imePadding()
-            .padding(start = 16.dp),
+        modifier = modifier.imePadding(),
     ) {
         itemsIndexed(searchListUiState.timetableItems) { index, timetableItem ->
             var rowHeight by remember { mutableIntStateOf(0) }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Remove the extra padding on the SearchList.

Sorry, the padding were added by me at #808 . That was duplicated with other fixes. 🙇 
Please remove the padding I added and make use of the margins on the `Row` .
That `Row` is also used on other screens, so that will keep it more consistent.

https://github.com/DroidKaigi/conference-app-2023/blob/84b7c041973b7d8fb3c1bae62e251ddc6c361f49/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/SearchList.kt#L81

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
![adbeem-20230823004736](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/ea2cf1d9-66be-412f-a437-4e6aed573891)|![adbeem-20230823004643](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/15f836ec-d51f-4369-b1fe-5422f20511b3)
![adbeem-20230823004750](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/0c04f6c3-72e1-462d-bb81-ae9aff265969)|![adbeem-20230823004845](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/c68a2249-f523-4a46-82d6-6560aaf54f73)


## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
