### PR TITLE
[iOS] Implement the calendar registration feature on the session detail

### DIFF
--- a/app-ios/App/DroidKaigi2023/DroidKaigi2023.xcodeproj/project.pbxproj
+++ b/app-ios/App/DroidKaigi2023/DroidKaigi2023.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DroidKaigi2023/Info.plist;
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "Use for adding events to your calendar";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -496,6 +497,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DroidKaigi2023/Info.plist;
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "Use for adding events to your calendar";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/app-ios/Modules/Package.resolved
+++ b/app-ios/Modules/Package.resolved
@@ -118,6 +118,15 @@
       }
     },
     {
+      "identity" : "lottie-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-spm",
+      "state" : {
+        "revision" : "60ea4f82fba8b4cb21a75665a889e86ed4d81c6e",
+        "version" : "4.2.0"
+      }
+    },
+    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",

--- a/app-ios/Modules/Package.swift
+++ b/app-ios/Modules/Package.swift
@@ -142,6 +142,7 @@ var package = Package(
             dependencies: [
                 "Assets",
                 "Component",
+                "Event",
                 "KMPContainer",
                 "Model",
             ]

--- a/app-ios/Modules/Package.swift
+++ b/app-ios/Modules/Package.swift
@@ -99,6 +99,10 @@ var package = Package(
         ),
 
         .target(
+            name: "Event"
+        ),
+
+        .target(
             name: "FloorMap",
             dependencies: [
                 "Assets",

--- a/app-ios/Modules/Package.swift
+++ b/app-ios/Modules/Package.swift
@@ -99,7 +99,10 @@ var package = Package(
         ),
 
         .target(
-            name: "Event"
+            name: "Event",
+            dependencies: [
+                .product(name: "Dependencies", package: "swift-dependencies"),
+            ]
         ),
 
         .target(

--- a/app-ios/Modules/Sources/Event/EventKitClient.swift
+++ b/app-ios/Modules/Sources/Event/EventKitClient.swift
@@ -1,0 +1,44 @@
+import EventKit
+import UIKit
+
+public protocol EventKitClientProtocol {
+    func requestAccessIfNeeded() async throws -> Bool
+    func addEvent(title: String, startDate: Date, endDate: Date) throws
+}
+
+public struct EventKitClient: EventKitClientProtocol {
+    private let eventStore: EKEventStore = .init()
+
+    public init() {}
+
+    public func requestAccessIfNeeded() async throws -> Bool {
+        switch EKEventStore.authorizationStatus(for: .event) {
+        case .denied, .restricted:
+            _ = await UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+        case .authorized, .fullAccess, .writeOnly:
+            return true
+        case .notDetermined:
+            break
+        @unknown default:
+            break
+        }
+        if #available(iOS 17.0, *) {
+            return try await eventStore.requestWriteOnlyAccessToEvents()
+        } else {
+            return try await eventStore.requestAccess(to: .event)
+        }
+    }
+
+    public func addEvent(title: String, startDate: Date, endDate: Date) throws {
+        guard let defaultCalendar = eventStore.defaultCalendarForNewEvents else {
+            return
+        }
+        let event = EKEvent(eventStore: eventStore)
+        event.title = title
+        event.startDate = startDate
+        event.endDate = endDate
+        event.calendar = defaultCalendar
+
+        try eventStore.save(event, span: .thisEvent)
+    }
+}

--- a/app-ios/Modules/Sources/Event/EventKitClientKey.swift
+++ b/app-ios/Modules/Sources/Event/EventKitClientKey.swift
@@ -1,0 +1,12 @@
+import Dependencies
+
+public enum EventKitClientKey: DependencyKey {
+    public static var liveValue: EventKitClientProtocol = EventKitClient()
+}
+
+public extension DependencyValues {
+   var eventKitClient: EventKitClientProtocol {
+       get { self[EventKitClientKey.self] }
+       set { self[EventKitClientKey.self] = newValue }
+   }
+}

--- a/app-ios/Modules/Sources/Event/EventKitClientMock.swift
+++ b/app-ios/Modules/Sources/Event/EventKitClientMock.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct EventKitClientMock: EventKitClientProtocol {
+    public init() {}
+
+    public func requestAccessIfNeeded() async throws -> Bool {
+        return true
+    }
+
+    public func addEvent(title: String, startDate: Date, endDate: Date) throws {}
+}

--- a/app-ios/Modules/Sources/Session/SessionView.swift
+++ b/app-ios/Modules/Sources/Session/SessionView.swift
@@ -16,6 +16,7 @@ public struct SessionView: View {
     @ObservedObject private(set) var viewModel: SessionViewModel
     @State private var isDescriptionExpanded: Bool = false
     @State private var canBeExpanded: Bool = false
+    @State private var isAddingToCalendarConfirming: Bool = false
     @State private var presentingURL: IdentifiableURL?
 
     public init(timetableItem: TimetableItem) {
@@ -175,7 +176,9 @@ public struct SessionView: View {
             ToolbarItem(placement: .bottomBar) {
                 Button {
                     Task {
-                        await viewModel.requestAddingToCalendar()
+                        if await viewModel.requestEventAccessIfNeeded() {
+                            isAddingToCalendarConfirming.toggle()
+                        }
                     }
                 } label: {
                     Assets.Icons.calendarAddOn.swiftUIImage
@@ -192,13 +195,13 @@ public struct SessionView: View {
                 }
             }
         }
-        .confirmationDialog("", isPresented: $viewModel.isAddingToCalendarConfirming) {
+        .confirmationDialog("", isPresented: $isAddingToCalendarConfirming) {
             Button("Add to your calendar") {
                 viewModel.addToCalendar()
             }
 
             Button("Cancel", role: .cancel) {
-                viewModel.isAddingToCalendarConfirming = false
+                isAddingToCalendarConfirming = false
             }
         }
         .sheet(item: $presentingURL) { url in

--- a/app-ios/Modules/Sources/Session/SessionView.swift
+++ b/app-ios/Modules/Sources/Session/SessionView.swift
@@ -13,7 +13,7 @@ private let startDateFormatter: DateFormatter = {
 }()
 
 public struct SessionView: View {
-    let viewModel: SessionViewModel
+    @ObservedObject private(set) var viewModel: SessionViewModel
     @State private var isDescriptionExpanded: Bool = false
     @State private var canBeExpanded: Bool = false
     @State private var presentingURL: IdentifiableURL?
@@ -174,7 +174,9 @@ public struct SessionView: View {
             }
             ToolbarItem(placement: .bottomBar) {
                 Button {
-                    // TODO: Add to Calendar
+                    Task {
+                        await viewModel.requestAddingToCalendar()
+                    }
                 } label: {
                     Assets.Icons.calendarAddOn.swiftUIImage
                 }
@@ -188,6 +190,15 @@ public struct SessionView: View {
                 } label: {
                     Assets.Icons.bookmarkBorder.swiftUIImage
                 }
+            }
+        }
+        .confirmationDialog("", isPresented: $viewModel.isAddingToCalendarConfirming) {
+            Button("Add to your calendar") {
+                viewModel.addToCalendar()
+            }
+
+            Button("Cancel", role: .cancel) {
+                viewModel.isAddingToCalendarConfirming = false
             }
         }
         .sheet(item: $presentingURL) { url in

--- a/app-ios/Modules/Sources/Session/SessionViewModel.swift
+++ b/app-ios/Modules/Sources/Session/SessionViewModel.swift
@@ -6,20 +6,18 @@ import shared
 @MainActor
 final class SessionViewModel: ObservableObject {
     @Dependency(\.eventKitClient) var eventKitClient
-    @Published var isAddingToCalendarConfirming: Bool = false
     let timetableItem: TimetableItem
 
     init(timetableItem: TimetableItem) {
         self.timetableItem = timetableItem
     }
 
-    func requestAddingToCalendar() async {
+    func requestEventAccessIfNeeded() async -> Bool {
         do {
-            if try await eventKitClient.requestAccessIfNeeded() {
-                isAddingToCalendarConfirming.toggle()
-            }
+            return try await eventKitClient.requestAccessIfNeeded()
         } catch {
             print(error.localizedDescription)
+            return false
         }
     }
 

--- a/app-ios/Modules/Sources/Session/SessionViewModel.swift
+++ b/app-ios/Modules/Sources/Session/SessionViewModel.swift
@@ -1,10 +1,37 @@
+import Dependencies
+import Event
 import Foundation
 import shared
 
-final class SessionViewModel {
+@MainActor
+final class SessionViewModel: ObservableObject {
+    @Dependency(\.eventKitClient) var eventKitClient
+    @Published var isAddingToCalendarConfirming: Bool = false
     let timetableItem: TimetableItem
 
     init(timetableItem: TimetableItem) {
         self.timetableItem = timetableItem
+    }
+
+    func requestAddingToCalendar() async {
+        do {
+            if try await eventKitClient.requestAccessIfNeeded() {
+                isAddingToCalendarConfirming.toggle()
+            }
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+
+    func addToCalendar() {
+        do {
+            try eventKitClient.addEvent(
+                title: timetableItem.title.currentLangTitle,
+                startDate: timetableItem.startsAt.toDate(),
+                endDate: timetableItem.endsAt.toDate()
+            )
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }


### PR DESCRIPTION
## Issue
- close #887

## Overview (Required)
- This PR implements the calendar registration feature on the session detail
  - The event module is copied from the official app 2022
  - This PR doesn't provide any localizations

## Links
- https://github.com/DroidKaigi/conference-app-2022/tree/main/app-ios/Sources/Event

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/53ae1863-9373-4703-98e2-fab9399e9df3" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
