### PR TITLE
:wrench: Fix behavior when search results are Empty.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SearchScreenViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/SearchScreenViewModel.kt
@@ -71,8 +71,8 @@ class SearchScreenViewModel @Inject constructor(
             SearchScreenUiState.Empty(
                 searchQuery = SearchQuery(searchQuery),
                 searchFilterDayUiState = searchFilterDayUiState(filters.days),
-                searchFilterCategoryUiState = searchFilterCategoryUiState(filters.categories),
-                searchFilterSessionTypeUiState = searchFilterSessionTypeUiState(filters.sessionTypes),
+                searchFilterCategoryUiState = searchFilterCategoryUiState(filters.categories, sessions.categories),
+                searchFilterSessionTypeUiState = searchFilterSessionTypeUiState(filters.sessionTypes, sessions.sessionTypes),
                 searchFilterLanguageUiState = searchFilterLanguageUiState(filters.languages),
             )
         } else {
@@ -105,11 +105,11 @@ class SearchScreenViewModel @Inject constructor(
 
     private fun searchFilterCategoryUiState(
         selectedCategories: List<TimetableCategory>,
-        categories: List<TimetableCategory>? = null,
+        categories: List<TimetableCategory>,
     ): SearchFilterUiState<TimetableCategory> {
         return SearchFilterUiState(
             selectedItems = selectedCategories.toImmutableList(),
-            items = categories.orEmpty().toImmutableList(),
+            items = categories.toImmutableList(),
             isSelected = selectedCategories.isNotEmpty(),
             selectedValues = selectedCategories.joinToString { it.title.currentLangTitle },
         )
@@ -117,11 +117,11 @@ class SearchScreenViewModel @Inject constructor(
 
     private fun searchFilterSessionTypeUiState(
         selectedSessionTypes: List<TimetableSessionType>,
-        sessionTypes: List<TimetableSessionType>? = null,
+        sessionTypes: List<TimetableSessionType>,
     ): SearchFilterUiState<TimetableSessionType> {
         return SearchFilterUiState(
             selectedItems = selectedSessionTypes.toImmutableList(),
-            items = sessionTypes.orEmpty().toImmutableList(),
+            items = sessionTypes.toImmutableList(),
             isSelected = selectedSessionTypes.isNotEmpty(),
             selectedValues = selectedSessionTypes.joinToString { it.label.currentLangTitle },
         )


### PR DESCRIPTION
Modify to allow re-filtering of category and session type.

## Issue
- close #1001 

## Overview (Required)
- Fix behavior when search results are Empty.
- Modify to allow re-filtering of category and session type.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/ad625c9b-f2c3-470d-842d-168a15731a49" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/7a437b61-2878-49bf-8a13-7614b955bab3" width="300" >