### PR TITLE
[iOS] Fix the layout of the timetable item

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
@@ -58,6 +58,7 @@ struct TimetableListItemView: View {
                 }
                 Spacer().frame(height: 16)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             Button(
                 action: {
                     // TODO: favorite action


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR fixes the layout of the timetable item

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/ca92eef0-9de2-48db-875a-f4baaa755887" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/8d229a51-a6e2-4d1c-8af3-09032fc75276" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
