### PR TITLE
[iOS] add a picker to switch SwiftUI-based and Compose-based views

### DIFF
--- a/app-ios/Modules/Sources/Contributor/ContributorView.swift
+++ b/app-ios/Modules/Sources/Contributor/ContributorView.swift
@@ -7,17 +7,33 @@ import SwiftUI
 public struct ContributorView: View {
     @State var presentingURL: IdentifiableURL?
 
+    @State private var selection: ViewType = .swiftUi
+    private enum ViewType: Hashable {
+        case swiftUi
+        case compose
+    }
+
     public init() {}
 
     public var body: some View {
-        Group {
-//            ContributorSwiftUIView { url in
-//                presentingURL = .init(string: url)
-//            }
-
-            ContributorComposeView { url in
-                presentingURL = .init(string: url)
+        VStack {
+            Picker("select view type", selection: $selection) {
+                Text("SwiftUI").tag(ViewType.swiftUi)
+                Text("Compose").tag(ViewType.compose)
             }
+            .pickerStyle(.segmented)
+
+            switch selection {
+            case .swiftUi:
+                ContributorSwiftUIView { url in
+                    presentingURL = .init(string: url)
+                }
+            case .compose:
+                ContributorComposeView { url in
+                    presentingURL = .init(string: url)
+                }
+            }
+            Spacer()
         }
         .navigationTitle("Contributor")
         .sheet(item: $presentingURL) { url in

--- a/app-ios/Modules/Sources/Contributor/ContributorView.swift
+++ b/app-ios/Modules/Sources/Contributor/ContributorView.swift
@@ -8,7 +8,7 @@ public struct ContributorView: View {
     @State var presentingURL: IdentifiableURL?
 
     @State private var selection: ViewType = .swiftUi
-    private enum ViewType: Hashable {
+    private enum ViewType {
         case swiftUi
         case compose
     }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- SSIA

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
SwiftUI | Compose
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/b95749d7-e932-4660-a6d7-e4f0349db8c6" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/d0f577ce-10ad-44da-9d99-2df8d627bf7f" width="300" />
