### PR TITLE
[iOS] Add a bottom padding to the floor map

### DIFF
--- a/app-ios/Modules/Sources/FloorMap/FloorMapView.swift
+++ b/app-ios/Modules/Sources/FloorMap/FloorMapView.swift
@@ -28,6 +28,7 @@ public struct FloorMapView: View {
                             case .basement: basementMapView(sideEvents: floorSideEvent.basement)
                             default: groundMapView(sideEvents: floorSideEvent.ground)
                             }
+                            Spacer().frame(height: 8 + 40 + 24) // row bottom padding + button height + button bottom padding 
                         }
                         .foregroundStyle(AssetColors.Primary.primary.swiftUIColor)
                         VStack(spacing: 0) {


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- The side events on the floor map are partially hidden under the footer button.
   This PR adds a bottom padding and resolves that.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/be23a11b-93c4-4ba5-bc2c-7b840f42ebc5" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/d6ac9e4f-661b-45d9-9dc9-0dea8f5d8542" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
