### PR TITLE
Remove bookmarkList padding

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/BookmarkList.kt
@@ -48,7 +48,7 @@ fun BookmarkList(
     val density = LocalDensity.current
     LazyColumn(
         state = scrollState,
-        modifier = modifier.padding(end = 16.dp),
+        modifier = modifier,
     ) {
         itemsIndexed(timetableItemMap.toList(), key = { _, (key, _) -> key }) { index, (_, values) ->
             var rowHeight by remember { mutableIntStateOf(0) }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fixed BookmarkList padding based on Figma's design
  - padding end is none

<img src="https://github.com/DroidKaigi/conference-app-2023/assets/39705795/93347c45-fbf4-4f9c-955e-25bf5716378a" width="300" />

## Links
- figma
  - https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=54902-40572&mode=dev

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
![adbeem-20230823005913](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/5d5bfebd-44c6-45d4-9b1d-31e00c4227bf)|![adbeem-20230823010544](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/81929740-9806-402e-88aa-1d0a35cfc3a2)
![adbeem-20230823005921](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/2bb68e62-8bf7-4b86-b59e-45934a7f3853)|![adbeem-20230823010549](https://github.com/DroidKaigi/conference-app-2023/assets/39705795/bd955e7b-d644-4429-962b-718c6e031981)



## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
