### PR TITLE
Replace a deprecated detekt rule

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -61,7 +61,7 @@ style:
   ClassOrdering:
     active: true
   # Multi-line if statements force curly braces
-  MandatoryBracesIfStatements:
+  BracesOnIfStatements:
     active: true
   # Multiline for, while... forces curly braces
   MandatoryBracesLoops:


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR replaces a deprecated detekt rule to resolve the following warning:

```
Property 'style>MandatoryBracesIfStatements' is deprecated. Use `BracesOnIfStatements` with `always` configuration instead.
```

## Links
- https://detekt.dev/docs/rules/style/#bracesonifstatements

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
