### PR TITLE
chore - remove isTest in SearchTextFieldAppBar Method

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchTextFieldAppBar.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/SearchTextFieldAppBar.kt
@@ -39,7 +39,6 @@ import io.github.droidkaigi.confsched2023.designsystem.preview.MultiThemePreview
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
 import io.github.droidkaigi.confsched2023.sessions.SessionsStrings.SearchPlaceHolder
 import io.github.droidkaigi.confsched2023.ui.handleOnClickIfNotNavigating
-import io.github.droidkaigi.confsched2023.ui.isTest
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -88,10 +87,7 @@ private fun SearchTextField(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     LaunchedEffect(Unit) {
-        // NOTE: Temporary workaround to pass unit tests
-        if (!isTest()) {
-            focusRequester.requestFocus()
-        }
+        focusRequester.requestFocus()
     }
 
     BasicTextField(


### PR DESCRIPTION
## Issue
- close #666

## Overview (Required)
- All UnitTests appear to succeed. I think it has been resolved naturally now.

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
<img width="711" alt="스크린샷 2023-09-09 오전 2 53 44" src="https://github.com/DroidKaigi/conference-app-2023/assets/17498974/1f468160-49ba-4c8f-b6be-e5a4da762e18">


## Movie (Optional)
