### PR TITLE
Configure workflows to use proper run-names and for DRY

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -1,0 +1,29 @@
+name: "Setup the build environment for iOS builds"
+description: "setup Xcode, Swift package manager, fastlane and gradle"
+
+inputs:
+  arch:
+    description: "The architecture to build for iOS framework." # behaves as a named variable
+    default: "x86_64"
+outputs:
+  working-directory:
+    description: "The working directory to build the iOS project." # behaves as a named variable
+    value: "app-ios"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+      with:
+        bundler-cache: true
+
+    - uses: ./.github/actions/xcode-select
+
+    - uses: ./.github/actions/setup-java
+
+    - shell: bash
+      name: Set up XCFramework arch filter
+      run: echo "arch=${{ inputs.arch }}" >> local.properties
+
+    - uses: ./.github/actions/spm

--- a/.github/workflows/ActionLint.yml
+++ b/.github/workflows/ActionLint.yml
@@ -2,8 +2,14 @@ on:
   push:
     paths:
       - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
 
-name: "Trigger: Push action"
+name: "Actionlint"
+
+run-name: "Run ActionLint by ${{ github.actor }}"
+
 permissions: {}
 
 jobs:
@@ -12,8 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - uses: jaxxstorm/action-install-gh-release@c5ead9a448b4660cf1e7866ee22e4dc56538031a #v1.10.0
+        with:
+          repo: rhysd/actionlint
+          tag: "v1.6.25"
+          cache: enable
+  
       - name: Run actionlint
-        run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.25
-          ./actionlint -color
-        shell: bash
+        run: actionlint -color

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+run-name: "Build Android project on ${{ github.event_name}}${{ github.event.pull_request.number && format('#{0}', github.event.pull_request.number) || '' }} by ${{ github.actor }}"
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/CompareScreenshot.yml
+++ b/.github/workflows/CompareScreenshot.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+run-name: "Compare screenshots on ${{ github.event_name}}#${{ github.event.pull_request.number }} by ${{ github.actor }}"
+
 permissions: { }
 
 jobs:

--- a/.github/workflows/CompareScreenshotComment.yml
+++ b/.github/workflows/CompareScreenshotComment.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
+run-name: "Comment screenshot diffs; ${{ github.event.workflow_run.name }} - ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
+
 permissions: { }
 
 jobs:

--- a/.github/workflows/DropStaging.yml
+++ b/.github/workflows/DropStaging.yml
@@ -7,6 +7,8 @@ on:
 # Disable all permissions. We have to enable required permissions at job-level.
 permissions: {}
 
+run-name: "Drop a staging artifact for ${{ github.event_name}}#${{ github.event.pull_request.number }} by ${{ github.actor }}"
+
 jobs:
   drop-stage:
     name: "Drop from staging"

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - 'app-ios/**'
 
-run-name: "Format by ${{ github.actor }}"
+run-name: "Format a project on ${{ github.event_name}}#${{ github.event.pull_request.number }} by ${{ github.actor }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/StagePullRequest.yml
+++ b/.github/workflows/StagePullRequest.yml
@@ -10,6 +10,8 @@ on:
 # Disable all permissions. We have to enable required permissions at job-level.
 permissions: {}
 
+run-name: "Promote a pr artifact to staging; ${{ github.event.workflow_run.name }} - ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
+
 jobs:
   stage-epic:
     if: >

--- a/.github/workflows/StagePush.yml
+++ b/.github/workflows/StagePush.yml
@@ -10,6 +10,8 @@ on:
 # Disable all permissions. We have to enable required permissions at job-level.
 permissions: {}
 
+run-name: "Promote a branch artifact to staging; ${{ github.event.workflow_run.name }} - ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
+
 jobs:
   stage-default:
     if: >

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'app-ios/**'
 
-run-name: "UnitTest by ${{ github.actor }}"
+run-name: "Run UnitTest on ${{ github.event_name}}${{ github.event.pull_request.number && format('#{0}', github.event.pull_request.number) || '' }} by ${{ github.actor }}"
 
 permissions: { }
 

--- a/.github/workflows/iOSBuild.yml
+++ b/.github/workflows/iOSBuild.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ios-build-${{ github.ref }}
   cancel-in-progress: true
 
+run-name: "Build iOS project on ${{ github.event_name}}${{ github.event.pull_request.number && format('#{0}', github.event.pull_request.number) || '' }} by ${{ github.actor }}"
+
 jobs:
   build-ios:
     runs-on: macos-13
@@ -17,19 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
-        with:
-          bundler-cache: true
-
-      - uses: ./.github/actions/xcode-select
-
-      - uses: ./.github/actions/setup-java
-
-      - name: Set up XCFramework arch filter
-        run: echo "arch=x86_64" >> local.properties
-
-      - uses: ./.github/actions/spm
+      - id: ios
+        uses: ./.github/actions/setup-ios
 
       - run: bundle exec fastlane build
-        working-directory: app-ios
+        working-directory: ${{ steps.ios.outputs.working-directory }}

--- a/.github/workflows/iOSLint.yml
+++ b/.github/workflows/iOSLint.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'app-ios/**'
 
+run-name: "Run lint for iOS on ${{ github.event_name}}#${{ github.event.pull_request.number }} by ${{ github.actor }}"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,4 +20,5 @@ jobs:
           fetch-depth: 1
 
       - name: SwiftLint
-        run: cd app-ios && swiftlint lint --reporter github-actions-logging
+        run: swiftlint lint --reporter github-actions-logging
+        working-directory: app-ios


### PR DESCRIPTION
## Issue
- close N/a

## Overview (Required)

- Specify `run-name` for each workflow unless defined
- Aggregate a couple of setup actions for iOS build into the single action

## Links
- N/a
