### PR TITLE
[Android] Fixed slow scrolling of sponsor screen

### DIFF
--- a/feature/sponsors/build.gradle.kts
+++ b/feature/sponsors/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 
     implementation(libs.composeHiltNavigtation)
     implementation(libs.composeMaterialIcon)
+    implementation(libs.composeCoil)
 }

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
@@ -1,27 +1,22 @@
 package io.github.droidkaigi.confsched2023.sponsors.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreviews
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
-import io.github.droidkaigi.confsched2023.ui.previewOverride
-import io.github.droidkaigi.confsched2023.ui.rememberAsyncImagePainter
 
 @Composable
 fun SponsorItem(
@@ -29,10 +24,8 @@ fun SponsorItem(
     modifier: Modifier = Modifier,
     onSponsorClick: (url: String) -> Unit,
 ) {
-    Image(
-        painter = previewOverride(previewPainter = { rememberVectorPainter(image = Icons.Default.Image) }) {
-            rememberAsyncImagePainter(sponsor.logo)
-        },
+    AsyncImage(
+        model = sponsor.logo,
         contentDescription = sponsor.name,
         modifier = modifier
             .padding(

--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/component/SponsorItem.kt
@@ -1,15 +1,20 @@
 package io.github.droidkaigi.confsched2023.sponsors.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import io.github.droidkaigi.confsched2023.designsystem.preview.MultiLanguagePreviews
@@ -17,6 +22,7 @@ import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreview
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.model.Sponsor
 import io.github.droidkaigi.confsched2023.model.fakes
+import io.github.droidkaigi.confsched2023.ui.isTest
 
 @Composable
 fun SponsorItem(
@@ -24,19 +30,35 @@ fun SponsorItem(
     modifier: Modifier = Modifier,
     onSponsorClick: (url: String) -> Unit,
 ) {
-    AsyncImage(
-        model = sponsor.logo,
-        contentDescription = sponsor.name,
-        modifier = modifier
-            .padding(
-                top = if (sponsor.plan.isPlatinum) 0.dp else 8.dp,
-                bottom = if (sponsor.plan.isPlatinum) 12.dp else 8.dp,
-            )
-            .background(color = Color.White)
-            .clip(RoundedCornerShape(if (sponsor.plan.isSupporter) 4.dp else 8.dp))
-            .clickable { onSponsorClick(sponsor.link) }
-            .fillMaxSize(),
-    )
+    if (LocalInspectionMode.current || isTest()) {
+        Image(
+            painter = rememberVectorPainter(image = Icons.Default.Image),
+            contentDescription = sponsor.name,
+            modifier = modifier
+                .padding(
+                    top = if (sponsor.plan.isPlatinum) 0.dp else 8.dp,
+                    bottom = if (sponsor.plan.isPlatinum) 12.dp else 8.dp,
+                )
+                .background(color = Color.White)
+                .clip(RoundedCornerShape(if (sponsor.plan.isSupporter) 4.dp else 8.dp))
+                .clickable { onSponsorClick(sponsor.link) }
+                .fillMaxSize(),
+        )
+    } else {
+        AsyncImage(
+            model = sponsor.logo,
+            contentDescription = sponsor.name,
+            modifier = modifier
+                .padding(
+                    top = if (sponsor.plan.isPlatinum) 0.dp else 8.dp,
+                    bottom = if (sponsor.plan.isPlatinum) 12.dp else 8.dp,
+                )
+                .background(color = Color.White)
+                .clip(RoundedCornerShape(if (sponsor.plan.isSupporter) 4.dp else 8.dp))
+                .clickable { onSponsorClick(sponsor.link) }
+                .fillMaxSize(),
+        )
+    }
 }
 
 @MultiThemePreviews


### PR DESCRIPTION
## Issue
- close #1088

## Overview (Required)
- https://github.com/DroidKaigi/conference-app-2023/issues/1088#issuecomment-1706375083
- Use coil instead of compose-imageloader.
- Coil resizes large sponsor images to fit, solving the scrolling problem.

## Links
- 

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/17231507/b27cd474-9d15-4f96-a325-05d513178cd9" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/17231507/5cbfbeb8-4721-4004-8505-e1a9c0cf20f4" width="300" >
