### PR TITLE
Replace the deprecated setter for the detekt configuration

### DIFF
--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidGradleDsl.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidGradleDsl.kt
@@ -73,7 +73,7 @@ fun Project.setupDetekt(extension: DetektExtension) {
         // parallel processing
         parallel = true
         // detekt configuration file
-        config = files("${project.rootDir}/config/detekt/detekt.yml")
+        config.setFrom("${project.rootDir}/config/detekt/detekt.yml")
         // baseline configuration file
         baseline = file("${project.rootDir}/config/detekt/baseline.xml")
         // apply your own configuration file on top of the default settings


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR replaces the deprecated setter for the detekt configuration to resolve the following warning:

```
w: file:///***/conference-app-2023/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/AndroidGradleDsl.kt:76:9 'setter for config: ConfigurableFileCollection' is deprecated. Setter will be removed in a future release. Use `from` or `setFrom` instead.
```

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
