### PR TITLE
:recycle: Set margin for the SideEventList only when screen end

### DIFF
--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/section/FloorMapSideEventList.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/section/FloorMapSideEventList.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2023.floormap.section
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -9,6 +11,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.floormap.component.FloorMapSideEventItem
 import io.github.droidkaigi.confsched2023.model.SideEvent
 import kotlinx.collections.immutable.ImmutableList
@@ -29,6 +32,9 @@ fun FloorMapSideEventList(
                 sideEvent = sideEvent,
                 onSideEventClick = onSideEventClick,
             )
+        }
+        item {
+            Spacer(modifier = Modifier.height(80.dp))
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #829 

## Overview (Required)
- The title says it all.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/648f0589-3f7f-483c-9c77-99cd7b746706" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/a4facc49-98e0-4536-9793-b519887d0abf" width="300" >





