### PR TITLE
Support large font for session tag and timetable tab

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SessionTag.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SessionTag.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +47,7 @@ fun SessionTag(
                 shape = RoundedCornerShape(50.dp),
             )
             .padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
     ) {
         Text(
             text = label,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SessionTag.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SessionTag.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2023.sessions.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -29,7 +29,7 @@ fun SessionTag(
 ) {
     Box(
         modifier = modifier
-            .height(24.dp)
+            .defaultMinSize(minHeight = 24.dp)
             .then(
                 if (borderColor != null) {
                     Modifier.border(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -77,7 +77,7 @@ fun TimetableTab(
         },
         selectedContentColor = MaterialTheme.colorScheme.onPrimary,
         unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = modifier.heightIn(min = tabMinHeight, max = tabMaxHeight),
+        modifier = modifier.heightIn(min = tabMinHeight),
     )
 }
 
@@ -114,7 +114,7 @@ fun TimetableTabRow(
     TabRow(
         selectedTabIndex = selectedTabIndex,
         modifier = modifier
-            .height(tabRowMaxHeight - ((tabRowMaxHeight - tabRowMinHeight) * tabState.tabCollapseProgress))
+            .defaultMinSize(minHeight = tabRowMaxHeight - ((tabRowMaxHeight - tabRowMinHeight) * tabState.tabCollapseProgress))
             .padding(
                 start = tabRowHorizontalSpacing,
                 top = tabRowTopSpacing,

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreenTest.kt
@@ -98,7 +98,7 @@ class TimetableItemDetailScreenTest {
     @Test
     @Category(ScreenshotTests::class)
     @Config(fontScale = 0.5f)
-    fun smallFontScaleShot() {
+    fun checkSmallFontScaleShot() {
         timetableItemDetailScreenRobot {
             setupScreenContent()
             checkScreenCapture()
@@ -108,7 +108,7 @@ class TimetableItemDetailScreenTest {
     @Test
     @Category(ScreenshotTests::class)
     @Config(fontScale = 1.5f)
-    fun largeFontScaleShot() {
+    fun checkLargeFontScaleShot() {
         timetableItemDetailScreenRobot {
             setupScreenContent()
             checkScreenCapture()
@@ -118,7 +118,7 @@ class TimetableItemDetailScreenTest {
     @Test
     @Category(ScreenshotTests::class)
     @Config(fontScale = 2.0f)
-    fun hugeFontScaleShot() {
+    fun checkHugeFontScaleShot() {
         timetableItemDetailScreenRobot {
             setupScreenContent()
             checkScreenCapture()

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenTest.kt
@@ -109,4 +109,34 @@ class TimetableScreenTest {
             checkTimetableListCapture()
         }
     }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 0.5f)
+    fun checkSmallFontScaleShot() {
+        timetableScreenRobot {
+            setupTimetableScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 1.5f)
+    fun checkLargeFontScaleShot() {
+        timetableScreenRobot {
+            setupTimetableScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 2.0f)
+    fun checkHugeFontScaleShot() {
+        timetableScreenRobot {
+            setupTimetableScreenContent()
+            checkScreenCapture()
+        }
+    }
 }


### PR DESCRIPTION
## Issue
- sorry, I haven't opened any issue. Please tell me if I should open it before PR and I'll create the one.
- I've found the problem that the session tags and the timetable tabs don't support large font size.
  - Please refer to the screenshot I attached bottom to see exactly what happend.
### how to reproduce: 
- Device: Pixel6 emulator
- Change the font size to the largest in the device settings.
- Open the app.


## Overview (Required)
- Stopped specifying a fixed height and instead set a minimum height.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
### large font size
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/d2b6ead0-3a80-4534-8e34-452a6b432155" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/e1be61ef-b3ee-4bd8-8387-42b4df1d9614" width="300" />
### normal font size
There is no difference.
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/72125f8a-91f5-41ea-aece-ca22f123d41a" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/e2f9ce35-87bd-441d-ab7a-22aa199cb514" width="300" />
