### PR TITLE
Sort sessions by name in RoomResponse

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
@@ -81,12 +81,9 @@ internal fun SessionsAllResponse.toTimetable(): Timetable {
         .associateBy(
             keySelector = { room -> room.id },
             valueTransform = { room ->
-                val roomSorts = timetableContents.rooms.map { it.sort }.sorted()
                 TimetableRoom(
                     id = room.id,
                     name = room.name.toMultiLangText(),
-                    sort = room.sort,
-                    sortIndex = roomSorts.indexOf(room.sort),
                     type = room.name.toRoomType(),
                 )
             },
@@ -141,7 +138,7 @@ internal fun SessionsAllResponse.toTimetable(): Timetable {
             }
                 .sortedWith(
                     compareBy<TimetableItem> { it.startsAt }
-                        .thenBy { it.room.sort },
+                        .thenBy { it.room.name.currentLangTitle },
                 )
                 .toPersistentList(),
         ),

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/FakeSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/FakeSessionsApiClient.kt
@@ -49,10 +49,10 @@ fun SessionsAllResponse.Companion.fake(): SessionsAllResponse {
         SpeakerResponse(fullName = "ry", id = "2", isTopSpeaker = true),
     )
     val rooms = listOf(
-        RoomResponse(name = LocaledResponse(ja = "Chipmunk ja", en = "Chipmunk"), id = 1, sort = 1),
-        RoomResponse(name = LocaledResponse(ja = "Arctic Fox ja", en = "Arctic Fox"), id = 2, sort = 2),
-        RoomResponse(name = LocaledResponse(ja = "Bumblebee ja", en = "Bumblebee"), id = 3, sort = 3),
-        RoomResponse(name = LocaledResponse(ja = "Dolphin ja", en = "Dolphin"), id = 4, sort = 4),
+        RoomResponse(name = LocaledResponse(ja = "Chipmunk ja", en = "Chipmunk"), id = 1),
+        RoomResponse(name = LocaledResponse(ja = "Arctic Fox ja", en = "Arctic Fox"), id = 2),
+        RoomResponse(name = LocaledResponse(ja = "Bumblebee ja", en = "Bumblebee"), id = 3),
+        RoomResponse(name = LocaledResponse(ja = "Dolphin ja", en = "Dolphin"), id = 4),
     )
     val categories = listOf(
         CategoryResponse(

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/response/RoomResponse.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/response/RoomResponse.kt
@@ -6,5 +6,4 @@ import kotlinx.serialization.Serializable
 data class RoomResponse(
     val name: LocaledResponse,
     val id: Int,
-    val sort: Int,
 )

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Timetable.kt
@@ -28,7 +28,7 @@ public data class Timetable(
     }
 
     val rooms: List<TimetableRoom> by lazy {
-        timetableItems.map { it.room }.toSet().sortedBy { it.sort }
+        timetableItems.map { it.room }.toSet().sortedBy { it.name.currentLangTitle }
     }
 
     val categories: List<TimetableCategory> by lazy {
@@ -103,11 +103,11 @@ public fun Timetable?.orEmptyContents(): Timetable = this ?: Timetable()
 
 public fun Timetable.Companion.fake(): Timetable {
     val rooms = mutableListOf(
-        TimetableRoom(1, MultiLangText("Arctic Fox", "Arctic Fox"), 0, 0, RoomA),
-        TimetableRoom(2, MultiLangText("Bumblebee", "Bumblebee"), 1, 1, RoomB),
-        TimetableRoom(3, MultiLangText("Chipmunk", "Chipmunk"), 2, 2, RoomC),
-        TimetableRoom(4, MultiLangText("Dolphin", "Dolphin"), 3, 3, RoomD),
-        TimetableRoom(5, MultiLangText("Electric Eel", "Electric Eel"), 4, 4, RoomE),
+        TimetableRoom(1, MultiLangText("Arctic Fox", "Arctic Fox"), RoomA),
+        TimetableRoom(2, MultiLangText("Bumblebee", "Bumblebee"), RoomB),
+        TimetableRoom(3, MultiLangText("Chipmunk", "Chipmunk"), RoomC),
+        TimetableRoom(4, MultiLangText("Dolphin", "Dolphin"), RoomD),
+        TimetableRoom(5, MultiLangText("Electric Eel", "Electric Eel"), RoomE),
     )
     repeat(10) {
         rooms += rooms

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -127,8 +127,6 @@ public fun Session.Companion.fake(): Session {
         room = TimetableRoom(
             id = 1,
             name = MultiLangText("Room1", "Room2"),
-            sort = 1,
-            sortIndex = 0,
             type = RoomA,
         ),
         targetAudience = "For App developer アプリ開発者向け",

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableRoom.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableRoom.kt
@@ -3,8 +3,6 @@ package io.github.droidkaigi.confsched2023.model
 public data class TimetableRoom(
     val id: Int,
     val name: MultiLangText,
-    val sort: Int,
-    val sortIndex: Int,
     val type: RoomType,
 )
 


### PR DESCRIPTION
## Issue
- close #633

## Overview (Required)
- Sort sessions by name in RoomResponse.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
The following is when the system language is Japanese.

Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/c4e85daa-d0ec-4855-9d3d-08b2437572b5" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/67e5abb6-6743-4909-8c96-580701287cf9" width="300" />

The following is when the system language is English.
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/ec37b0db-cb8f-4ea7-9e58-a66a8fbbce41" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/1838962/31ce25e8-a9b0-41d7-807e-8f1b7c104224" width="300" />