### PR TITLE
Fixed contributors screen crash on communication error

### DIFF
--- a/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/RandomUUID.kt
+++ b/core/ui/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/ui/RandomUUID.kt
@@ -1,0 +1,5 @@
+package io.github.droidkaigi.confsched2023.ui
+
+import java.util.UUID
+
+actual fun randomUUIDHash(): Int = UUID.randomUUID().hashCode()

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/ErrorAndRetryHandler.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/ErrorAndRetryHandler.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2023.ui
 
 import io.github.droidkaigi.confsched2023.designsystem.strings.Strings
+import io.github.droidkaigi.confsched2023.ui.UserMessageResult.ActionPerformed
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.retry
@@ -16,7 +17,7 @@ fun <T> Flow<T>.handleErrorAndRetry(
         actionLabel = actionLabel.asString(),
     )
 
-    val retryPerformed = messageResult == UserMessageResult.ActionPerformed
+    val retryPerformed = messageResult == ActionPerformed
 
     retryPerformed
 }.catch { /* Do nothing if the user dose not retry. */ }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/RandomUUID.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/RandomUUID.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched2023.ui
+
+expect fun randomUUIDHash(): Int

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/UserMessage.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/UserMessage.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import java.util.UUID
 
 /**
  * SnackbarMessageEffect shows a snackbar message when a [UserMessage] is emitted by [userMessageStateHolder].
@@ -53,17 +52,18 @@ data class UserMessage(
     val message: String,
     val actionLabel: String? = null,
     val duration: SnackbarDuration? = null,
-    val id: Long = UUID.randomUUID().mostSignificantBits,
+    val id: Int = randomUUIDHash(),
     val userMessageResult: UserMessageResult? = null,
 )
 
 data class MessageUiState(
     val userMessages: List<UserMessage> = emptyList(),
 )
+
 class UserMessageStateHolderImpl : UserMessageStateHolder {
     private var _messageUiState by mutableStateOf(MessageUiState())
     override val messageUiState get() = _messageUiState
-    override fun messageShown(messageId: Long, userMessageResult: UserMessageResult) {
+    override fun messageShown(messageId: Int, userMessageResult: UserMessageResult) {
         val messages = _messageUiState.userMessages.toMutableList()
         messages.indexOfFirst { it.id == messageId }.let { userMessageIndex ->
             if (userMessageIndex == -1) return@let
@@ -112,7 +112,7 @@ class UserMessageStateHolderImpl : UserMessageStateHolder {
 
 interface UserMessageStateHolder {
     val messageUiState: MessageUiState
-    fun messageShown(messageId: Long, userMessageResult: UserMessageResult)
+    fun messageShown(messageId: Int, userMessageResult: UserMessageResult)
     suspend fun showMessage(
         message: String,
         actionLabel: String? = null,
@@ -123,4 +123,21 @@ interface UserMessageStateHolder {
 enum class UserMessageResult {
     Dismissed,
     ActionPerformed,
+}
+
+class FakeUserMessageStateHolder : UserMessageStateHolder {
+    private var _messageUiState by mutableStateOf(MessageUiState())
+    override val messageUiState get() = _messageUiState
+    override fun messageShown(messageId: Int, userMessageResult: UserMessageResult) {
+        // fake
+    }
+
+    override suspend fun showMessage(
+        message: String,
+        actionLabel: String?,
+        duration: SnackbarDuration?,
+    ): UserMessageResult {
+        // fake
+        return UserMessageResult.Dismissed
+    }
 }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/UserMessage.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/UserMessage.kt
@@ -124,20 +124,3 @@ enum class UserMessageResult {
     Dismissed,
     ActionPerformed,
 }
-
-class FakeUserMessageStateHolder : UserMessageStateHolder {
-    private var _messageUiState by mutableStateOf(MessageUiState())
-    override val messageUiState get() = _messageUiState
-    override fun messageShown(messageId: Int, userMessageResult: UserMessageResult) {
-        // fake
-    }
-
-    override suspend fun showMessage(
-        message: String,
-        actionLabel: String?,
-        duration: SnackbarDuration?,
-    ): UserMessageResult {
-        // fake
-        return UserMessageResult.Dismissed
-    }
-}

--- a/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/RandomUUID.kt
+++ b/core/ui/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/ui/RandomUUID.kt
@@ -1,0 +1,5 @@
+package io.github.droidkaigi.confsched2023.ui
+
+import platform.Foundation.NSUUID
+
+actual fun randomUUIDHash(): Int = NSUUID().hash.toInt()

--- a/feature/contributors/build.gradle.kts
+++ b/feature/contributors/build.gradle.kts
@@ -15,10 +15,6 @@ kotlin {
                 implementation(projects.core.model)
                 implementation(projects.core.ui)
                 implementation(libs.kotlinxCoroutinesCore)
-            }
-        }
-        androidMain {
-            dependencies {
                 implementation(projects.core.designsystem)
             }
         }

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
@@ -13,11 +13,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -25,6 +28,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import io.github.droidkaigi.confsched2023.contributors.component.ContributorListItem
 import io.github.droidkaigi.confsched2023.model.Contributor
+import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.PersistentList
 
 const val contributorsScreenRoute = "contributors"
@@ -40,8 +44,15 @@ fun ContributorsScreen(
     contentPadding: PaddingValues = PaddingValues(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    SnackbarMessageEffect(
+        snackbarHostState = snackbarHostState,
+        userMessageStateHolder = viewModel.userMessageStateHolder,
+    )
     ContributorsScreen(
         uiState = uiState,
+        snackbarHostState = snackbarHostState,
         onBackClick = onNavigationIconClick,
         onContributorItemClick = onContributorItemClick,
         contentPadding = contentPadding,
@@ -52,6 +63,7 @@ fun ContributorsScreen(
 @Composable
 private fun ContributorsScreen(
     uiState: ContributorsUiState,
+    snackbarHostState: SnackbarHostState,
     onBackClick: () -> Unit,
     onContributorItemClick: (url: String) -> Unit,
     contentPadding: PaddingValues,
@@ -60,6 +72,7 @@ private fun ContributorsScreen(
     val localLayoutDirection = LocalLayoutDirection.current
     Scaffold(
         modifier = Modifier.testTag(ContributorsScreenTestTag),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             LargeTopAppBar(
                 title = {

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsViewModel.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsViewModel.kt
@@ -1,10 +1,13 @@
 package io.github.droidkaigi.confsched2023.contributors
 
+import io.github.droidkaigi.confsched2023.designsystem.strings.AppStrings
 import io.github.droidkaigi.confsched2023.model.ContributorsRepository
 import io.github.droidkaigi.confsched2023.ui.HiltViewModel
 import io.github.droidkaigi.confsched2023.ui.Inject
 import io.github.droidkaigi.confsched2023.ui.KmpViewModel
+import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched2023.ui.buildUiState
+import io.github.droidkaigi.confsched2023.ui.handleErrorAndRetry
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.SharingStarted
@@ -13,10 +16,15 @@ import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel
 class ContributorsViewModel @Inject constructor(
-    contributorsRepository: ContributorsRepository
-) : KmpViewModel() {
+    contributorsRepository: ContributorsRepository,
+    val userMessageStateHolder: UserMessageStateHolder,
+) : KmpViewModel(), UserMessageStateHolder by userMessageStateHolder {
     private val contributors = contributorsRepository
         .contributors()
+        .handleErrorAndRetry(
+            AppStrings.Retry,
+            userMessageStateHolder,
+        )
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.Lazily,

--- a/feature/contributors/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/contributors/DarwinContributors.kt
+++ b/feature/contributors/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/contributors/DarwinContributors.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.window.ComposeUIViewController
 import io.github.droidkaigi.confsched2023.data.contributors.DefaultContributorsRepository
 import io.github.droidkaigi.confsched2023.data.contributors.FakeContributorsApiClient
+import io.github.droidkaigi.confsched2023.ui.FakeUserMessageStateHolder
 import platform.UIKit.UIViewController
 
 @Suppress("UNUSED")
@@ -14,7 +15,8 @@ fun viewController(): UIViewController = ComposeUIViewController {
         // FIXME: Tentatively passing FakeRepository
         DefaultContributorsRepository(
             FakeContributorsApiClient()
-        )
+        ),
+        FakeUserMessageStateHolder()
     )
     val uiViewController = LocalUIViewController.current
     LaunchedEffect(uiViewController) {

--- a/feature/contributors/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/contributors/DarwinContributors.kt
+++ b/feature/contributors/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/contributors/DarwinContributors.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.window.ComposeUIViewController
 import io.github.droidkaigi.confsched2023.data.contributors.DefaultContributorsRepository
 import io.github.droidkaigi.confsched2023.data.contributors.FakeContributorsApiClient
-import io.github.droidkaigi.confsched2023.ui.FakeUserMessageStateHolder
+import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolderImpl
 import platform.UIKit.UIViewController
 
 @Suppress("UNUSED")
@@ -16,7 +16,7 @@ fun viewController(): UIViewController = ComposeUIViewController {
         DefaultContributorsRepository(
             FakeContributorsApiClient()
         ),
-        FakeUserMessageStateHolder()
+        UserMessageStateHolderImpl()
     )
     val uiViewController = LocalUIViewController.current
     LaunchedEffect(uiViewController) {


### PR DESCRIPTION
## Issue
- close #752

## Overview (Required)
- When a communication error occurs on the Contributors screen
Show the snackbar.
- UUID.mostSignificantBits was used for the UserMessage.id, but since there is no similar function in IOS, the UUID hash code is used as the id.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/51166726/b94bbaa1-9255-46c1-b269-acb029d02bbe" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/51166726/f7039093-0015-4f59-aca5-bab601e19ed5" width="300" >
