### PR TITLE
[Android] Not to crash on sponsor screen when network is offline 

### DIFF
--- a/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
+++ b/feature/sponsors/src/main/java/io/github/droidkaigi/confsched2023/sponsors/SponsorsScreenViewModel.kt
@@ -2,10 +2,12 @@ package io.github.droidkaigi.confsched2023.sponsors
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.github.droidkaigi.confsched2023.designsystem.strings.AppStrings
 import io.github.droidkaigi.confsched2023.model.SponsorsRepository
 import io.github.droidkaigi.confsched2023.sponsors.section.SponsorListUiState
 import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolder
 import io.github.droidkaigi.confsched2023.ui.buildUiState
+import io.github.droidkaigi.confsched2023.ui.handleErrorAndRetry
 import io.github.droidkaigi.confsched2023.ui.viewModelScope
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -22,6 +24,10 @@ class SponsorsScreenViewModel @Inject constructor(
     UserMessageStateHolder by userMessageStateHolder {
 
     private val sponsorsStateFlow = sponsorsRepository.sponsors()
+        .handleErrorAndRetry(
+            AppStrings.Retry,
+            userMessageStateHolder,
+        )
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),


### PR DESCRIPTION
## Issue
- close #1092

## Overview (Required)
- By showing snackbar and enable to retry, enable to keep running this app without crash even if offline.

## Links
- nothing

## Movie
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/0682c23c-83a5-43a2-af81-f6800779be7e" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/f3ba4925-6909-46c9-8738-811c425e4173" width="300" >

