### PR TITLE
Use builder pattern for `AppError` constructor

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AppError.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AppError.kt
@@ -1,23 +1,20 @@
 package io.github.droidkaigi.confsched2023.model
 
 public sealed class AppError : RuntimeException {
-    private constructor()
-    private constructor(message: String?) : super(message)
-    private constructor(message: String?, cause: Throwable?) : super(message, cause)
-    private constructor(cause: Throwable?) : super(cause)
+    private constructor(message: String? = null, cause: Throwable? = null) : super(message, cause)
 
-    public sealed class ApiException(cause: Throwable?) : AppError(cause) {
-        public class NetworkException(cause: Throwable?) : ApiException(cause)
-        public class ServerException(cause: Throwable?) : ApiException(cause)
-        public class TimeoutException(cause: Throwable?) : ApiException(cause)
-        public class SessionNotFoundException(cause: Throwable?) : AppError(cause)
-        public class UnknownException(cause: Throwable?) : AppError(cause)
+    public sealed class ApiException(cause: Throwable?) : AppError(cause = cause) {
+        public class NetworkException(cause: Throwable?) : ApiException(cause = cause)
+        public class ServerException(cause: Throwable?) : ApiException(cause = cause)
+        public class TimeoutException(cause: Throwable?) : ApiException(cause = cause)
+        public class SessionNotFoundException(cause: Throwable?) : AppError(cause = cause)
+        public class UnknownException(cause: Throwable?) : AppError(cause = cause)
     }
 
-    public sealed class ExternalIntegrationError(cause: Throwable?) : AppError(cause) {
+    public sealed class ExternalIntegrationError(cause: Throwable?) : AppError(cause = cause) {
         public class NoCalendarIntegrationFoundException(cause: Throwable?) :
             ExternalIntegrationError(cause)
     }
 
-    public class UnknownException(cause: Throwable?) : AppError(cause)
+    public class UnknownException(cause: Throwable?) : AppError(cause = cause)
 }


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Apply curry convert for `AppError` constructor

## Link
- https://engineering.leanix.net/blog/kotlin-builder-pattern/
