### PR TITLE
[iOS] Enable links in descriptions on the session detail

### DIFF
--- a/app-ios/Modules/Sources/Session/SessionView.swift
+++ b/app-ios/Modules/Sources/Session/SessionView.swift
@@ -15,7 +15,8 @@ private let startDateFormatter: DateFormatter = {
 public struct SessionView: View {
     let viewModel: SessionViewModel
     @State private var isDescriptionExpanded: Bool = false
-    @State private var canBeExpanded = false
+    @State private var canBeExpanded: Bool = false
+    @State private var presentingURL: IdentifiableURL?
 
     public init(timetableItem: TimetableItem) {
         self.viewModel = .init(timetableItem: timetableItem)
@@ -65,7 +66,7 @@ public struct SessionView: View {
 
                 if let session = viewModel.timetableItem as? TimetableItem.Session {
                     VStack(alignment: .leading, spacing: 16) {
-                        Text(session.description_.currentLangTitle)
+                        Text(.init(session.description_.currentLangTitle))
                             .textSelection(.enabled)
                             .lineLimit(isDescriptionExpanded ? nil : 5)
                             .background {
@@ -189,7 +190,16 @@ public struct SessionView: View {
                 }
             }
         }
-
+        .sheet(item: $presentingURL) { url in
+            if let url = url.id {
+                SafariView(url: url)
+                    .ignoresSafeArea()
+            }
+        }
+        .environment(\.openURL, OpenURLAction { url in
+            presentingURL = IdentifiableURL(url)
+            return .handled
+        })
     }
 }
 


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR enables links in descriptions on the session detail

## Links
-

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/26d79481-2731-4ecf-965f-7e631b6cf7cc" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/1f9b8e7a-f029-4ff8-9021-757df6bbcea6" width="300" />
|| <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/de9522e9-2810-4835-b077-eec2ed021e67" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
