### PR TITLE
Adjust Margin Size for TimetableListItem

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableListItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableListItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -68,7 +69,7 @@ fun TimetableListItem(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             FlowRow(
-                modifier = Modifier.weight(1F),
+                modifier = Modifier.weight(1F).padding(top = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
@@ -93,6 +94,7 @@ fun TimetableListItem(
                     } else {
                         SessionsStrings.AddToFavorites.asString()
                     },
+                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         }


### PR DESCRIPTION
## Issue
- close #837 

## Overview (Required)
- The 12dp margins at the top and bottom of the TimetableListItem were changed to 16dp at the top and 8dp at the bottom.    
  - 4dp added to the top margin.
- The margin of `chipContent` is not aligned with the top and bottom of the icon, so the margin of the icon is adjusted as well.


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/62137820/4d392c11-538c-4b41-9b1d-91d704bc0737" width="800" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/62137820/b0199711-a20d-4a80-8581-5d2beebb4106" width="800" />


