### PR TITLE
Switching the Code of conduct page based on the selected language

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -57,7 +57,9 @@ import io.github.droidkaigi.confsched2023.model.AboutItem.Sponsors
 import io.github.droidkaigi.confsched2023.model.AboutItem.Staff
 import io.github.droidkaigi.confsched2023.model.AboutItem.X
 import io.github.droidkaigi.confsched2023.model.AboutItem.YouTube
+import io.github.droidkaigi.confsched2023.model.Lang.JAPANESE
 import io.github.droidkaigi.confsched2023.model.TimetableItem
+import io.github.droidkaigi.confsched2023.model.defaultLang
 import io.github.droidkaigi.confsched2023.sessions.navigateSearchScreen
 import io.github.droidkaigi.confsched2023.sessions.navigateTimetableScreen
 import io.github.droidkaigi.confsched2023.sessions.navigateToBookmarkScreen
@@ -148,7 +150,13 @@ private fun NavGraphBuilder.mainScreen(
                 onAboutItemClick = { aboutItem ->
                     when (aboutItem) {
                         Sponsors -> navController.navigateSponsorsScreen()
-                        CodeOfConduct -> externalNavController.navigate(url = "https://portal.droidkaigi.jp/about/code-of-conduct")
+                        CodeOfConduct -> {
+                            val url = if(defaultLang() == JAPANESE) {
+                                "https://portal.droidkaigi.jp/about/code-of-conduct"
+                            }else{
+                                "https://portal.droidkaigi.jp/en/about/code-of-conduct"
+                            }
+                            externalNavController.navigate(url = url)}
                         Contributors -> mainNestedNavController.navigate(contributorsScreenRoute)
                         License -> externalNavController.navigateToLicenseScreen()
                         Medium -> externalNavController.navigate(url = "https://medium.com/droidkaigi")


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Switching the Code of conduct page based on the selected language

## Links
- EN: https://portal.droidkaigi.jp/en/about/code-of-conduct
- JP: https://portal.droidkaigi.jp/about/code-of-conduct

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
English | Japanese
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/16269075/843f98d8-1450-44f5-b47f-754fe84695dc" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/16269075/4af5109a-dd87-4056-aa2c-b60fd5560fc4" width="300" >








