### PR TITLE
[iOS] Switch information links depending on the current locale

### DIFF
--- a/app-ios/Modules/Sources/About/AboutView.swift
+++ b/app-ios/Modules/Sources/About/AboutView.swift
@@ -2,6 +2,7 @@ import Assets
 import Component
 import LicenseList
 import Model
+import shared
 import SwiftUI
 import Theme
 
@@ -86,7 +87,7 @@ public struct AboutView<ContributorView: View, StaffView: View, SponsorView: Vie
                     }
                     Divider()
                     SectionTitle(title: "Others")
-                    SafariLink(url: .codeOfConduct) {
+                    SafariLink(url: LocaleKt.getDefaultLocale() == .japan ? .codeOfConduct : .codeOfConductEn) {
                         ListTile(
                             icon: Assets.Icons.gavel.swiftUIImage,
                             title: "行動規範"
@@ -100,7 +101,7 @@ public struct AboutView<ContributorView: View, StaffView: View, SponsorView: Vie
                         )
                     }
                     Divider()
-                    SafariLink(url: .privacyPolicy) {
+                    SafariLink(url: LocaleKt.getDefaultLocale() == .japan ? .privacyPolicy : .privacyPolicyEn) {
                         ListTile(
                             icon: Assets.Icons.privacyTip.swiftUIImage,
                             title: "プライバシーポリシー"

--- a/app-ios/Modules/Sources/About/Constants/URL+About.swift
+++ b/app-ios/Modules/Sources/About/Constants/URL+About.swift
@@ -5,5 +5,7 @@ extension URL {
     static let twitter = URL(string: "https://twitter.com/DroidKaigi")!
     static let medium = URL(string: "https://medium.com/droidkaigi")!
     static let privacyPolicy = URL(string: "https://portal.droidkaigi.jp/about/privacy")!
+    static let privacyPolicyEn = URL(string: "https://portal.droidkaigi.jp/en/about/privacy")!
     static let codeOfConduct = URL(string: "https://portal.droidkaigi.jp/about/code-of-conduct")!
+    static let codeOfConductEn = URL(string: "https://portal.droidkaigi.jp/en/about/code-of-conduct")!
 }


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR changes to switch links to Code Of Conduct and Privacy Policy depending on the current locale

## Links
- #1022

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/2d613098-5c40-4538-b780-5e194791a346" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/387a3ca4-70ad-4bc0-8326-142159b90418" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
