### PR TITLE
Set JST time zone for robot tests

### DIFF
--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/RobotTestRule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/RobotTestRule.kt
@@ -60,6 +60,7 @@ class RobotTestRule(
         return RuleChain
             .outerRule(HiltAndroidAutoInjectRule(testInstance))
             .around(CoroutinesTestRule())
+            .around(TimeZoneTestRule())
             .around(object : TestWatcher() {
                 override fun starting(description: Description) {
                     // To see logs in the console

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/TimeZoneTestRule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/TimeZoneTestRule.kt
@@ -4,9 +4,15 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import java.util.TimeZone
 
-class TimeZoneTestRule : TestWatcher() {
+class TimeZoneTestRule() : TestWatcher() {
+    private lateinit var evacuatedTimeZone: TimeZone
+
     override fun starting(description: Description) {
-        super.starting(description)
+        evacuatedTimeZone = TimeZone.getDefault()
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"))
+    }
+    
+    override fun finished(description: Description) {
+        TimeZone.setDefault(evacuatedTimeZone)
     }
 }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/TimeZoneTestRule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/TimeZoneTestRule.kt
@@ -4,14 +4,14 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import java.util.TimeZone
 
-class TimeZoneTestRule() : TestWatcher() {
+class TimeZoneTestRule : TestWatcher() {
     private lateinit var evacuatedTimeZone: TimeZone
 
     override fun starting(description: Description) {
         evacuatedTimeZone = TimeZone.getDefault()
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"))
     }
-    
+
     override fun finished(description: Description) {
         TimeZone.setDefault(evacuatedTimeZone)
     }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/TimeZoneTestRule.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/TimeZoneTestRule.kt
@@ -1,0 +1,12 @@
+package io.github.droidkaigi.confsched2023.testing
+
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.util.TimeZone
+
+class TimeZoneTestRule : TestWatcher() {
+    override fun starting(description: Description) {
+        super.starting(description)
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"))
+    }
+}


### PR DESCRIPTION
## Issue
- close #906

## Overview (Required)
- Set JST time zone for all robot test as test rule

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
