### PR TITLE
:recycle: A summary statement of the third day's content is now displayed.

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/sessions/DefaultSessionsApiClient.kt
@@ -144,6 +144,17 @@ fun SessionsAllResponse.toTimetable(): Timetable {
                             .map { speakerIdToSpeaker[it]!! }
                             .toPersistentList(),
                         levels = apiSession.levels.toPersistentList(),
+                        description = if (
+                            apiSession.i18nDesc?.ja == null &&
+                            apiSession.i18nDesc?.en == null
+                        ) {
+                            MultiLangText(
+                                jaTitle = apiSession.description ?: "",
+                                enTitle = apiSession.description ?: "",
+                            )
+                        } else {
+                            apiSession.i18nDesc.toMultiLangText()
+                        },
                     )
                 }
             }

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
@@ -110,7 +110,7 @@ fun ClickableLinkText(
             val actualHeight = layoutResult.value?.size?.height?.toFloat() ?: 0f
             val expectedHeight = with(density) { style.fontSize.toPx() * maxLines }
             actualHeight > expectedHeight
-        } 
+        }
     }
 
     LaunchedEffect(isOverflowing) {

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
@@ -3,8 +3,15 @@ package io.github.droidkaigi.confsched2023.designsystem.component
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -82,6 +89,7 @@ fun ClickableLinkText(
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,
     url: String? = null,
+    onOverflow: (Boolean) -> Unit = {},
 ) {
     val findResults = findResults(
         content = content,
@@ -93,8 +101,24 @@ fun ClickableLinkText(
         findUrlResults = findResults,
     )
 
+    val layoutResult = remember { mutableStateOf<LayoutCoordinates?>(null) }
+
+    val density = LocalDensity.current
+
+    val isOverflowing by remember { derivedStateOf {
+        val actualHeight = layoutResult.value?.size?.height?.toFloat() ?: 0f
+        val expectedHeight = with(density) { style.fontSize.toPx() * maxLines }
+        actualHeight > expectedHeight
+    }}
+
+    LaunchedEffect(isOverflowing) {
+        onOverflow(isOverflowing)
+    }
+
     ClickableText(
-        modifier = modifier,
+        modifier = modifier.onGloballyPositioned { coordinates ->
+            layoutResult.value = coordinates
+        },
         text = annotatedString,
         style = style,
         overflow = overflow,

--- a/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
+++ b/core/designsystem/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/designsystem/component/ClickableLinkText.kt
@@ -105,11 +105,13 @@ fun ClickableLinkText(
 
     val density = LocalDensity.current
 
-    val isOverflowing by remember { derivedStateOf {
-        val actualHeight = layoutResult.value?.size?.height?.toFloat() ?: 0f
-        val expectedHeight = with(density) { style.fontSize.toPx() * maxLines }
-        actualHeight > expectedHeight
-    }}
+    val isOverflowing by remember {
+        derivedStateOf {
+            val actualHeight = layoutResult.value?.size?.height?.toFloat() ?: 0f
+            val expectedHeight = with(density) { style.fontSize.toPx() * maxLines }
+            actualHeight > expectedHeight
+        } 
+    }
 
     LaunchedEffect(isOverflowing) {
         onOverflow(isOverflowing)

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Timetable.kt
@@ -160,7 +160,7 @@ public fun Timetable.Companion.fake(): Timetable {
                         "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
                     enTitle = "This is a description\nThis is a description\nThis is a description\n" +
                         "This is a description\nThis is a description\nThis is a description\n",
-                )
+                ),
             ),
         )
         for (day in -1..1) {
@@ -243,7 +243,7 @@ public fun Timetable.Companion.fake(): Timetable {
                         "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
                     enTitle = "This is a description\nThis is a description\nThis is a description\n" +
                         "This is a description\nThis is a description\nThis is a description\n",
-                )
+                ),
             ),
         )
     }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Timetable.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Timetable.kt
@@ -155,6 +155,12 @@ public fun Timetable.Companion.fake(): Timetable {
                         tagLine = "iOS Engineer",
                     ),
                 ),
+                description = MultiLangText(
+                    jaTitle = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n" +
+                        "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
+                    enTitle = "This is a description\nThis is a description\nThis is a description\n" +
+                        "This is a description\nThis is a description\nThis is a description\n",
+                )
             ),
         )
         for (day in -1..1) {
@@ -232,6 +238,12 @@ public fun Timetable.Companion.fake(): Timetable {
                         tagLine = "iOS Engineer",
                     ),
                 ),
+                description = MultiLangText(
+                    jaTitle = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n" +
+                        "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
+                    enTitle = "This is a description\nThis is a description\nThis is a description\n" +
+                        "This is a description\nThis is a description\nThis is a description\n",
+                )
             ),
         )
     }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -61,6 +61,7 @@ public sealed class TimetableItem {
         override val asset: TimetableAsset,
         override val levels: PersistentList<String>,
         override val speakers: PersistentList<TimetableSpeaker>,
+        val description: MultiLangText,
     ) : TimetableItem()
 
     private val startsDateString: String by lazy {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -509,7 +509,7 @@ fun PreviewTimetableGridItemWelcomeTalk() {
                             "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
                         enTitle = "This is a description\nThis is a description\nThis is a description\n" +
                             "This is a description\nThis is a description\nThis is a description\n",
-                    )
+                    ),
                 ),
                 onTimetableItemClick = {},
                 gridItemHeightPx = 154,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridItem.kt
@@ -504,6 +504,12 @@ fun PreviewTimetableGridItemWelcomeTalk() {
                         "ADVANCED",
                     ),
                     speakers = persistentListOf(),
+                    description = MultiLangText(
+                        jaTitle = "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n" +
+                            "これはディスクリプションです。\nこれはディスクリプションです。\nこれはディスクリプションです。\n",
+                        enTitle = "This is a description\nThis is a description\nThis is a description\n" +
+                            "This is a description\nThis is a description\nThis is a description\n",
+                    )
                 ),
                 onTimetableItemClick = {},
                 gridItemHeightPx = 154,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -93,7 +93,17 @@ fun TimetableItemDetailContent(
             }
 
             is Special -> {
-                // do nothing
+                val description = when (selectedLanguage) {
+                    Lang.JAPANESE -> uiState.description.jaTitle
+                    Lang.ENGLISH -> uiState.description.enTitle
+                    Lang.MIXED -> uiState.description.jaTitle
+                    null,
+                    -> ""
+                }
+                DescriptionSection(
+                    description = description,
+                    onLinkClick = onLinkClick,
+                )
             }
         }
     }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -128,6 +128,7 @@ private fun DescriptionSection(
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (isExpanded) Int.MAX_VALUE else 5,
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+                onOverflow = { isExpanded = it.not() }
             )
             if (!isExpanded) {
                 ReadMoreOutlinedButton(

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableItemDetailContent.kt
@@ -128,7 +128,7 @@ private fun DescriptionSection(
                 overflow = TextOverflow.Ellipsis,
                 maxLines = if (isExpanded) Int.MAX_VALUE else 5,
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-                onOverflow = { isExpanded = it.not() }
+                onOverflow = { isExpanded = it.not() },
             )
             if (!isExpanded) {
                 ReadMoreOutlinedButton(


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- The website shows a summary statement of the third day's content, but the app does not currently show it.
- Therefore, we have modified it so that it is displayed.
- In addition, the Read More button is no longer displayed when the text is short.

## Links
- https://2023.droidkaigi.jp/timetable/e2d76d8b-f875-4919-810c-62a9b84b82df/

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/61a25bb5-757f-4bcf-8727-c4d0e5a32cf5" width="300" > | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/da706ff5-9ca9-408a-b09d-cf2f7276ab53" width="300" >