### PR TITLE
[Android] show snackbar message

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AppError.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AppError.kt
@@ -1,7 +1,8 @@
 package io.github.droidkaigi.confsched2023.model
 
 public sealed class AppError : RuntimeException {
-    private constructor(message: String? = null, cause: Throwable? = null) : super(message, cause)
+    private constructor(message: String?, cause: Throwable?) : super(message, cause)
+    private constructor(cause: Throwable?) : super(cause)
 
     public sealed class ApiException(cause: Throwable?) : AppError(cause = cause) {
         public class NetworkException(cause: Throwable?) : ApiException(cause = cause)


### PR DESCRIPTION
## Issue
- close #1101

## Overview (Required)
- Now, snackbar will be shown without any messages (only "Retry" is dispalyed).
- In this PR, fix enabling to display message.
- If message and cause is passed to RuntimeException class's constructor, message of exception will be set the value of indicated variable value.
  - the default value of message on AppError's constructor is `null` ([ref](https://github.com/DroidKaigi/conference-app-2023/blob/main/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AppError.kt#L4))
  - so, I think message will be always `null` because message is not indicated on any classes's constructor inheritting `AppError` class

## Links
- https://github.com/JetBrains/kotlin/blob/10e94f90ac1b2396d0427d9078c1fe481859cb60/libraries/stdlib/jvm/runtime/kotlin/TypeAliases.kt#L13

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/2739b875-4adf-4b53-969b-e5622ddeaaf0" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/c50d418b-4587-4c0f-835b-24ff27c5fa28" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/3b78825b-751b-43b6-b6ed-490c57fc43c3" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/4df421e5-1190-4ed2-a2a2-d6cfa7be9147" width="300" />



