### PR TITLE
Avoid necessary boxing by mutableFloatStateOf

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
@@ -503,7 +503,7 @@ class ScreenScaleState(
 ) {
     private var verticalScaleLowerBound = initialVerticalScaleLowerBound
     private val verticalScaleUpperBound = 1f
-    private val verticalScaleState = mutableStateOf(
+    private val verticalScaleState = mutableFloatStateOf(
         initialVerticalScale.coerceIn(verticalScaleLowerBound, verticalScaleUpperBound),
     )
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Avoid necessary boxing by mutableFloatStateOf
- Because, `mutableStateOf` doing the boxing even if the value is primitive type.

## Links
- 