### PR TITLE
[Android] Adjust snackbar padding on timetable

### DIFF
--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -72,8 +71,6 @@ private fun ContributorsScreen(
     contentPadding: PaddingValues,
     isTopAppBarHidden: Boolean,
 ) {
-    println(contentPadding)
-    println(contentPadding.calculateTopPadding())
     val scrollBehavior =
         if (!isTopAppBarHidden) {
             TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -106,13 +103,18 @@ private fun ContributorsScreen(
                 )
             }
         },
-    ) { padding ->
+        contentWindowInsets = WindowInsets(
+            left = contentPadding.calculateLeftPadding(localLayoutDirection),
+            top = contentPadding.calculateTopPadding(),
+            right = contentPadding.calculateRightPadding(localLayoutDirection),
+            bottom = contentPadding.calculateBottomPadding(),
+        ),
+    ) { innerContentPadding ->
         Contributors(
             contributors = uiState.contributors,
             onContributorItemClick = onContributorItemClick,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
                 .let {
                     if (scrollBehavior != null) {
                         it.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -120,6 +122,7 @@ private fun ContributorsScreen(
                         it
                     }
                 },
+            contentPadding = innerContentPadding,
         )
     }
 }
@@ -129,9 +132,11 @@ private fun Contributors(
     contributors: PersistentList<Contributor>,
     onContributorItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues,
 ) {
     LazyColumn(
         modifier = modifier,
+        contentPadding = contentPadding,
     ) {
         items(contributors) {
             ContributorListItem(

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -71,6 +72,8 @@ private fun ContributorsScreen(
     contentPadding: PaddingValues,
     isTopAppBarHidden: Boolean,
 ) {
+    println(contentPadding)
+    println(contentPadding.calculateTopPadding())
     val scrollBehavior =
         if (!isTopAppBarHidden) {
             TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -103,18 +106,13 @@ private fun ContributorsScreen(
                 )
             }
         },
-        contentWindowInsets = WindowInsets(
-            left = contentPadding.calculateLeftPadding(localLayoutDirection),
-            top = contentPadding.calculateTopPadding(),
-            right = contentPadding.calculateRightPadding(localLayoutDirection),
-            bottom = contentPadding.calculateBottomPadding(),
-        ),
-    ) { innerContentPadding ->
+    ) { padding ->
         Contributors(
             contributors = uiState.contributors,
             onContributorItemClick = onContributorItemClick,
             modifier = Modifier
                 .fillMaxSize()
+                .padding(padding)
                 .let {
                     if (scrollBehavior != null) {
                         it.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -122,7 +120,6 @@ private fun ContributorsScreen(
                         it
                     }
                 },
-            contentPadding = innerContentPadding,
         )
     }
 }
@@ -132,11 +129,9 @@ private fun Contributors(
     contributors: PersistentList<Contributor>,
     onContributorItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues,
 ) {
     LazyColumn(
         modifier = modifier,
-        contentPadding = contentPadding,
     ) {
         items(contributors) {
             ContributorListItem(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -184,14 +184,7 @@ private fun TimetableScreen(
                     )
                 }
             },
-        snackbarHost = {
-            SnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier.padding(
-                    WindowInsets.safeContent.asPaddingValues(),
-                ),
-            )
-        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             TimetableTopArea(
                 timetableUiType = uiState.timetableUiType,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -6,13 +6,11 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost


### PR DESCRIPTION
## Issue
- close #1098

## Overview (Required)
- padding of the snackbar on timetable screen seems too much if compare with other screens
- In this pr, trying to fit with other screens how to be displayed

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/b36969ee-29b0-471a-97f7-d860dfbd02ac" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/652c1107-0f75-478b-98cf-2b331848c901" width="300" />

