### PR TITLE
[iOS] Make the description on the session detail selectable

### DIFF
--- a/app-ios/Modules/Sources/Session/SessionView.swift
+++ b/app-ios/Modules/Sources/Session/SessionView.swift
@@ -66,6 +66,7 @@ public struct SessionView: View {
                 if let session = viewModel.timetableItem as? TimetableItem.Session {
                     VStack(alignment: .leading, spacing: 16) {
                         Text(session.description_)
+                            .textSelection(.enabled)
                             .lineLimit(isDescriptionExpanded ? nil : 5)
                             .background {
                                 ViewThatFits(in: .vertical) {


### PR DESCRIPTION
## Issue
- close #885

## Overview (Required)
- This PR makes the description on the session detail selectable to copy it

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/bc7ff956-1172-48ab-a570-570b13ae3600" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/bda45c9a-345b-40c6-8255-39137d5dbc64" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
