### PR TITLE
divide Locale const for Preview and PreviewTest on Annotations.kt

### DIFF
--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
@@ -60,13 +60,13 @@ object MultiLanguagePreviewDefinition {
     object Japanese {
         const val Name = "Japanese"
         const val Locale = "ja_JP"
-        const val LocaleShort = "ja"
+        const val Language = "ja"
     }
 
     object English {
         const val Name = "English"
         const val Locale = "en_US"
-        const val LocaleShort = "en"
+        const val Language = "en"
     }
 }
 
@@ -78,11 +78,11 @@ object MultiLanguagePreviewDefinition {
 @Preview(
     name = MultiLanguagePreviewDefinition.Japanese.Name,
     group = MultiLanguagePreviewDefinition.Group,
-    locale = MultiLanguagePreviewDefinition.Japanese.LocaleShort,
+    locale = MultiLanguagePreviewDefinition.Japanese.Language,
 )
 @Preview(
     name = MultiLanguagePreviewDefinition.English.Name,
     group = MultiLanguagePreviewDefinition.Group,
-    locale = MultiLanguagePreviewDefinition.English.LocaleShort,
+    locale = MultiLanguagePreviewDefinition.English.Language,
 )
 annotation class MultiLanguagePreviews

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/preview/Annotations.kt
@@ -60,25 +60,29 @@ object MultiLanguagePreviewDefinition {
     object Japanese {
         const val Name = "Japanese"
         const val Locale = "ja_JP"
+        const val LocaleShort = "ja"
     }
 
     object English {
         const val Name = "English"
         const val Locale = "en_US"
+        const val LocaleShort = "en"
     }
 }
 
 /**
  * Annotation for previewing multiple languages.
+ *
+ * Note: locale param need to follow [locale qualifier](https://developer.android.com/guide/topics/resources/providing-resources#LocaleQualifier).
  */
 @Preview(
     name = MultiLanguagePreviewDefinition.Japanese.Name,
     group = MultiLanguagePreviewDefinition.Group,
-    locale = MultiLanguagePreviewDefinition.Japanese.Locale,
+    locale = MultiLanguagePreviewDefinition.Japanese.LocaleShort,
 )
 @Preview(
     name = MultiLanguagePreviewDefinition.English.Name,
     group = MultiLanguagePreviewDefinition.Group,
-    locale = MultiLanguagePreviewDefinition.English.Locale,
+    locale = MultiLanguagePreviewDefinition.English.LocaleShort,
 )
 annotation class MultiLanguagePreviews


### PR DESCRIPTION
## Issue
- close #902

## Overview (Required)
- locale parameter of `@Preview` annotation should follow [LocaleQualifier](https://developer.android.com/guide/topics/resources/providing-resources#LocaleQualifier)
  - i.e. ja, en, fr-rFR
- `PreviewTest.newLocales(...)` uses `java.util.Locale` on the other hand
  - i.e.  ja, en, ja_JP, fr_FR
- In this PR, divide existing Locale const to two consts to use them separately

## Links
- https://developer.android.com/guide/topics/resources/providing-resources#LocaleQualifier

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/205ca17b-31a5-492b-816b-18d9568c5a0a" width="360" /><br><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/82816967-25d7-4526-9266-3f00599a8877" width="360" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/c629d07a-c188-4064-9f5d-ec759ef3922a" width="360" /><br><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/4c3d9d4c-da11-4b6f-a253-11b96b71af70" width="360" />


