### PR TITLE
[iOS] Fix missing targets of the build scheme

### DIFF
--- a/app-ios/App/DroidKaigi2023/DroidKaigi2023.xcodeproj/xcshareddata/xcschemes/DroidKaigi2023.xcscheme
+++ b/app-ios/App/DroidKaigi2023/DroidKaigi2023.xcodeproj/xcshareddata/xcschemes/DroidKaigi2023.xcscheme
@@ -123,9 +123,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "StampsTests"
-               BuildableName = "StampsTests"
-               BlueprintName = "StampsTests"
+               BlueprintIdentifier = "TimetableTests"
+               BuildableName = "TimetableTests"
+               BlueprintName = "TimetableTests"
                ReferencedContainer = "container:../../Modules">
             </BuildableReference>
          </TestableReference>
@@ -133,9 +133,19 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "TimetableTests"
-               BuildableName = "TimetableTests"
-               BlueprintName = "TimetableTests"
+               BlueprintIdentifier = "AchievementsTests"
+               BuildableName = "AchievementsTests"
+               BlueprintName = "AchievementsTests"
+               ReferencedContainer = "container:../../Modules">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StaffTests"
+               BuildableName = "StaffTests"
+               BlueprintName = "StaffTests"
                ReferencedContainer = "container:../../Modules">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR adds `AchievementsTests` and `StaffTests` to the build scheme and fixes missing targets

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
