### PR TITLE
Remove duplicate dependency at feature module for core module

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/convention/AndroidFeaturePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/convention/AndroidFeaturePlugin.kt
@@ -1,7 +1,9 @@
 package io.github.droidkaigi.confsched2023.convention
 
+import io.github.droidkaigi.confsched2023.primitive.implementation
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 
 class AndroidFeaturePlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -14,6 +16,12 @@ class AndroidFeaturePlugin : Plugin<Project> {
                 apply("droidkaigi.primitive.android.roborazzi")
                 apply("droidkaigi.primitive.kover")
                 apply("droidkaigi.primitive.detekt")
+            }
+
+            dependencies {
+                implementation(project(":core:model"))
+                implementation(project(":core:designsystem"))
+                implementation(project(":core:ui"))
             }
         }
     }

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/GradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/GradleDsl.kt
@@ -12,6 +12,12 @@ fun DependencyHandlerScope.implementation(
     add("implementation", artifact)
 }
 
+fun DependencyHandlerScope.implementation(
+    project: Project
+) {
+    add("implementation", project)
+}
+
 fun DependencyHandlerScope.debugImplementation(
     artifact: MinimalExternalModuleDependency,
 ) {

--- a/feature/about/build.gradle.kts
+++ b/feature/about/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.about"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
     implementation(libs.composeHiltNavigtation)

--- a/feature/floor-map/build.gradle.kts
+++ b/feature/floor-map/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.floormap"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     implementation(libs.composeMaterialWindowSize)
     testImplementation(projects.core.testing)
 

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.main"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
     implementation(libs.composeHiltNavigtation)

--- a/feature/sessions/build.gradle.kts
+++ b/feature/sessions/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.sessions"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
     implementation(libs.composeHiltNavigtation)

--- a/feature/sponsors/build.gradle.kts
+++ b/feature/sponsors/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.sponsors"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
     implementation(libs.composeHiltNavigtation)

--- a/feature/staff/build.gradle.kts
+++ b/feature/staff/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.staff"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
     implementation(libs.composeHiltNavigtation)

--- a/feature/stamps/build.gradle.kts
+++ b/feature/stamps/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 android.namespace = "io.github.droidkaigi.confsched2023.feature.stamps"
 
 dependencies {
-    implementation(projects.core.designsystem)
-    implementation(projects.core.ui)
-    implementation(projects.core.model)
     testImplementation(projects.core.testing)
 
     implementation(libs.composeHiltNavigtation)


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Remove duplicate dependency at feature module for core module
- Currently, our architecture want to that feature module refer the some core module.
- However, we can try to reduce the duplicate code that dependencies setting.
   - For this purpose, I tried to move the code into the feature module plugin.

## Links
- 
