### PR TITLE
enable to display session title when bigfont / bigdisplay

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -105,7 +106,7 @@ private fun ResizeableText(
             }
         },
         style = styles[styleIndex],
-        modifier = Modifier.padding(end = 16.dp),
+        modifier = Modifier.padding(end = 16.dp).heightIn(max = 88.dp),
     )
 }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -108,9 +108,10 @@ private fun ResizeableText(
         style = styles[styleIndex],
         modifier = Modifier
             .padding(end = 16.dp)
-            // title heights of LargeTopAppBar will be used `TopAppBarLargeTokens.ContainerHeight` and `TopAppBarSmallTokens.ContainerHeight`.
-            // these are internal values in material3.
-            // so, set max height as constant dp. (Large - Small)
+            // title heights of LargeTopAppBar will use `TopAppBarLargeTokens.ContainerHeight`, `TopAppBarSmallTokens.ContainerHeight` and `scroll offset`.
+            // because of this, this height become taller than our expectation.
+            // we want to fix max height, but `ContainerHeight`s are internal values in material3.
+            // so set as constant dp. (Large - Small)
             .heightIn(max = 88.dp),
     )
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -106,7 +106,12 @@ private fun ResizeableText(
             }
         },
         style = styles[styleIndex],
-        modifier = Modifier.padding(end = 16.dp).heightIn(max = 88.dp),
+        modifier = Modifier
+            .padding(end = 16.dp)
+            // title heights of LargeTopAppBar will be used `TopAppBarLargeTokens.ContainerHeight` and `TopAppBarSmallTokens.ContainerHeight`.
+            // these are internal values in material3.
+            // so, set max height as constant dp. (Large - Small)
+            .heightIn(max = 88.dp),
     )
 }
 


### PR DESCRIPTION
# ※If this is not good solution, please close :bow: 

## Issue
- close #464

## Overview (Required)
- when set font & display to BIG, there is a possibility the seesion titles are displayed with overflow
- on LargeTopAppBar, height of large title is expected not to exceed particular value.
  - https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/AppBar.kt;l=358-359?q=AppBar.kt
- and when layout, the height will considered such like following
  - `large title height (max)` - `min title height` + `scroll offset`
  - https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/AppBar.kt;l=1246-1247?q=AppBar.kt
  - because of this, large title area will be large than dislayed actually (I think)
- I set `heightIn(...)` to set max height of `ResizableText` component as ↓
  - `large title height (max)` - `min title height`
  - https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/tokens/TopAppBarLargeTokens.kt;l=26
  - https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/tokens/TopAppBarSmallTokens.kt;l=26

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/e57cd386-dcfc-4c82-8afb-631b202ac1f5" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/faefb02d-0d80-4e3c-a973-a7b6ffd75b42" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/bbfca67b-2e28-4c40-a8a1-e2c1bab1c506" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/e4f60b1f-dba7-46dc-8bb6-a9545ed77603" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/33386ced-be42-48e3-b75b-d940872e4fac" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/0ae8591d-9313-4861-9e29-f6645c9fdabe" width="300" />

### when not bigfont / bigdisplay
※it is for making sure that there is not diff when it is not bigfont/bigdisplay.
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/da7e1037-0565-4cd5-9bd3-7138145bde3f" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/252d5079-78e0-408f-9705-24866adbf682" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/9b91ba3b-3b22-4264-b744-90e62fa4e399" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/340b1d1e-8c46-4a4c-bada-e09503bd829e" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/339f4fb7-c77a-4edc-9e81-6d2d7f9a7e6f" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/2f4e848b-d897-451f-ae42-31face4b35af" width="300" />

