### PR TITLE
:memo: Move ContributorsScreen to KaigiNavHost.

### DIFF
--- a/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
+++ b/app-android/src/main/java/io/github/droidkaigi/confsched2023/KaigiApp.kt
@@ -126,6 +126,20 @@ private fun KaigiNavHost(
             onBackClick = navController::popBackStack,
             onStaffClick = externalNavController::navigate,
         )
+        // For KMP, we are not using navigation abstraction for contributors screen
+        composable(contributorsScreenRoute) {
+            val lifecycleOwner = LocalLifecycleOwner.current
+            ContributorsScreen(
+                viewModel = hiltViewModel<ContributorsViewModel>(),
+                onNavigationIconClick = {
+                    handleOnClickIfNotNavigating(
+                        lifecycleOwner,
+                        navController::popBackStack,
+                    )
+                },
+                onContributorItemClick = externalNavController::navigate,
+            )
+        }
     }
 }
 
@@ -157,7 +171,7 @@ private fun NavGraphBuilder.mainScreen(
                     when (aboutItem) {
                         Sponsors -> navController.navigateSponsorsScreen()
                         CodeOfConduct -> { externalNavController.navigate(url = "$portalBaseUrl/about/code-of-conduct") }
-                        Contributors -> mainNestedNavController.navigate(contributorsScreenRoute)
+                        Contributors -> navController.navigate(contributorsScreenRoute)
                         License -> externalNavController.navigateToLicenseScreen()
                         Medium -> externalNavController.navigate(url = "https://medium.com/droidkaigi")
                         PrivacyPolicy -> { externalNavController.navigate(url = "$portalBaseUrl/about/privacy") }
@@ -180,21 +194,6 @@ private fun NavGraphBuilder.mainScreen(
                 },
                 contentPadding = contentPadding,
             )
-            // For KMP, we are not using navigation abstraction for contributors screen
-            composable(contributorsScreenRoute) {
-                val lifecycleOwner = LocalLifecycleOwner.current
-                ContributorsScreen(
-                    viewModel = hiltViewModel<ContributorsViewModel>(),
-                    onNavigationIconClick = {
-                        handleOnClickIfNotNavigating(
-                            lifecycleOwner,
-                            mainNestedNavController::popBackStack,
-                        )
-                    },
-                    onContributorItemClick = externalNavController::navigate,
-                    contentPadding = contentPadding,
-                )
-            }
         },
     )
 }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- When displaying the Contributor screen, BottomNavigation is no longer displayed as in the Staff screen.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/d9e713fe-4969-4a0b-990d-3141efaeb4de" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/208508a6-28d4-4e92-8ff9-8f69f33500b6" width="300" >