### PR TITLE
prevent consecutive navigation event

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     implementation(projects.core.model)
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
+    implementation(projects.core.ui)
     implementation(libs.composeNavigation)
     implementation(libs.composeHiltNavigtation)
     implementation(libs.composeMaterialWindowSize)

--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.ContextCompat.startActivity
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -73,6 +73,7 @@ import io.github.droidkaigi.confsched2023.staff.staffScreen
 import io.github.droidkaigi.confsched2023.stamps.navigateStampsScreen
 import io.github.droidkaigi.confsched2023.stamps.nestedStampsScreen
 import io.github.droidkaigi.confsched2023.stamps.stampsScreenRoute
+import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
 import kotlinx.collections.immutable.PersistentList
 
 @Composable
@@ -171,9 +172,15 @@ private fun NavGraphBuilder.mainScreen(
             )
             // For KMP, we are not using navigation abstraction for contributors screen
             composable(contributorsScreenRoute) {
+                val lifecycleOwner = LocalLifecycleOwner.current
                 ContributorsScreen(
                     viewModel = hiltViewModel<ContributorsViewModel>(),
-                    onNavigationIconClick = navController::popBackStack,
+                    onNavigationIconClick = {
+                        handleOnClickIfNotNavigating(
+                            lifecycleOwner,
+                            mainNestedNavController::popBackStack,
+                        )
+                    },
                     onContributorItemClick = externalNavController::navigate,
                 )
             }

--- a/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/OnClickHandler.kt
+++ b/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/OnClickHandler.kt
@@ -3,6 +3,11 @@ package io.github.droidkaigi.confsched2023.ui
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 
+/**
+ * Invoke "onClick" if current lifecycle isn't operating other navigation.
+ * @param owner a current LifecycleOwner
+ * @param onClick the method that want to invoke
+ */
 fun handleOnClickIfNotNavigating(owner: LifecycleOwner, onClick: () -> Unit) {
     // https://stackoverflow.com/a/76386604/4339442
     val currentState = owner.lifecycle.currentState

--- a/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/OnClickHandler.kt
+++ b/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/OnClickHandler.kt
@@ -1,0 +1,12 @@
+package io.github.droidkaigi.confsched2023.ui
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+
+fun handleOnClickIfNotNavigating(owner: LifecycleOwner, onClick: () -> Unit) {
+    // https://stackoverflow.com/a/76386604/4339442
+    val currentState = owner.lifecycle.currentState
+    if (currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+        onClick()
+    }
+}

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkTopArea.kt
@@ -32,11 +32,11 @@ import androidx.compose.ui.text.lerp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.Lifecycle
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings
+import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
 import kotlin.math.min
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -125,14 +125,7 @@ fun BookmarkTopArea(
                 contentDescription = null,
                 modifier = Modifier
                     .size(24.dp)
-                    .clickable {
-                        // Ignore click events when you've started navigating to another screen
-                        // https://stackoverflow.com/a/76386604/4339442
-                        val currentState = lifecycleOwner.lifecycle.currentState
-                        if (currentState.isAtLeast(Lifecycle.State.RESUMED)) {
-                            onBackPressClick()
-                        }
-                    },
+                    .clickable { handleOnClickIfNotNavigating(lifecycleOwner, onBackPressClick) },
             )
             Text(
                 text = SessionsStrings.Bookmark.asString(),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchTextFieldAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchTextFieldAppBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
@@ -37,6 +38,7 @@ import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePrev
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.SearchPlaceHolder
+import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
 import io.github.droidkaigi.confsched2023.ui.isTest
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,13 +49,14 @@ fun SearchTextFieldAppBar(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
     TopAppBar(
         modifier = modifier,
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
         ),
         navigationIcon = {
-            IconButton(onClick = onBackClick) {
+            IconButton(onClick = { handleOnClickIfNotNavigating(lifecycleOwner, onBackClick) }) {
                 Icon(
                     imageVector = Icons.Default.ArrowBack,
                     contentDescription = null,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -18,12 +18,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.model.MultiLangText
+import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -40,6 +42,7 @@ fun TimetableItemDetailScreenTopAppBar(
             scrollBehavior.state.collapsedFraction >= 0.5f
         }
     }
+    val lifecycleOwner = LocalLifecycleOwner.current
     LargeTopAppBar(
         title = {
             // TODO: Need some better way to switch these text styles
@@ -65,7 +68,9 @@ fun TimetableItemDetailScreenTopAppBar(
             }
         },
         navigationIcon = {
-            IconButton(onClick = onNavigationIconClick) {
+            IconButton(onClick = {
+                handleOnClickIfNotNavigating(lifecycleOwner, onNavigationIconClick)
+            }) {
                 Icon(
                     imageVector = Icons.Filled.ArrowBack,
                     contentDescription = null,

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -28,6 +29,7 @@ import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.sponsors.section.SponsorList
 import io.github.droidkaigi.confsched2023.sponsors.section.SponsorListUiState
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
+import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
 
 const val sponsorsScreenRoute = "sponsors"
 fun NavGraphBuilder.sponsorsScreen(
@@ -82,6 +84,7 @@ private fun SponsorsScreen(
     onSponsorClick: (Sponsor) -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val lifecycleOwner = LocalLifecycleOwner.current
     Scaffold(
         modifier = Modifier
             .nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -92,9 +95,9 @@ private fun SponsorsScreen(
                     Text(text = SponsorsStrings.Sponsor.asString())
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = onBackClick,
-                    ) {
+                    IconButton(onClick = {
+                        handleOnClickIfNotNavigating(lifecycleOwner, onBackClick)
+                    }) {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
                             contentDescription = "Back",

--- a/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
+++ b/feature/staff/src/main/kotlin/io/github/droidkaigi/confsched2023/staff/StaffScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -27,6 +28,7 @@ import androidx.navigation.compose.composable
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheet
 import io.github.droidkaigi.confsched2023.staff.section.StaffSheetUiState
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
+import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
 
 const val staffScreenRoute = "staff"
 
@@ -76,12 +78,15 @@ private fun StaffScreen(
     onBackClick: () -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+    val lifecycleOwner = LocalLifecycleOwner.current
     Scaffold(
         topBar = {
             LargeTopAppBar(
                 title = { Text(text = "Staff") },
                 navigationIcon = {
-                    IconButton(onClick = onBackClick) {
+                    IconButton(onClick = {
+                        handleOnClickIfNotNavigating(lifecycleOwner, onBackClick)
+                    }) {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
                             contentDescription = "Back",


### PR DESCRIPTION
## Issue
- close #971

## Overview (Required)
- add handler method for click event
  - ignore events if other navigation has been started
- enable to back from contributor screen
  - now, if we back from contributor screen, empty screen is displayed (even if single tap)

## Links
- https://stackoverflow.com/questions/76386471/how-to-avoid-onclick-callback-being-called-multiple-times-jetpack-compose/76386604#76386604

## Movie
Target | Before | After
:--: | :--: | :--:
Searcj | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/af82b34a-dcbd-4c32-9f15-42781d1f7c01" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/4063450b-f75f-4b05-9e02-aae682a40352" width="300" >
TimetableItemDetail | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/7fe299a1-c9cb-47b8-96b3-761f60836c03" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/98085e57-0cd2-4e0d-a767-6bb533f385d2" width="300" >
Staff | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/42c937a0-33bf-43a0-a3b6-dcedfce9eb83" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/9d0f1735-5160-4f35-a00c-972f70c87083" width="300" >
Sponsor | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/46d5488c-a5c3-48f1-ba6e-c0b59f918ca8" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/fa9cef09-a9db-411c-a930-48de45bab36d" width="300" >
Contributor | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/4163e392-6fbd-491e-9e10-ecb1d97cb5de" width="300" >| <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/2173401b-bf1e-4919-988f-a94aaa429125" width="300" >
Contributor(2) | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/7acfaab1-9181-4291-9d3c-b3abc3524da9" width="300" >  | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/1cc97e8d-e0b4-4741-b46a-2d544bda6743" width="300" >
 | <video src="" width="300" > | <video src="" width="300" >
Bookmark | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/b82702f2-1c67-42d6-92f4-d678695801d2" width="300"> | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/76c48ec9-39c4-4e96-8dac-9a536920343d" width="300" >



