### PR TITLE
Tweak layout spacing for the timetable screen tabs - 2

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
@@ -77,7 +77,7 @@ fun TimetableTab(
         },
         selectedContentColor = MaterialTheme.colorScheme.onPrimary,
         unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = modifier.heightIn(min = minTabHeight),
+        modifier = modifier.heightIn(min = tabMinHeight, max = tabMaxHeight),
     )
 }
 
@@ -88,7 +88,7 @@ fun TimetableTabIndicator(
     Box(
         modifier
             .zIndex(-1f)
-            .padding(horizontal = tabIndicatorHorizontalSpacing)
+            .padding(horizontal = tabIndicatorHorizontalGap / 2)
             .fillMaxSize()
             .background(
                 color = MaterialTheme.colorScheme.primary,
@@ -114,8 +114,13 @@ fun TimetableTabRow(
     TabRow(
         selectedTabIndex = selectedTabIndex,
         modifier = modifier
-            .height(maxTabRowHeight - ((maxTabRowHeight - minTabRowHeight) * tabState.tabCollapseProgress))
-            .padding(horizontal = tabRowHorizontalSpacing),
+            .height(tabRowMaxHeight - ((tabRowMaxHeight - tabRowMinHeight) * tabState.tabCollapseProgress))
+            .padding(
+                start = tabRowHorizontalSpacing,
+                top = tabRowTopSpacing,
+                end = tabRowHorizontalSpacing,
+                bottom = tabRowBottomSpacing,
+            ),
         divider = {},
         indicator = indicator,
         tabs = tabs,
@@ -123,12 +128,13 @@ fun TimetableTabRow(
 }
 
 @Composable
-fun rememberTimetableTabState(): TimetableTabState {
+fun rememberTimetableTabState(initialScrollOffset: Float = 0.0f): TimetableTabState {
     val offsetLimit = LocalDensity.current.run {
-        (maxTabRowHeight - minTabRowHeight).toPx()
+        (tabRowMaxHeight - tabRowMinHeight).toPx()
     }
     return rememberSaveable(saver = TimetableTabState.Saver) {
         TimetableTabState(
+            initialScrollOffset = initialScrollOffset,
             initialOffsetLimit = -offsetLimit,
         )
     }
@@ -179,12 +185,16 @@ class TimetableTabState(
     }
 }
 
-private val minTabHeight = 32.dp
-private val baselineTabHeight = 56.dp
-private val maxTabRowHeight = 84.dp
-private val minTabRowHeight = 56.dp
-private val tabIndicatorHorizontalSpacing = 8.dp
-private val tabRowHorizontalSpacing = (maxTabRowHeight - baselineTabHeight) / 2 - tabIndicatorHorizontalSpacing
+private val tabMinHeight = 32.dp
+private val tabMaxHeight = 56.dp
+
+private val tabIndicatorHorizontalGap = 8.dp
+
+private val tabRowHorizontalSpacing = 16.dp - (tabIndicatorHorizontalGap / 2)
+private val tabRowTopSpacing = 16.dp
+private val tabRowBottomSpacing = 12.dp
+private val tabRowMinHeight = tabMinHeight + tabRowTopSpacing + tabRowBottomSpacing
+private val tabRowMaxHeight = tabMaxHeight + tabRowTopSpacing + tabRowBottomSpacing
 
 @MultiThemePreviews
 // @MultiLanguagePreviews

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.model.DroidKaigi2023Day
@@ -188,7 +187,7 @@ private val tabIndicatorHorizontalSpacing = 8.dp
 private val tabRowHorizontalSpacing = (maxTabRowHeight - baselineTabHeight) / 2 - tabIndicatorHorizontalSpacing
 
 @MultiThemePreviews
-@MultiLanguagePreviews
+// @MultiLanguagePreviews
 @Composable
 fun TimetableTabPreview() {
     KaigiTheme {
@@ -199,6 +198,55 @@ fun TimetableTabPreview() {
                 onClick = {},
                 scrollState = rememberTimetableTabState(),
             )
+        }
+    }
+}
+
+@MultiThemePreviews
+// @MultiLanguagePreviews
+@Composable
+fun TimetableTabRowPreview() {
+    val scrollState = rememberTimetableTabState()
+    val selectedTabIndex = 0
+    KaigiTheme {
+        Surface {
+            TimetableTabRow(tabState = scrollState, selectedTabIndex = selectedTabIndex) {
+                DroidKaigi2023Day.entries.forEachIndexed { index, day ->
+                    TimetableTab(
+                        day = day,
+                        selected = selectedTabIndex == index,
+                        onClick = {},
+                        scrollState = scrollState,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@MultiThemePreviews
+// @MultiLanguagePreviews
+@Composable
+fun CollapsedTimetableTabRowPreview() {
+    val scrollState = rememberSaveable(saver = TimetableTabState.Saver) {
+        TimetableTabState(
+            initialScrollOffset = -1.0f,
+            initialOffsetLimit = -1.0f,
+        )
+    }
+    val selectedTabIndex = 0
+    KaigiTheme {
+        Surface {
+            TimetableTabRow(tabState = scrollState, selectedTabIndex = selectedTabIndex) {
+                DroidKaigi2023Day.entries.forEachIndexed { index, day ->
+                    TimetableTab(
+                        day = day,
+                        selected = index == selectedTabIndex,
+                        onClick = {},
+                        scrollState = scrollState,
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue
n/a

## Overview (Required)

This PR amends my previous PR #911. It is now compliant the UI design spec :wink: 

Note that I have not changed the implementation for large screen devices, so #872 is not resolved yet.

### :memo: Discussion with @takahirom in the previous PR

ref.) https://github.com/DroidKaigi/conference-app-2023/pull/911#discussion_r1303160775

> Tabs are already vertically center aligned to the parent container element (TabRow), so I thought the horizontal spacing size should be the same as the vertical ones.
> 
> However, I noticed my mistake after this PR getting merged. (Sorry!) I checked the UI design spec (Figma) and it says a bit different layout constraints specified to Tabs and TabRow. They are not vertically aligned and the bottom padding amount is less than other directions.
> 
> I'm going to create a PR to match the implementation with the UI design spec later. 
> <img src="https://user-images.githubusercontent.com/2552365/262712708-3e96a888-f82c-48b7-825f-1f9b42ace0a3.png" width="400" />

## Links

- [DroidKaigi 2023 App UI – Figma > Timetable/List/FV](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56145-49559&mode=design&t=7a5a3LtVLzDym3kX-4)
- [DroidKaigi 2023 App UI – Figma > Timetable/List/Scroll-3](https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56145-49616&mode=design&t=1ynYiD1m9fkZAb1p-4)

## Screenshot
| Before | After |
:--: | :--:
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/770b2d8c-62c2-4ff2-bf11-99875510141e" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/21f06e44-2531-4e8f-a9f3-c14e99d67f00" width="300" /> |
| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/2e7c0e8c-5b53-476d-ac36-efd3f4be23a6" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2552365/d6d30831-6877-4d08-90c4-6b10d88c8b39" width="300" /> |
