### PR TITLE
Bookmarking with TimetableItemDetail automatically shrinks the DescriptionSection

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -32,6 +32,7 @@ import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItem.Session
 import io.github.droidkaigi.confsched2023.model.fake
 import io.github.droidkaigi.confsched2023.sessions.TimetableItemDetailScreenUiState.Loaded
+import io.github.droidkaigi.confsched2023.sessions.TimetableItemDetailScreenUiState.Loading
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailBottomAppBar
 import io.github.droidkaigi.confsched2023.sessions.component.TimetableItemDetailScreenTopAppBar
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableItemDetail
@@ -164,10 +165,11 @@ private fun TimetableItemDetailScreen(
         AnimatedContent(
             targetState = uiState,
             transitionSpec = { fadeIn().togetherWith(fadeOut()) },
+            contentKey = { uiState is Loaded },
             label = "TimetableItemDetailScreen",
         ) {
             when (it) {
-                TimetableItemDetailScreenUiState.Loading -> {
+                Loading -> {
                     LoadingText(
                         modifier = Modifier.fillMaxSize(),
                     )


### PR DESCRIPTION
## Issue
- close #967 

## Overview (Required)
### Cause of bug
- When creating a TimetableItemDetail, uiState was specified as the target of AnimatedContent, and TimetableItemDetail was being recomposed whenever uiState's isBookmarked changed.
### Fixes
- Specify { uiState is Loaded } in the contentKey lambda of AnimatedContent so that it is recomposed only when the uiState changes to Loaded.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/16633277/0d058ef3-02bb-472b-9fe2-d101bca8bf9a" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/16633277/4190836f-052f-484e-a961-9e326e4159c0" width="300" >
