### PR TITLE
:recycle: Added display control of the translation function.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -122,7 +122,7 @@ sealed class TimetableItemDetailScreenUiState {
         val timetableItem: TimetableItem,
         val timetableItemDetailSectionUiState: TimetableItemDetailSectionUiState,
         val isBookmarked: Boolean,
-        val isSelectableLang: Boolean,
+        val isLangSelectable: Boolean,
         val viewBookmarkListRequestState: ViewBookmarkListRequestState,
         val currentLang: Lang?,
     ) : TimetableItemDetailScreenUiState()
@@ -155,7 +155,7 @@ private fun TimetableItemDetailScreen(
             if (uiState is Loaded) {
                 TimetableItemDetailScreenTopAppBar(
                     title = uiState.timetableItem.title,
-                    isSelectableLang = uiState.isSelectableLang,
+                    isLangSelectable = uiState.isLangSelectable,
                     onNavigationIconClick = onNavigationIconClick,
                     onSelectedLanguage = onSelectedLanguage,
                     scrollBehavior = scrollBehavior,
@@ -216,7 +216,7 @@ fun TimetableItemDetailScreenPreview() {
                     timetableItem = fakeSession,
                     timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(fakeSession),
                     isBookmarked = isBookMarked,
-                    isSelectableLang = true,
+                    isLangSelectable = true,
                     viewBookmarkListRequestState = ViewBookmarkListRequestState.NotRequested,
                     currentLang = Lang.JAPANESE,
                 ),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -122,6 +122,7 @@ sealed class TimetableItemDetailScreenUiState {
         val timetableItem: TimetableItem,
         val timetableItemDetailSectionUiState: TimetableItemDetailSectionUiState,
         val isBookmarked: Boolean,
+        val isSelectableLang: Boolean,
         val viewBookmarkListRequestState: ViewBookmarkListRequestState,
         val currentLang: Lang?,
     ) : TimetableItemDetailScreenUiState()
@@ -154,6 +155,7 @@ private fun TimetableItemDetailScreen(
             if (uiState is Loaded) {
                 TimetableItemDetailScreenTopAppBar(
                     title = uiState.timetableItem.title,
+                    isSelectableLang = uiState.isSelectableLang,
                     onNavigationIconClick = onNavigationIconClick,
                     onSelectedLanguage = onSelectedLanguage,
                     scrollBehavior = scrollBehavior,
@@ -214,6 +216,7 @@ fun TimetableItemDetailScreenPreview() {
                     timetableItem = fakeSession,
                     timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(fakeSession),
                     isBookmarked = isBookMarked,
+                    isSelectableLang = true,
                     viewBookmarkListRequestState = ViewBookmarkListRequestState.NotRequested,
                     currentLang = Lang.JAPANESE,
                 ),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailViewModel.kt
@@ -10,6 +10,7 @@ import io.github.droidkaigi.confsched2023.model.Lang
 import io.github.droidkaigi.confsched2023.model.SessionsRepository
 import io.github.droidkaigi.confsched2023.model.TimetableItem
 import io.github.droidkaigi.confsched2023.model.TimetableItemId
+import io.github.droidkaigi.confsched2023.model.TimetableSessionType
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableItemDetailSectionUiState
 import io.github.droidkaigi.confsched2023.sessions.strings.TimetableItemDetailStrings
 import io.github.droidkaigi.confsched2023.ui.UserMessageResult
@@ -73,6 +74,7 @@ class TimetableItemDetailViewModel @Inject constructor(
                 timetableItem = timetableItem,
                 timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(timetableItem),
                 isBookmarked = bookmarked,
+                isSelectableLang = timetableItem.sessionType == TimetableSessionType.NORMAL,
                 viewBookmarkListRequestState = viewBookmarkListRequestState,
                 currentLang = selectedLang,
             )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailViewModel.kt
@@ -74,7 +74,7 @@ class TimetableItemDetailViewModel @Inject constructor(
                 timetableItem = timetableItem,
                 timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(timetableItem),
                 isBookmarked = bookmarked,
-                isSelectableLang = timetableItem.sessionType == TimetableSessionType.NORMAL,
+                isLangSelectable = timetableItem.sessionType == TimetableSessionType.NORMAL,
                 viewBookmarkListRequestState = viewBookmarkListRequestState,
                 currentLang = selectedLang,
             )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -41,7 +41,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 fun TimetableItemDetailScreenTopAppBar(
     title: MultiLangText,
-    isSelectableLang: Boolean,
+    isLangSelectable: Boolean,
     onNavigationIconClick: () -> Unit,
     onSelectedLanguage: (Lang) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
@@ -93,7 +93,7 @@ fun TimetableItemDetailScreenTopAppBar(
             val expandMenu = { expanded = true }
             val shrinkMenu = { expanded = false }
 
-            if (isSelectableLang) {
+            if (isLangSelectable) {
                 IconButton(onClick = expandMenu) {
                     Icon(
                         imageVector = Icons.Outlined.GTranslate,
@@ -170,7 +170,7 @@ private fun ResizeableText(
 fun TimetableItemDetailScreenTopAppBarPreview() {
     TimetableItemDetailScreenTopAppBar(
         title = MultiLangText(jaTitle = "タイトル", enTitle = "title"),
-        isSelectableLang = true,
+        isLangSelectable = true,
         onNavigationIconClick = {},
         onSelectedLanguage = {},
         scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),
@@ -183,7 +183,7 @@ fun TimetableItemDetailScreenTopAppBarPreview() {
 fun TimetableItemDetailScreenTopAppBarUnSelectableLangPreview() {
     TimetableItemDetailScreenTopAppBar(
         title = MultiLangText(jaTitle = "タイトル", enTitle = "title"),
-        isSelectableLang = false,
+        isLangSelectable = false,
         onNavigationIconClick = {},
         onSelectedLanguage = {},
         scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailScreenTopAppBar.kt
@@ -41,6 +41,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 fun TimetableItemDetailScreenTopAppBar(
     title: MultiLangText,
+    isSelectableLang: Boolean,
     onNavigationIconClick: () -> Unit,
     onSelectedLanguage: (Lang) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
@@ -92,11 +93,13 @@ fun TimetableItemDetailScreenTopAppBar(
             val expandMenu = { expanded = true }
             val shrinkMenu = { expanded = false }
 
-            IconButton(onClick = expandMenu) {
-                Icon(
-                    imageVector = Icons.Outlined.GTranslate,
-                    contentDescription = null,
-                )
+            if (isSelectableLang) {
+                IconButton(onClick = expandMenu) {
+                    Icon(
+                        imageVector = Icons.Outlined.GTranslate,
+                        contentDescription = null,
+                    )
+                }
             }
             DropdownMenu(
                 expanded = expanded,
@@ -167,6 +170,20 @@ private fun ResizeableText(
 fun TimetableItemDetailScreenTopAppBarPreview() {
     TimetableItemDetailScreenTopAppBar(
         title = MultiLangText(jaTitle = "タイトル", enTitle = "title"),
+        isSelectableLang = true,
+        onNavigationIconClick = {},
+        onSelectedLanguage = {},
+        scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@MultiThemePreviews
+@Composable
+fun TimetableItemDetailScreenTopAppBarUnSelectableLangPreview() {
+    TimetableItemDetailScreenTopAppBar(
+        title = MultiLangText(jaTitle = "タイトル", enTitle = "title"),
+        isSelectableLang = false,
         onNavigationIconClick = {},
         onSelectedLanguage = {},
         scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Added a new setting that does not display the Description except for normal sessions since it does not contain a Description.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/de5423f4-2cbf-4e7b-8a05-94f8ce045f7c" width="300" > | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/e7f1e94c-f889-4f8a-9be0-61d7afa8e721" width="300" >