### PR TITLE
Hide searching text when enable the BigFont/BigDisplay

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchTextFieldAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchTextFieldAppBar.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2023.sessions.component
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -92,7 +91,6 @@ private fun SearchTextField(
         value = searchQuery,
         onValueChange = onSearchQueryChanged,
         modifier = modifier
-            .height(56.0.dp)
             .fillMaxWidth(1.0f)
             .focusRequester(focusRequester),
         enabled = enabled,

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/SearchScreenTest.kt
@@ -46,7 +46,7 @@ class SearchScreenTest {
     @Test
     @Category(ScreenshotTests::class)
     @Config(fontScale = 0.5f)
-    fun smallFontScaleShot() {
+    fun checkSmallFontScaleShot() {
         searchScreenRobot {
             setupSearchScreenContent()
             checkScreenCapture()
@@ -56,7 +56,7 @@ class SearchScreenTest {
     @Test
     @Category(ScreenshotTests::class)
     @Config(fontScale = 1.5f)
-    fun largeFontScaleShot() {
+    fun checkLargeFontScaleShot() {
         searchScreenRobot {
             setupSearchScreenContent()
             checkScreenCapture()
@@ -66,7 +66,7 @@ class SearchScreenTest {
     @Test
     @Category(ScreenshotTests::class)
     @Config(fontScale = 2.0f)
-    fun hugeFontScaleShot() {
+    fun checkHugeFontScaleShot() {
         searchScreenRobot {
             setupSearchScreenContent()
             checkScreenCapture()

--- a/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/SearchScreenTest.kt
+++ b/feature/sessions/src/test/java/io/github/droidkaigi/confsched2023/sessions/SearchScreenTest.kt
@@ -45,6 +45,36 @@ class SearchScreenTest {
 
     @Test
     @Category(ScreenshotTests::class)
+    @Config(fontScale = 0.5f)
+    fun smallFontScaleShot() {
+        searchScreenRobot {
+            setupSearchScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 1.5f)
+    fun largeFontScaleShot() {
+        searchScreenRobot {
+            setupSearchScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
+    @Config(fontScale = 2.0f)
+    fun hugeFontScaleShot() {
+        searchScreenRobot {
+            setupSearchScreenContent()
+            checkScreenCapture()
+        }
+    }
+
+    @Test
+    @Category(ScreenshotTests::class)
     fun checkFilterDayChipShot() {
         searchScreenRobot {
             checkFilterChipShot(FilterDayChipTestTag)


### PR DESCRIPTION
## Issue
- close #790 

## Overview (Required)
- Implementing it so that the searching text doesn't distort when increasing the font size. 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
BigFont/BigDisplay setting |
:--: |
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/40746838/28d18643-b05a-4943-9f0f-45c461d880d7" width="300" /> |

### NormalFont
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/40746838/4be60084-2a65-4c2b-b3a2-8fdb100f8ffc" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/40746838/f25f7068-f187-4cd6-908c-8d021c42dc36" width="300" />

### BigFont
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/40746838/4fb6425d-fe1f-42e9-baec-97209c125af5" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/40746838/9c8727a2-1a7a-4276-a80f-00339bbc4783" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
