### PR TITLE
:wrench: Fixed so that the app does not crash even in Release builds.

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -68,7 +68,7 @@ android {
             buildConfigField(
                 type = "String",
                 name = "SERVER_URL",
-                value = "\"https://ssot-api.droidkaigi.jp\"",
+                value = "\"https://ssot-api.droidkaigi.jp/\"",
             )
         }
     }

--- a/app-android/proguard-rules.pro
+++ b/app-android/proguard-rules.pro
@@ -22,5 +22,5 @@
 
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
-## Firebase
+# Jetpack DataStore
 -keep class androidx.datastore.*.** {*;}

--- a/app-android/proguard-rules.pro
+++ b/app-android/proguard-rules.pro
@@ -21,3 +21,6 @@
 #-renamesourcefileattribute SourceFile
 
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+
+## Firebase
+-keep class androidx.datastore.*.** {*;}

--- a/core/data/proguard-rules.pro
+++ b/core/data/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+## Firebase
+-keep class androidx.datastore.*.** {*;}

--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsRepository.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsRepository.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
-class DefaultSessionsRepository(
+public class DefaultSessionsRepository(
     private val sessionsApi: SessionsApiClient,
     private val userDataStore: UserDataStore,
     private val sessionCacheDataStore: SessionCacheDataStore,


### PR DESCRIPTION
## Issue
- close #988 

## Overview (Required)
- Until I fixed it, I was getting a "pending composition has not been applied." error and crashing.
- The cause was that the DefaultSessionsRepository used in TimetableScreenViewModel did not have a public modifier.