### PR TITLE
Use `TYPESAFE_PROJECT_ACCESSORS` for `core/ui` module

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -14,10 +14,10 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project(":core:designsystem"))
-                implementation(project(":core:data"))
+                implementation(projects.core.designsystem)
+                implementation(projects.core.data)
                 implementation(libs.kermit)
-                api(project(":core:common"))
+                api(projects.core.common)
                 api(libs.composeImageLoader)
             }
         }


### PR DESCRIPTION
## Issue

- N/A

## Overview (Required)
- Use `TYPESAFE_PROJECT_ACCESSORS` for `core/ui` module

## Links

About [TYPESAFE_PROJECT_ACCESSORS](https://docs.gradle.org/7.0/release-notes.html)
