### PR TITLE
fix: replace the right Title from Stamps to Achievements

### DIFF
--- a/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/strings/MainStrings.kt
+++ b/feature/main/src/main/java/io/github/droidkaigi/confsched2023/main/strings/MainStrings.kt
@@ -17,7 +17,7 @@ sealed class MainStrings : Strings<MainStrings>(Bindings) {
             when (item) {
                 Timetable -> "Timetable"
                 FloorMap -> "Floor Map"
-                Stamps -> "Stamps"
+                Stamps -> "Achievements"
                 About -> "About"
                 Contributors -> "Contributors"
                 is Time -> "${item.hours}時${item.minutes}分"

--- a/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsStrings.kt
+++ b/feature/stamps/src/main/java/io/github/droidkaigi/confsched2023/stamps/StampsStrings.kt
@@ -13,7 +13,7 @@ sealed class StampsStrings : Strings<StampsStrings>(Bindings) {
     private object Bindings : StringsBindings<StampsStrings>(
         Lang.Japanese to { item, _ ->
             when (item) {
-                Title -> "Stamps"
+                Title -> "Achievements"
                 DescriptionNotes -> "※ この企画は変更または中止になる可能性があります"
             }
         },


### PR DESCRIPTION
## Issue
there is no issue about this PR. I just found a difference.

## Overview (Required)
- replaced the right Title from Stamps to Achievements
  - Title
  - the title of bottomTab

## Links
- Right design: https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=55510-31726&mode=design&t=mDOW4PL2sMMyJplu-4

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/2215210/a047ce46-2355-488e-b4e0-7c26bb1e9144" width=250 /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/2215210/3767c167-c65c-4e09-9874-6d6c0b844743" width=250 />
