### PR TITLE
The TimetableItemDetail Snackbar doesn't disappear after some seconds

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailViewModel.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions
 
+import androidx.compose.material3.SnackbarDuration.Short
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -72,8 +73,9 @@ class TimetableItemDetailViewModel @Inject constructor(
             val bookmarked = timetableItemStateFlow.value?.second ?: return@launch
             if (bookmarked) {
                 val result = userMessageStateHolder.showMessage(
-                    TimetableItemDetailStrings.BookmarkedSuccessfully.asString(),
-                    TimetableItemDetailStrings.ViewBookmarkList.asString(),
+                    message = TimetableItemDetailStrings.BookmarkedSuccessfully.asString(),
+                    actionLabel = TimetableItemDetailStrings.ViewBookmarkList.asString(),
+                    duration = Short,
                 )
                 if (result == UserMessageResult.ActionPerformed) {
                     viewBookmarkListRequestStateFlow.update { ViewBookmarkListRequestState.Requested }


### PR DESCRIPTION
## Issue
- close #969 

## Overview (Required)
#### Added ability to set duration of snackbar with action labels

- The default duration of Material3's showSnackbar was 4 seconds if there was an action label and infinite if not.
- When the duration is set before the function `SnackbarMessageEffect` that calls Material3's `showSnackbar` is called, the value is passed to Material3's `showSnackbar`'s duration, otherwise it is left at its default value.
- Only `TimetableItemDetailViewModel`'s `onBookmarkClick` sets the snack bar duration inside the app, so it should not affect other snackbars

## Movie
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/60963155/eda9c334-ee4c-4622-ae94-aea1af2f1cf6" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/60963155/6e6a9e97-48a9-4ec0-bd0f-d256d0304b03" width="300" >
