### PR TITLE
[Android] fix bottom padding on contributor screen

### DIFF
--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
@@ -1,9 +1,8 @@
 package io.github.droidkaigi.confsched2023.contributors
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -24,7 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import io.github.droidkaigi.confsched2023.contributors.component.ContributorListItem
 import io.github.droidkaigi.confsched2023.model.Contributor
@@ -42,7 +40,6 @@ fun ContributorsScreen(
     isTopAppBarHidden: Boolean = false,
     onNavigationIconClick: () -> Unit,
     onContributorItemClick: (url: String) -> Unit,
-    contentPadding: PaddingValues = PaddingValues(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -57,7 +54,6 @@ fun ContributorsScreen(
         snackbarHostState = snackbarHostState,
         onBackClick = onNavigationIconClick,
         onContributorItemClick = onContributorItemClick,
-        contentPadding = contentPadding,
     )
 }
 
@@ -68,7 +64,6 @@ private fun ContributorsScreen(
     snackbarHostState: SnackbarHostState,
     onBackClick: () -> Unit,
     onContributorItemClick: (url: String) -> Unit,
-    contentPadding: PaddingValues,
     isTopAppBarHidden: Boolean,
 ) {
     val scrollBehavior =
@@ -77,7 +72,6 @@ private fun ContributorsScreen(
         } else {
             null
         }
-    val localLayoutDirection = LocalLayoutDirection.current
     Scaffold(
         modifier = Modifier.testTag(ContributorsScreenTestTag),
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -103,18 +97,13 @@ private fun ContributorsScreen(
                 )
             }
         },
-        contentWindowInsets = WindowInsets(
-            left = contentPadding.calculateLeftPadding(localLayoutDirection),
-            top = contentPadding.calculateTopPadding(),
-            right = contentPadding.calculateRightPadding(localLayoutDirection),
-            bottom = contentPadding.calculateBottomPadding(),
-        ),
-    ) { innerContentPadding ->
+    ) { padding ->
         Contributors(
             contributors = uiState.contributors,
             onContributorItemClick = onContributorItemClick,
             modifier = Modifier
                 .fillMaxSize()
+                .padding(padding)
                 .let {
                     if (scrollBehavior != null) {
                         it.nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -122,7 +111,6 @@ private fun ContributorsScreen(
                         it
                     }
                 },
-            contentPadding = innerContentPadding,
         )
     }
 }
@@ -132,11 +120,9 @@ private fun Contributors(
     contributors: PersistentList<Contributor>,
     onContributorItemClick: (url: String) -> Unit,
     modifier: Modifier = Modifier,
-    contentPadding: PaddingValues,
 ) {
     LazyColumn(
         modifier = modifier,
-        contentPadding = contentPadding,
     ) {
         items(contributors) {
             ContributorListItem(


### PR DESCRIPTION
## Issue
- NO_ISSUE

## Overview (Required)
- As following image(Before), bottom element of contributor will be buried behind the navbar.
  - with some device, snackbar is not displayed due to the navbar.
- Now, contributor screen is move into about screen
  - so I tried to change padding setting same as staff and sponsor screen to enable to show bottom element and snackbar.
- This doesn't have an issue ticket, so if it's AWFUL change, please close this PR :bow: 

## Links
- nothing

## Screenshot (Optional if screenshot test is present or unrelated to UI)
device | Before | After
:--: | :--: | :--:
Pixel 6 api 30 | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/fd608cdc-373a-4ec8-b2c3-a846ba8e645c" width="150" /><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/0d6ba1ab-2586-4cec-9991-8746b75f3d60" width="150" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/809771e2-5452-469d-a7ff-6c0fd598af69" width="150" /><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/d979bdca-bc86-47d9-848d-94d276d32f48" width="150" />
Pixel Fold api 33 | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/59f8692a-53dd-480b-aa8f-577882d4b350" width="300" /><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/d4b737c9-e3dd-4ec6-acb0-ecc1e87bd587" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/3acdd0b5-a200-4db4-8305-78489afd244c" width="300" /><img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/01a589d3-5f02-41ad-b1cf-a10903a0bcc7" width="300" />


