### PR TITLE
[iOS] Add rounded top corners to the timetable

### DIFF
--- a/app-ios/Modules/Sources/Component/RoundedCornersShape.swift
+++ b/app-ios/Modules/Sources/Component/RoundedCornersShape.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+public struct RoundedCornersShape: Shape {
+    public var corners: UIRectCorner
+    public var cornerSize: CGSize
+
+    public init(corners: UIRectCorner = .allCorners, cornerSize: CGSize) {
+        self.corners = corners
+        self.cornerSize = cornerSize
+    }
+
+    public init(corners: UIRectCorner = .allCorners, cornerRadius: CGFloat) {
+        self.corners = corners
+        self.cornerSize = CGSize(width: cornerRadius, height: cornerRadius)
+    }
+
+    public func path(in rect: CGRect) -> Path {
+        Path(UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: cornerSize).cgPath)
+    }
+}

--- a/app-ios/Modules/Sources/Timetable/TimetableView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableView.swift
@@ -1,4 +1,5 @@
 import Assets
+import Component
 import Model
 import shared
 import SwiftUI
@@ -61,6 +62,7 @@ public struct TimetableView<SessionView: View>: View {
                             }
                         }
                         .background(AssetColors.Surface.surface.swiftUIColor)
+                        .clipShape(RoundedCornersShape(corners: [.topLeft, .topRight], cornerRadius: 40))
                     }
                     .navigationDestination(for: TimetableRouting.self) { routing in
                         switch routing {


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR adds rounded top corners to the timetable

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/48dcd0a7-6e21-4ff2-b2ee-ed4eb58a3802" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/26bd9c84-62c7-4227-bee0-3a2ea94d5dba" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >