### PR TITLE
use Activity.enableEdgeToEdge(...)

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -94,7 +94,6 @@ dependencies {
     implementation(libs.composeNavigation)
     implementation(libs.composeHiltNavigtation)
     implementation(libs.composeMaterialWindowSize)
-    implementation(libs.accompanistSystemUiController)
     implementation(libs.androidxBrowser)
     implementation(libs.androidxWindow)
     implementation(libs.kermit)

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -9,13 +9,11 @@ import android.os.Build
 import android.provider.CalendarContract
 import androidx.annotation.RequiresApi
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -82,12 +80,6 @@ fun KaigiApp(
     modifier: Modifier = Modifier,
 ) {
     KaigiTheme {
-        val useDarkIcons = !isSystemInDarkTheme()
-
-        DisposableEffect(useDarkIcons) {
-            onDispose {}
-        }
-
         Surface(
             modifier = modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
@@ -30,7 +29,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.window.layout.DisplayFeature
 import co.touchlab.kermit.Logger
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.github.droidkaigi.confsched2023.about.aboutScreenRoute
 import io.github.droidkaigi.confsched2023.about.navigateAboutScreen
 import io.github.droidkaigi.confsched2023.about.nestedAboutScreen
@@ -84,11 +82,9 @@ fun KaigiApp(
     modifier: Modifier = Modifier,
 ) {
     KaigiTheme {
-        val systemUiController = rememberSystemUiController()
         val useDarkIcons = !isSystemInDarkTheme()
 
-        DisposableEffect(systemUiController, useDarkIcons) {
-            systemUiController.setSystemBarsColor(Color.Transparent, useDarkIcons)
+        DisposableEffect(useDarkIcons) {
             onDispose {}
         }
 

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/MainActivity.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/MainActivity.kt
@@ -3,13 +3,13 @@ package io.github.droidkaigi.confsched2023
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
-import androidx.core.view.WindowCompat
 import androidx.window.layout.DisplayFeature
 import androidx.window.layout.WindowInfoTracker
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,7 +23,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        enableEdgeToEdge()
 
         setContent {
             val windowSize = calculateWindowSizeClass(this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ compose-jb = "1.4.3"
 composeCompiler = "1.5.1"
 composeHiltNavigatiaon = "1.0.0"
 androidxLifecycle = "2.6.1"
-androidxActivity = "1.7.2"
+androidxActivity = "1.8.0-alpha06"
 androidxFragment = "1.6.1"
 kotlinxCoroutines = "1.7.3"
 accompanist = "0.30.1"
@@ -85,7 +85,6 @@ composeHiltNavigtation = { module = "androidx.hilt:hilt-navigation-compose", ver
 composeLintCheck = { module = "com.slack.lint.compose:compose-lint-checks", version = "1.2.0" }
 composeCoil = { module = "io.coil-kt:coil-compose", version = "2.4.0" }
 composeImageLoader = { module = "io.github.qdsfdhvh:image-loader", version = "1.6.4" }
-accompanistSystemUiController = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 composeShimmer = { module = "com.valentinilk.shimmer:compose-shimmer", version = "1.0.5" }
 
 androidxFragment = { module = "androidx.fragment:fragment", version.ref = "androidxFragment" }


### PR DESCRIPTION
## Issue
- close #909

## Overview (Required)
- As written in Issue, use Activity.enableEdgeToEdge(...) instead of using WindowCompat / SystemUiController

## Links
- https://github.com/android/nowinandroid/commit/2b218b97d959d79268bb0883a9e31ebcea18cb82

## Screenshot (Optional if screenshot test is present or unrelated to UI)
※Expect: No diff arround the system bar and the navigation bar
api | Before | After
:--: | :--: | :--:
34 | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/040bce8e-9199-4362-8e6c-8fd531169f33" width="150" /><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/9e776389-3921-47ad-94ff-298e016a313d" width="150"><br><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/362694c1-f527-45c4-b448-11d87646e30d" width="150"><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/d16185b3-732c-40d3-b06b-8df7c12e95f8" width="150"> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/d7bfc4e4-0d82-4dfc-a66c-76f37c88af41" width="150" /><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/cb906ea4-2634-42e4-b0aa-7923e5449ea3" width="150"><br><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/743df29d-b19a-4a7d-a018-1d8053ca5022" width="150"><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/b5c9c040-d835-419f-ac21-7dda7eed5c36" width="150">
23 | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/d69af94c-f8e0-4114-aa50-ef9a64382ed3" width="150"><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/04f8ef25-4c4f-45c1-a753-17536d1f671e" width="150">  | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/482aa0ab-9e88-4d75-96c9-56c4070bb98d" width="150"><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/eae272db-9c1f-4b3f-8c08-193b2e5fd707" width="150"> 


