### PR TITLE
Tweak layout spacing for the timetable screen tabs

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
@@ -89,7 +89,7 @@ fun TimetableTabIndicator(
     Box(
         modifier
             .zIndex(-1f)
-            .padding(horizontal = 8.dp)
+            .padding(horizontal = tabIndicatorHorizontalSpacing)
             .fillMaxSize()
             .background(
                 color = MaterialTheme.colorScheme.primary,
@@ -114,7 +114,9 @@ fun TimetableTabRow(
 ) {
     TabRow(
         selectedTabIndex = selectedTabIndex,
-        modifier = modifier.height(maxTabRowHeight - ((maxTabRowHeight - minTabRowHeight) * tabState.tabCollapseProgress)),
+        modifier = modifier
+            .height(maxTabRowHeight - ((maxTabRowHeight - minTabRowHeight) * tabState.tabCollapseProgress))
+            .padding(horizontal = tabRowHorizontalSpacing),
         divider = {},
         indicator = indicator,
         tabs = tabs,
@@ -179,8 +181,11 @@ class TimetableTabState(
 }
 
 private val minTabHeight = 32.dp
+private val baselineTabHeight = 56.dp
 private val maxTabRowHeight = 84.dp
 private val minTabRowHeight = 56.dp
+private val tabIndicatorHorizontalSpacing = 8.dp
+private val tabRowHorizontalSpacing = (maxTabRowHeight - baselineTabHeight) / 2 - tabIndicatorHorizontalSpacing
 
 @MultiThemePreviews
 @MultiLanguagePreviews


### PR DESCRIPTION
## Overview (Required)

Tweak spacing around tabs on the timetable screen.

## Links

- [DroidKaigi 2023 App UI – Figma > Timetable/List/FV](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56145-49559&mode=design&t=7a5a3LtVLzDym3kX-4)

## Screenshot
Before | After
:--: | :--:
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/8f7d5398-76e1-45e7-a451-94b208fae7dc" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/5ef13ca7-969b-4e83-b6e6-13ca66a262de" width="300" /> |
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/05a497e7-41bd-4708-95de-89aeac2fff7c" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/06b0b6f8-fac2-4351-9253-69e190ca930a" width="300" /> |