### PR TITLE
Improve timetable list accessibility

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -84,8 +84,12 @@ public sealed class TimetableItem {
         "$minutes" + MultiLangText(jaTitle = "分", enTitle = "min").currentLangTitle
     }
 
+    public val formattedTimeString: String by lazy {
+        "$startsTimeString ~ $endsTimeString"
+    }
+
     public val formattedDateTimeString: String by lazy {
-        "$startsDateString / $startsTimeString ~ $endsTimeString ($minutesString)"
+        "$startsDateString / $formattedTimeString ($minutesString)"
     }
 
     public val url: String get() = "https://2023.droidkaigi.jp/timetable/${id.value}"

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableList.kt
@@ -29,6 +29,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -99,10 +102,14 @@ fun TimetableList(
                             space = 4.dp,
                             alignment = Alignment.CenterVertically,
                         ),
+                        modifier = Modifier.semantics(mergeDescendants = true) {
+                            contentDescription = timetableItem.formattedTimeString
+                        },
                     ) {
                         Text(
                             text = timetableItem.startsTimeString,
                             fontWeight = FontWeight.Medium,
+                            modifier = Modifier.clearAndSetSemantics {},
                         )
                         Box(
                             modifier = Modifier
@@ -114,6 +121,7 @@ fun TimetableList(
                             text = timetableItem.endsTimeString,
                             color = MaterialTheme.colorScheme.secondary,
                             fontWeight = FontWeight.Medium,
+                            modifier = Modifier.clearAndSetSemantics {},
                         )
                     }
                 }


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- I improved the accessibility of `TimetableList`.
    - When you enable TalkBack, `startsTimeString` and `endsTimeString`  were being read separately, so now they are read as a whole.

## Links
- [Modifier.clearAndSetSemantics](https://developer.android.com/reference/kotlin/androidx/compose/ui/semantics/package-summary#(androidx.compose.ui.Modifier).clearAndSetSemantics(kotlin.Function1))

## Screenshot (Optional if screenshot test is present or unrelated to UI)

### Before
<img width="1001" alt="before" src="https://github.com/DroidKaigi/conference-app-2023/assets/15653509/812a7235-c424-4626-a14a-a9141f415540">

### After
<img width="753" alt="after" src="https://github.com/DroidKaigi/conference-app-2023/assets/15653509/eae74877-0794-4728-a62b-601a9b8baa16">
