### PR TITLE
[iOS] fix time format on timetable screen

### DIFF
--- a/app-ios/Modules/Sources/Model/TimetableTimeGroupItems.swift
+++ b/app-ios/Modules/Sources/Model/TimetableTimeGroupItems.swift
@@ -1,36 +1,17 @@
 import shared
 
 public struct TimetableTimeGroupItems: Identifiable, Equatable, Hashable {
-    public struct Duration: Hashable {
-        public let startsAt: Kotlinx_datetimeInstant
-        public let endsAt: Kotlinx_datetimeInstant
-
-        var minute: Int {
-            let startMinute = Int(startsAt.epochSeconds) / 60
-            let endMinute = Int(endsAt.epochSeconds) / 60
-
-            return endMinute - startMinute
-        }
-
-        public init(startsAt: Kotlinx_datetimeInstant, endsAt: Kotlinx_datetimeInstant) {
-            self.startsAt = startsAt
-            self.endsAt = endsAt
-        }
-    }
-
     public var id: String {
         UUID().uuidString
     }
 
-    public var startsAt: Date
-    public var endsAt: Date
-    public var minute: Int
+    public var startsTimeString: String
+    public var endsTimeString: String
     public var items: [TimetableItemWithFavorite]
 
-    public init(duration: Duration, items: [TimetableItemWithFavorite]) {
-        self.startsAt = duration.startsAt.toDate()
-        self.endsAt = duration.endsAt.toDate()
-        self.minute = duration.minute
+    public init(startsTimeString: String, endsTimeString: String, items: [TimetableItemWithFavorite]) {
+        self.startsTimeString = startsTimeString
+        self.endsTimeString = endsTimeString
         self.items = items
     }
 }

--- a/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkViewModel.swift
@@ -44,19 +44,17 @@ final class BookmarkViewModel: ObservableObject {
         } ?? cachedTimetable.contents
         let timetableTimeGroupItems = timetableContents
 //            .filter { cachedTimetable.bookmarks.contains($0.timetableItem.id) }
-            .map {
-                TimetableTimeGroupItems.Duration(startsAt: $0.timetableItem.startsAt, endsAt: $0.timetableItem.endsAt)
-            }
-            .map { duration in
+            .map { content in
                 let items = timetableContents
                     .filter { itemWithFavorite in
-                        itemWithFavorite.timetableItem.startsAt == duration.startsAt && itemWithFavorite.timetableItem.endsAt == duration.endsAt
+                        itemWithFavorite.timetableItem.startsTimeString == content.timetableItem.startsTimeString && itemWithFavorite.timetableItem.endsTimeString == content.timetableItem.endsTimeString
                     }
                     .sorted {
                         $0.timetableItem.room.name.currentLangTitle < $1.timetableItem.room.name.currentLangTitle
                     }
                 return TimetableTimeGroupItems(
-                    duration: duration,
+                    startsTimeString: content.timetableItem.startsTimeString,
+                    endsTimeString: content.timetableItem.endsTimeString,
                     items: items
                 )
             }

--- a/app-ios/Modules/Sources/Timetable/Search/SearchViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/Search/SearchViewModel.swift
@@ -58,19 +58,17 @@ final class SearchViewModel: ObservableObject {
         }
         let timetableContents = cachedTimetable.filtered(filters: state.filters).contents
         let timetableTimeGroupItems = timetableContents
-            .map {
-                TimetableTimeGroupItems.Duration(startsAt: $0.timetableItem.startsAt, endsAt: $0.timetableItem.endsAt)
-            }
-            .map { duration in
+            .map { content in
                 let items = timetableContents
                     .filter { itemWithFavorite in
-                        itemWithFavorite.timetableItem.startsAt == duration.startsAt && itemWithFavorite.timetableItem.endsAt == duration.endsAt
+                        itemWithFavorite.timetableItem.startsTimeString == content.timetableItem.startsTimeString && itemWithFavorite.timetableItem.endsTimeString == content.timetableItem.endsTimeString
                     }
                     .sorted {
                         $0.timetableItem.room.name.currentLangTitle < $1.timetableItem.room.name.currentLangTitle
                     }
                 return TimetableTimeGroupItems(
-                    duration: duration,
+                    startsTimeString: content.timetableItem.startsTimeString,
+                    endsTimeString: content.timetableItem.endsTimeString,
                     items: items
                 )
             }

--- a/app-ios/Modules/Sources/Timetable/SessionTimeView.swift
+++ b/app-ios/Modules/Sources/Timetable/SessionTimeView.swift
@@ -1,27 +1,21 @@
+import Model
 import SwiftUI
 import Theme
 
-private let formatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .none
-    formatter.timeStyle = .short
-    return formatter
-}()
-
 struct SessionTimeView: View {
-    var startsAt: Date
-    var endsAt: Date
+    var startsTimeString: String
+    var endsTimeString: String
 
     var body: some View {
         VStack(spacing: 4) {
-            Text(formatter.string(from: startsAt))
+            Text(startsTimeString)
                 .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
                 .font(Font(UIFont.systemFont(ofSize: 16, weight: .bold)))
                 .frame(height: 24)
             Rectangle()
                 .foregroundColor(AssetColors.Outline.outlineVariant.swiftUIColor)
                 .frame(width: 2, height: 8)
-            Text(formatter.string(from: endsAt))
+            Text(endsTimeString)
                 .foregroundStyle(AssetColors.Secondary.secondary.swiftUIColor)
                 .font(Font(UIFont.systemFont(ofSize: 16, weight: .bold)))
                 .frame(height: 24)
@@ -29,6 +23,14 @@ struct SessionTimeView: View {
     }
 }
 
- #Preview {
-     SessionTimeView(startsAt: .distantPast, endsAt: .distantFuture)
- }
+#if DEBUG
+import shared
+
+#Preview {
+    SessionTimeView(
+        startsTimeString: Timetable.companion.fake().contents.first!.timetableItem.startsTimeString,
+        endsTimeString: Timetable.companion.fake().contents.first!.timetableItem.endsTimeString
+    )
+}
+
+#endif

--- a/app-ios/Modules/Sources/Timetable/TimetableListView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListView.swift
@@ -9,8 +9,8 @@ struct TimetableListView: View {
             ForEach(timetableTimeGroupItems) { timetableTimeGroupItem in
                 HStack(alignment: .top, spacing: 16) {
                     SessionTimeView(
-                        startsAt: timetableTimeGroupItem.startsAt,
-                        endsAt: timetableTimeGroupItem.endsAt
+                        startsTimeString: timetableTimeGroupItem.startsTimeString,
+                        endsTimeString: timetableTimeGroupItem.endsTimeString
                     )
                     VStack(spacing: 0) {
                         ForEach(timetableTimeGroupItem.items, id: \.timetableItem.id.value) { timetableItemWithFavorite in
@@ -37,10 +37,8 @@ import shared
     TimetableListView(
         timetableTimeGroupItems: [
             TimetableTimeGroupItems(
-                duration: .init(
-                    startsAt: Timetable.companion.fake().contents.first!.timetableItem.startsAt,
-                    endsAt: Timetable.companion.fake().contents.first!.timetableItem.endsAt
-                ),
+                startsTimeString: Timetable.companion.fake().contents.first!.timetableItem.startsTimeString,
+                endsTimeString: Timetable.companion.fake().contents.first!.timetableItem.endsTimeString,
                 items: [Timetable.companion.fake().contents.first!]
             ),
         ]

--- a/app-ios/Modules/Sources/Timetable/TimetableViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableViewModel.swift
@@ -41,19 +41,17 @@ final class TimetableViewModel: ObservableObject {
         }
         let timetableTimeGroupItems = cachedTimetable.dayTimetable(droidKaigi2023Day: state.selectedDay)
             .timetableItems
-            .map {
-                TimetableTimeGroupItems.Duration(startsAt: $0.startsAt, endsAt: $0.endsAt)
-            }
-            .map { duration in
+            .map { item in
                 let items = cachedTimetable.contents
                     .filter { itemWithFavorite in
-                        itemWithFavorite.timetableItem.startsAt == duration.startsAt && itemWithFavorite.timetableItem.endsAt == duration.endsAt
+                        itemWithFavorite.timetableItem.startsTimeString == item.startsTimeString && itemWithFavorite.timetableItem.endsTimeString == item.endsTimeString
                     }
                     .sorted {
                         $0.timetableItem.room.name.currentLangTitle < $1.timetableItem.room.name.currentLangTitle
                     }
                 return TimetableTimeGroupItems(
-                    duration: duration,
+                    startsTimeString: item.startsTimeString,
+                    endsTimeString: item.endsTimeString,
                     items: items
                 )
             }


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2023/issues/871

## Overview (Required)
- Fixed time format on timetable screen
- The layout is broken (unintentionally centered from before), but let me focus on the format now 🙏 -> Fixed https://github.com/DroidKaigi/conference-app-2023/pull/952

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/895023ad-94e9-4308-8eb5-253d161c13b9" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/1b00fd3a-a3d1-4f1e-b22b-9d856436dfb3" width="300" />

