### PR TITLE
Changed the priority of repository to search for plugins

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,9 @@
 pluginManagement {
     includeBuild("build-logic")
     repositories {
-        gradlePluginPortal()
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
 }
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
@@ -12,7 +12,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-
     }
 }
 rootProject.name = "conference-app-2023"


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
Changed the priority of repository to search for plugins.  
It may not be much of a problem, but gradlePluginPortal should have a lower priority to solve, so I changed it.

## Links
- https://developer.android.com/build/optimize-your-build#gradle_plugin_portal

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
