### PR TITLE
Optimize the time table performance with reduce boxing

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -14,7 +14,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -92,7 +92,7 @@ private fun ResizeableText(
     styles: ImmutableList<TextStyle>,
     overflow: TextOverflow,
 ) {
-    var styleIndex by remember(text) { mutableStateOf(0) }
+    var styleIndex by remember(text) { mutableIntStateOf(0) }
     Text(
         text = text,
         overflow = overflow,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableScreenScrollState.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableScreenScrollState.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2023.sessions.component
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -26,11 +26,11 @@ class TimetableScreenScrollState(
     initialSheetScrollOffset: Float = 0f,
 ) {
     // This value will be like -418.0
-    private var sheetScrollOffsetLimit by mutableStateOf(initialSheetOffsetLimit)
+    private var sheetScrollOffsetLimit by mutableFloatStateOf(initialSheetOffsetLimit)
 
     val isScreenLayoutCalculating get() = sheetScrollOffsetLimit == 0f
 
-    private val _sheetScrollOffset = mutableStateOf(initialSheetScrollOffset)
+    private val _sheetScrollOffset = mutableFloatStateOf(initialSheetScrollOffset)
 
     /**
      * If sheetScrollOffset is 0f, the sheet is fully collapsed.

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTab.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -146,12 +146,12 @@ class TimetableTabState(
     initialScrollOffset: Float = 0f,
 ) {
 
-    private val scrollOffsetLimit by mutableStateOf(initialOffsetLimit)
+    private val scrollOffsetLimit by mutableFloatStateOf(initialOffsetLimit)
 
     val tabCollapseProgress: Float
         get() = scrollOffset / scrollOffsetLimit
 
-    private val _scrollOffset = mutableStateOf(initialScrollOffset)
+    private val _scrollOffset = mutableFloatStateOf(initialScrollOffset)
 
     var scrollOffset: Float
         get() = _scrollOffset.value


### PR DESCRIPTION
## Issue
- Similar to https://github.com/DroidKaigi/conference-app-2023/pull/1013

## Overview (Required)
- Improve the performance by use suitable method.
- Reduce boxing will improve the performance
