### PR TITLE
Add message on grid view and detail of timetable

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
@@ -44,6 +46,7 @@ import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2023.model.TimetableSpeaker
 import io.github.droidkaigi.confsched2023.model.fake
+import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.ScheduleIcon
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.UserIcon
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableSizes
@@ -130,6 +133,27 @@ fun TimetableGridItem(
                     style = MaterialTheme.typography.bodySmall,
                     color = textColor,
                 )
+            }
+
+            if (timetableItem is Session) {
+                timetableItem.message?.let {
+                    Spacer(modifier = Modifier.height(TimetableGridItemSizes.titleToScheduleSpaceHeight))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Error,
+                            contentDescription = SessionsStrings.ErrorIcon.asString(),
+                            tint = MaterialTheme.colorScheme.errorContainer,
+                            modifier = Modifier.size(TimetableGridItemSizes.scheduleHeight),
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = it.currentLangTitle,
+                            color = MaterialTheme.colorScheme.errorContainer,
+                            fontSize = TimetableGridItemSizes.minTitleFontSize,
+                            lineHeight = TimetableGridItemSizes.minTitleLineHeight,
+                        )
+                    }
+                }
             }
 
             Spacer(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailSummaryCard.kt
@@ -2,20 +2,28 @@ package io.github.droidkaigi.confsched2023.sessions.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.outlined.Category
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Place
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
@@ -26,6 +34,7 @@ import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2023.model.fake
 import io.github.droidkaigi.confsched2023.model.nameAndFloor
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
+import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.ErrorIcon
 import java.util.Locale
 
 @Composable
@@ -33,43 +42,64 @@ fun TimetableItemDetailSummaryCard(
     timetableItem: TimetableItem,
     modifier: Modifier = Modifier,
 ) {
-    val isJapaneseLocale = Locale.getDefault().language == Locale("ja").language
+    Column(modifier = modifier) {
+        if (timetableItem is Session) {
+            timetableItem.message?.let {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Error,
+                        contentDescription = ErrorIcon.asString(),
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = it.currentLangTitle,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                }
+                Spacer(modifier = Modifier.size(20.dp))
+            }
+        }
 
-    Card(
-        shape = RoundedCornerShape(12.dp),
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                1.dp,
+        val isJapaneseLocale = Locale.getDefault().language == Locale("ja").language
+
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
+                    1.dp,
+                ),
             ),
-        ),
-    ) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 24.dp),
         ) {
-            TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Outlined.Schedule,
-                label = SessionsStrings.Date.asString(),
-                content = timetableItem.formattedDateTimeString,
-            )
-            TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Outlined.Place,
-                label = SessionsStrings.Place.asString(),
-                content = timetableItem.room.nameAndFloor,
-            )
-            TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Outlined.Language,
-                label = SessionsStrings.SupportedLanguages.asString(),
-                content = timetableItem.getSupportedLangString(isJapaneseLocale),
-            )
-            TimetableItemDetailSummaryCardRow(
-                leadingIcon = Icons.Outlined.Category,
-                label = SessionsStrings.Category.asString(),
-                content = timetableItem.category.title.currentLangTitle,
-            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 24.dp),
+            ) {
+                TimetableItemDetailSummaryCardRow(
+                    leadingIcon = Icons.Outlined.Schedule,
+                    label = SessionsStrings.Date.asString(),
+                    content = timetableItem.formattedDateTimeString,
+                )
+                TimetableItemDetailSummaryCardRow(
+                    leadingIcon = Icons.Outlined.Place,
+                    label = SessionsStrings.Place.asString(),
+                    content = timetableItem.room.nameAndFloor,
+                )
+                TimetableItemDetailSummaryCardRow(
+                    leadingIcon = Icons.Outlined.Language,
+                    label = SessionsStrings.SupportedLanguages.asString(),
+                    content = timetableItem.getSupportedLangString(isJapaneseLocale),
+                )
+                TimetableItemDetailSummaryCardRow(
+                    leadingIcon = Icons.Outlined.Category,
+                    label = SessionsStrings.Category.asString(),
+                    content = timetableItem.category.title.currentLangTitle,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- In timetable, there is the message part on list view but grid view and detail. So I added message on grid view and detail of timetable.

## Links
- none (there is no design of these pattern in Figma)

## Screenshot
I applied this patch before taking screenshots.
<details>
<summary>patch</summary>

```diff
diff --git a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt	(revision 77b3289372d5adba1b6e10cc7f93b608956d2884)
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt	(date 1692855411205)
@@ -111,7 +111,10 @@
                         speakers = apiSession.speakers
                             .map { speakerIdToSpeaker[it]!! }
                             .toPersistentList(),
-                        message = apiSession.message?.toMultiLangText(),
+                        message = MultiLangText(
+                            jaTitle = "このセッションは事情により中止となりました",
+                            enTitle = "This session has been cancelled due to circumstances.",
+                        ),
                         levels = apiSession.levels.toPersistentList(),
                     )
                 } else {
```
</details>

Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/6055a7eb-0497-41ed-8ec8-ed5d2ae4314d" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/4f0dc6f2-b16e-453d-b6b4-fc2c4aec7a21" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/4f562f1f-92fc-4f8b-9d9b-2dab60267fe1" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/bd551f36-105d-472e-9c9e-312adf0eb387" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/efada203-efbe-4919-8f56-3ad2a882dab2" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/66634184-993f-4a9f-aff6-cadf060e3398" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/72cad91a-6abc-4405-a92d-523380eafb5c" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/35623289/24e3c0f6-dc54-46e8-ae1b-3bb510f01006" width="300" />
