### PR TITLE
Extract kover configurations into a build-logic plugin

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("droidkaigi.primitive.android.crashlytics")
     id("droidkaigi.primitive.detekt")
     id("droidkaigi.primitive.android.roborazzi")
-    id("droidkaigi.primitive.kover")
+    id("droidkaigi.primitive.kover.entrypoint")
     id("droidkaigi.primitive.android.osslicenses")
 }
 
@@ -115,26 +115,4 @@ dependencies {
     implementation(libs.kermit)
     implementation(libs.firebaseDynamicLinks)
     testImplementation(projects.core.testing)
-}
-
-// Dependency configuration to aggregate Kover coverage reports
-// TODO: extract report aggregation to build-logic
-dependencies {
-    kover(projects.appIosShared)
-
-    kover(projects.feature.about)
-    kover(projects.feature.contributors)
-    kover(projects.feature.floorMap)
-    kover(projects.feature.main)
-    kover(projects.feature.sessions)
-    kover(projects.feature.sponsors)
-    kover(projects.feature.staff)
-    kover(projects.feature.achievements)
-
-    kover(projects.core.common)
-    kover(projects.core.data)
-    kover(projects.core.designsystem)
-    kover(projects.core.model)
-    kover(projects.core.testing)
-    kover(projects.core.ui)
 }

--- a/app-ios-shared/build.gradle.kts
+++ b/app-ios-shared/build.gradle.kts
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 plugins {
     id("droidkaigi.primitive.kmp")
     id("droidkaigi.primitive.kmp.ios")
-    id("droidkaigi.primitive.kover")
 }
 
 kotlin {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -94,9 +94,9 @@ gradlePlugin {
             id = "droidkaigi.primitive.kmp.serialization"
             implementationClass = "io.github.droidkaigi.confsched2023.primitive.KotlinSerializationPlugin"
         }
-        register("kover") {
-            id = "droidkaigi.primitive.kover"
-            implementationClass = "io.github.droidkaigi.confsched2023.primitive.KoverPlugin"
+        register("koverEntryPoint") {
+            id = "droidkaigi.primitive.kover.entrypoint"
+            implementationClass = "io.github.droidkaigi.confsched2023.primitive.KoverEntryPointPlugin"
         }
         register("detekt") {
             id = "droidkaigi.primitive.detekt"

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/convention/AndroidFeaturePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/convention/AndroidFeaturePlugin.kt
@@ -14,7 +14,6 @@ class AndroidFeaturePlugin : Plugin<Project> {
                 apply("droidkaigi.primitive.android.compose")
                 apply("droidkaigi.primitive.android.hilt")
                 apply("droidkaigi.primitive.android.roborazzi")
-                apply("droidkaigi.primitive.kover")
                 apply("droidkaigi.primitive.detekt")
             }
 

--- a/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KoverEntryPointPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/droidkaigi/confsched2023/primitive/KoverEntryPointPlugin.kt
@@ -5,10 +5,17 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 
-class KoverPlugin : Plugin<Project> {
+class KoverEntryPointPlugin : Plugin<Project> {
     override fun apply(target: Project) {
+        val koverPlugin = "org.jetbrains.kotlinx.kover"
         with(target) {
-            pluginManager.apply("org.jetbrains.kotlinx.kover")
+            pluginManager.apply(koverPlugin)
+
+            rootProject.subprojects {
+                if (this@subprojects.name == target.name) return@subprojects
+                this@subprojects.pluginManager.apply(koverPlugin)
+                target.dependencies.add("kover", this@subprojects)
+            }
 
             configure<KoverReportExtension> {
                 filters {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("droidkaigi.primitive.kmp.android")
     id("droidkaigi.primitive.kmp.ios")
     id("droidkaigi.primitive.kmp.android.hilt")
-    id("droidkaigi.primitive.kover")
     id("droidkaigi.primitive.detekt")
 }
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     id("droidkaigi.primitive.detekt")
     id("droidkaigi.primitive.kmp.ktorfit")
     id("droidkaigi.primitive.kmp.serialization")
-    id("droidkaigi.primitive.kover")
 }
 
 android.namespace = "io.github.droidkaigi.confsched2023.core.data"

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     id("droidkaigi.primitive.kmp.android.hilt")
     id("droidkaigi.primitive.detekt")
     id("droidkaigi.primitive.kmp.android.showkase")
-    id("droidkaigi.primitive.kover")
 }
 
 android.namespace = "io.github.droidkaigi.confsched2023.core.designsystem"

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     id("droidkaigi.primitive.kmp")
     id("droidkaigi.primitive.kmp.android")
     id("droidkaigi.primitive.kmp.ios")
-    id("droidkaigi.primitive.kover")
     id("droidkaigi.primitive.detekt")
 }
 

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("droidkaigi.primitive.android.kotlin")
     id("droidkaigi.primitive.android.compose")
     id("droidkaigi.primitive.android.hilt")
-    id("droidkaigi.primitive.kover")
     id("droidkaigi.primitive.detekt")
 }
 

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("droidkaigi.primitive.kmp.ios")
     id("droidkaigi.primitive.kmp.compose")
     id("droidkaigi.primitive.kmp.android.hilt")
-    id("droidkaigi.primitive.kover")
     id("droidkaigi.primitive.detekt")
 }
 

--- a/feature/contributors/build.gradle.kts
+++ b/feature/contributors/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("droidkaigi.primitive.kmp.android.hilt")
     id("droidkaigi.primitive.kmp.ios")
     id("droidkaigi.primitive.kmp.compose")
-    id("droidkaigi.primitive.kover")
 }
 
 android.namespace = "io.github.droidkaigi.confsched2023.feature.contributors"


### PR DESCRIPTION
## Issue
- close #761 

## Overview (Required)

Extracted kover configurations for each projects into a plugin like [kotlinx.coroutines' convention plugin](https://github.com/Kotlin/kotlinx.coroutines/blob/1ccc96890d38be52d1bdcd31af5befb54804aa05/buildSrc/src/main/kotlin/kover-conventions.gradle.kts) so that, when we add a new module, we don't have to care about applying kover plugin to it and adding `kover` declaration to report-aggregator module. 

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)

N/A

## Movie (Optional)

N/A