### PR TITLE
[Compose Multiplatform] apply theme to contributors screen (w/ workaround)

### DIFF
--- a/core/designsystem/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/FontResource.kt
+++ b/core/designsystem/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/theme/FontResource.kt
@@ -1,15 +1,8 @@
 package io.github.droidkaigi.confsched2023.designsystem.theme
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.platform.Font
 import org.jetbrains.compose.resources.ExperimentalResourceApi
-import org.jetbrains.compose.resources.resource
 
 val fontMap: HashMap<String, FontFamily?> = HashMap()
 
@@ -17,21 +10,23 @@ val fontMap: HashMap<String, FontFamily?> = HashMap()
 @ExperimentalResourceApi
 @Composable
 actual fun fontFamilyResource(fontResource: FontResource): FontFamily? {
-    var fontFamily: FontFamily? by
-        remember(fontResource.resName) { mutableStateOf(fontMap[fontResource.resName]) }
-    if (fontFamily == null) {
-        LaunchedEffect(fontResource.resName) {
-            fontFamily = try {
-                val font = Font(
-                    fontResource.resName,
-                    resource("font/${fontResource.resName}").readBytes(),
-                )
-                fontMap[fontResource.resName] = FontFamily(font)
-                fontMap[fontResource.resName]
-            } catch (e: Exception) {
-                throw IllegalArgumentException(e)
-            }
-        }
-    }
-    return fontFamily
+    // FIXME: Load the custom font in resources directory
+    return FontFamily.Default
+//    var fontFamily: FontFamily? by
+//        remember(fontResource.resName) { mutableStateOf(fontMap[fontResource.resName]) }
+//    if (fontFamily == null) {
+//        LaunchedEffect(fontResource.resName) {
+//            fontFamily = try {
+//                val font = Font(
+//                    fontResource.resName,
+//                    resource("font/${fontResource.resName}").readBytes(),
+//                )
+//                fontMap[fontResource.resName] = FontFamily(font)
+//                fontMap[fontResource.resName]
+//            } catch (e: Exception) {
+//                throw IllegalArgumentException(e)
+//            }
+//        }
+//    }
+//    return fontFamily
 }

--- a/feature/contributors/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/contributors/DarwinContributors.kt
+++ b/feature/contributors/src/iosMain/kotlin/io/github/droidkaigi/confsched2023/contributors/DarwinContributors.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2023.contributors
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.window.ComposeUIViewController
+import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.model.ContributorsRepository
 import io.github.droidkaigi.confsched2023.ui.UserMessageStateHolderImpl
 import platform.UIKit.UIViewController
@@ -23,10 +24,12 @@ fun contributorViewController(
 //        viewModel.viewModelScope.cancel()
     }
 
-    ContributorsScreen(
-        viewModel = viewModel,
-        isTopAppBarHidden = true,
-        onNavigationIconClick = { /** no action for iOS side **/ },
-        onContributorItemClick = onContributorItemClick,
-    )
+    KaigiTheme {
+        ContributorsScreen(
+            viewModel = viewModel,
+            isTopAppBarHidden = true,
+            onNavigationIconClick = { /** no action for iOS side **/ },
+            onContributorItemClick = onContributorItemClick,
+        )
+    }
 }


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2023/issues/1062

## Overview (Required)
- Apply KaigiTheme to contributions screen for iOS
- There is an issue that the custom font cannot be read from iOS side, so fixed to return the system font as a workaround 🙏

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/43767445/5f602366-7b6d-4029-ad70-3644b8100fc4" width="300" />
