### PR TITLE
Convert to data object at AboutStrings.kt

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2023/about/AboutStrings.kt
@@ -5,25 +5,25 @@ import io.github.droidkaigi.confsched2023.designsystem.strings.Strings
 import io.github.droidkaigi.confsched2023.designsystem.strings.StringsBindings
 
 sealed class AboutStrings : Strings<AboutStrings>(Bindings) {
-    object Title : AboutStrings()
-    object Description : AboutStrings()
-    object DateTitle : AboutStrings()
-    object DateDescription : AboutStrings()
-    object PlaceTitle : AboutStrings()
-    object PlaceDescription : AboutStrings()
+    data object Title : AboutStrings()
+    data object Description : AboutStrings()
+    data object DateTitle : AboutStrings()
+    data object DateDescription : AboutStrings()
+    data object PlaceTitle : AboutStrings()
+    data object PlaceDescription : AboutStrings()
     class PlaceLink(
         val url: String = "https://goo.gl/maps/vv9sE19JvRjYKtSP9",
     ) : AboutStrings()
-    object CreditsTitle : AboutStrings()
-    object Staff : AboutStrings()
-    object Contributor : AboutStrings()
-    object Sponsor : AboutStrings()
-    object OthersTitle : AboutStrings()
-    object CodeOfConduct : AboutStrings()
-    object License : AboutStrings()
-    object PrivacyPolicy : AboutStrings()
-    object AppVersion : AboutStrings()
-    object LicenceDescription : AboutStrings()
+    data object CreditsTitle : AboutStrings()
+    data object Staff : AboutStrings()
+    data object Contributor : AboutStrings()
+    data object Sponsor : AboutStrings()
+    data object OthersTitle : AboutStrings()
+    data object CodeOfConduct : AboutStrings()
+    data object License : AboutStrings()
+    data object PrivacyPolicy : AboutStrings()
+    data object AppVersion : AboutStrings()
+    data object LicenceDescription : AboutStrings()
 
     private object Bindings : StringsBindings<AboutStrings>(
         Lang.Japanese to { item, _ ->


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- those are can be convert to `data object` . I think no reason to keep the just `object`?

## Links
- Explain about [data object](https://medium.com/@domen.lanisnik/data-objects-in-kotlin-1a549bfad657)
