### PR TITLE
fix image size (aspect ratio) of speaker icon on TimetableGridITem

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -219,7 +218,7 @@ private fun SpeakerIcon(
         },
         contentDescription = UserIcon.asString(),
         modifier = modifier
-            .aspectRatio(ratio = 1f)
+            .size(TimetableGridItemSizes.speakerHeight)
             .clip(RoundedCornerShape(8.dp))
             .border(
                 BorderStroke(1.dp, md_theme_light_outline),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -218,6 +219,7 @@ private fun SpeakerIcon(
         },
         contentDescription = UserIcon.asString(),
         modifier = modifier
+            .aspectRatio(ratio = 1f)
             .clip(RoundedCornerShape(8.dp))
             .border(
                 BorderStroke(1.dp, md_theme_light_outline),


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- when loading speaker icon, width of icon will be expanded to max width of `Row`.
- by setting `Modifier.aspectRatio(...)`, fix the size of icon as square.
- There are snapshot diffs.
  - the image used for preview (Icons.Default.Person) is `24.dp`.
  - so, speaker icons were displayed little bit smaller than real.

## Links
- https://developer.android.com/jetpack/compose/graphics/images/customize#custom-aspect-ratio

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/3497d1fa-7ac2-4f9a-ab66-ea36292bfc86" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/76df738c-7de2-4f38-a976-d2c514013c5e" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/1a7254f0-a94c-436f-832a-27fea6e627d5" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/f1bb7b80-f57a-45c4-bf1e-3e7841df20fe" width="300" >
