### PR TITLE
Fix oss licenses plugin id

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("droidkaigi.primitive.detekt")
     id("droidkaigi.primitive.android.roborazzi")
     id("droidkaigi.primitive.kover")
-    id("droidkaigi.primitive.osslicenses")
+    id("droidkaigi.primitive.android.osslicenses")
 }
 
 val keystorePropertiesFile = file("keystore.properties")

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -99,7 +99,7 @@ gradlePlugin {
             implementationClass = "io.github.droidkaigi.confsched2023.primitive.DetektPlugin"
         }
         register("oss-licenses") {
-            id = "droidkaigi.primitive.osslicenses"
+            id = "droidkaigi.primitive.android.osslicenses"
             implementationClass = "io.github.droidkaigi.confsched2023.primitive.OssLicensesPlugin"
         }
 


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2023/pull/883#discussion_r1305399330

## Overview (Required)
- Fix the plugin id for `oss licenses` based on the previous PR comments.

## Links
- https://github.com/DroidKaigi/conference-app-2023/pull/883#discussion_r1305399330

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
