### PR TITLE
[iOS] Add search word highlight decoration when user inputs search word in SearchView.

### DIFF
--- a/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkView.swift
+++ b/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkView.swift
@@ -53,7 +53,8 @@ struct BookmarkView<SessionView: View>: View {
                         }
                         ScrollView {
                             TimetableListView(
-                                timetableTimeGroupItems: timetableItems
+                                timetableTimeGroupItems: timetableItems,
+                                searchWord: ""
                             )
                         }
                         .padding(.horizontal, 16)

--- a/app-ios/Modules/Sources/Timetable/Search/SearchView.swift
+++ b/app-ios/Modules/Sources/Timetable/Search/SearchView.swift
@@ -154,7 +154,8 @@ struct SearchView<SessionView: View>: View {
                         }
                         ScrollView {
                             TimetableListView(
-                                timetableTimeGroupItems: state.timeGroupTimetableItems
+                                timetableTimeGroupItems: state.timeGroupTimetableItems,
+                                searchWord: viewModel.state.filters.searchWord
                             )
                         }
                         .padding(.horizontal, 16)

--- a/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
@@ -5,6 +5,7 @@ import Theme
 
 struct TimetableListItemView: View {
     let timetableItemWithFavorite: TimetableItemWithFavorite
+    let searchWord: String
 
     var timetableItem: TimetableItem {
         self.timetableItemWithFavorite.timetableItem
@@ -30,7 +31,7 @@ struct TimetableListItemView: View {
                     }
                 }
                 Spacer().frame(height: 8)
-                Text(timetableItem.title.currentLangTitle)
+                Text(addHighlightAttributes(title: timetableItem.title.currentLangTitle, searchWord: searchWord))
                     .multilineTextAlignment(.leading)
                     .font(Font.system(size: 22, weight: .medium, design: .default))
                     .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
@@ -75,6 +76,15 @@ struct TimetableListItemView: View {
             .foregroundStyle(AssetColors.Surface.onSurface.swiftUIColor)
         }
     }
+
+    private func addHighlightAttributes(title: String, searchWord: String) -> AttributedString {
+        var attributedString = AttributedString(title)
+        if let range = attributedString.range(of: searchWord, options: .caseInsensitive) {
+            attributedString[range].underlineStyle = .single
+            attributedString[range].backgroundColor = AssetColors.Secondary.secondaryContainer.swiftUIColor
+        }
+        return attributedString
+    }
 }
 
 private extension RoomType {
@@ -93,6 +103,6 @@ private extension RoomType {
 
 #Preview {
     TimetableListItemView(
-        timetableItemWithFavorite: TimetableItemWithFavorite.companion.fake()
+        timetableItemWithFavorite: TimetableItemWithFavorite.companion.fake(), searchWord: ""
     )
 }

--- a/app-ios/Modules/Sources/Timetable/TimetableListView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct TimetableListView: View {
     let timetableTimeGroupItems: [TimetableTimeGroupItems]
+    let searchWord: String
 
     var body: some View {
         VStack(spacing: 0) {
@@ -16,7 +17,8 @@ struct TimetableListView: View {
                         ForEach(timetableTimeGroupItem.items, id: \.timetableItem.id.value) { timetableItemWithFavorite in
                             NavigationLink(value: TimetableRouting.session(timetableItemWithFavorite.timetableItem)) {
                                 TimetableListItemView(
-                                    timetableItemWithFavorite: timetableItemWithFavorite
+                                    timetableItemWithFavorite: timetableItemWithFavorite,
+                                    searchWord: searchWord
                                 )
                             }
                         }
@@ -41,7 +43,8 @@ import shared
                 endsTimeString: Timetable.companion.fake().contents.first!.timetableItem.endsTimeString,
                 items: [Timetable.companion.fake().contents.first!]
             ),
-        ]
+        ],
+        searchWord: ""
     )
 }
 

--- a/app-ios/Modules/Sources/Timetable/TimetableView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableView.swift
@@ -58,7 +58,7 @@ public struct TimetableView<SessionView: View>: View {
                                     viewModel.selectDay(day: $0)
                                 }
                             ) {
-                                TimetableListView(timetableTimeGroupItems: state)
+                                TimetableListView(timetableTimeGroupItems: state, searchWord: "")
                             }
                         }
                         .background(AssetColors.Surface.surface.swiftUIColor)


### PR DESCRIPTION
## Issue
- close #925

## Overview (Required)
Add addHighlightAttributes method for text highlight in `TimetableListItemView.swift`.
（Following the specifications of the Android application side, uppercase and lowercase letters are not distinguished.）

## Links
- [AttributedString in iOS 15](https://sarunw.com/posts/attributed-string/)

## Screenshot

English | Japanese
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/93af841d-b026-485e-b47c-a837e12eb468" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/6e43c111-7f25-4849-9a2c-e7b0d733f110" width="300" />