### PR TITLE
Adjust Timetable App Bar Bookmark Icon State

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -114,7 +114,7 @@ fun TimetableScreen(
 data class TimetableScreenUiState(
     val contentUiState: TimetableSheetUiState,
     val timetableUiType: TimetableUiType,
-    val onBookmarkIconClickStatus: Boolean?,
+    val onBookmarkIconClickStatus: Boolean,
 )
 
 private val timetableTopBackgroundLight = Color(0xFFF6FFD3)
@@ -257,7 +257,7 @@ fun PreviewTimetableScreenDark() {
                     ),
                 ),
                 TimetableUiType.Grid,
-                null,
+                false,
             ),
             SnackbarHostState(),
             {},

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -247,8 +247,8 @@ private fun TimetableScreen(
 fun PreviewTimetableScreenDark() {
     KaigiTheme {
         TimetableScreen(
-            TimetableScreenUiState(
-                TimetableSheetUiState.ListTimetable(
+            uiState = TimetableScreenUiState(
+                contentUiState = TimetableSheetUiState.ListTimetable(
                     mapOf(
                         DroidKaigi2023Day.Day1 to TimetableListUiState(
                             mapOf<String, List<TimetableItem>>().toPersistentMap(),
@@ -256,17 +256,17 @@ fun PreviewTimetableScreenDark() {
                         ),
                     ),
                 ),
-                TimetableUiType.Grid,
-                false,
+                timetableUiType = TimetableUiType.Grid,
+                onBookmarkIconClickStatus = false,
             ),
-            SnackbarHostState(),
-            {},
-            { _, _ -> },
-            {},
-            {},
-            {},
-            {},
-            Modifier.statusBarsPadding(),
+            snackbarHostState = SnackbarHostState(),
+            onTimetableItemClick = {},
+            onBookmarkClick = { _, _ -> },
+            onBookmarkIconClick = {},
+            onSearchClick = {},
+            onTimetableUiChangeClick = {},
+            onReachAnimationEnd = {},
+            modifier = Modifier.statusBarsPadding(),
         )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenViewModel.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreenViewModel.kt
@@ -44,8 +44,8 @@ class TimetableScreenViewModel @Inject constructor(
     private val timetableUiTypeStateFlow: MutableStateFlow<TimetableUiType> =
         MutableStateFlow(TimetableUiType.List)
 
-    private val bookmarkAnimationStartStateFlow: MutableStateFlow<Boolean?> =
-        MutableStateFlow(null)
+    private val bookmarkAnimationStartStateFlow: MutableStateFlow<Boolean> =
+        MutableStateFlow(false)
 
     private val timetableSheetUiState: StateFlow<TimetableSheetUiState> = buildUiState(
         sessionsStateFlow,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
@@ -32,7 +32,7 @@ fun BookmarkIcon(
     val lottieComposition by rememberLottieComposition(RawRes(raw.add_to_bookmark_lottie))
     var isPlaying by remember { mutableStateOf(false) }
 
-    val state = animateLottieCompositionAsState(
+    val lottieState = animateLottieCompositionAsState(
         composition = lottieComposition,
         isPlaying = isPlaying,
         restartOnPlay = true,
@@ -44,7 +44,7 @@ fun BookmarkIcon(
         }
     }
 
-    if (state.isPlaying && state.isAtEnd) {
+    if (lottieState.isPlaying && lottieState.isAtEnd) {
         isPlaying = false
         onReachAnimationEnd()
     }
@@ -53,10 +53,10 @@ fun BookmarkIcon(
         modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
-        if (state.isPlaying && !state.isAtEnd) {
+        if (lottieState.isPlaying && !lottieState.isAtEnd) {
             LottieAnimation(
                 composition = lottieComposition,
-                progress = { state.progress },
+                progress = { lottieState.progress },
                 modifier = Modifier
                     .semantics {
                         onClick(label = contentDescription, action = null)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.compose.LottieAnimation
-import com.airbnb.lottie.compose.LottieCancellationBehavior
 import com.airbnb.lottie.compose.LottieCompositionSpec.RawRes
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCancellationBehavior
 import com.airbnb.lottie.compose.LottieCompositionSpec.RawRes
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
@@ -25,27 +26,26 @@ import io.github.droidkaigi.confsched2023.feature.sessions.R.raw
 @Composable
 fun BookmarkIcon(
     contentDescription: String,
-    onBookmarkClickStatus: Boolean?,
+    onBookmarkClickStatus: Boolean,
     onReachAnimationEnd: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val lottieComposition by rememberLottieComposition(RawRes(raw.add_to_bookmark_lottie))
-    val animationRange = 0.1f..1f
     var isPlaying by remember { mutableStateOf(false) }
 
-    val progress by animateLottieCompositionAsState(
+    val state = animateLottieCompositionAsState(
         composition = lottieComposition,
         isPlaying = isPlaying,
         restartOnPlay = true,
     )
 
     LaunchedEffect(onBookmarkClickStatus) {
-        if (onBookmarkClickStatus != null) {
+        if (onBookmarkClickStatus) {
             isPlaying = true
         }
     }
 
-    if (progress == 1f) {
+    if (state.isPlaying && state.isAtEnd) {
         isPlaying = false
         onReachAnimationEnd()
     }
@@ -54,10 +54,10 @@ fun BookmarkIcon(
         modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
-        if (progress in animationRange) {
+        if (state.isPlaying && !state.isAtEnd) {
             LottieAnimation(
                 composition = lottieComposition,
-                progress = { progress },
+                progress = { state.progress },
                 modifier = Modifier
                     .semantics {
                         onClick(label = contentDescription, action = null)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -37,7 +37,7 @@ fun TimetableTopArea(
     onSearchClick: () -> Unit,
     onTopAreaBookmarkIconClick: () -> Unit,
     onReachAnimationEnd: () -> Unit,
-    onBookmarkClickStatus: Boolean?,
+    onBookmarkClickStatus: Boolean,
     modifier: Modifier = Modifier,
 ) {
     TopAppBar(
@@ -98,7 +98,7 @@ fun TimetableTopAreaPreview() {
                 onSearchClick = {},
                 onTopAreaBookmarkIconClick = {},
                 onReachAnimationEnd = {},
-                onBookmarkClickStatus = null,
+                onBookmarkClickStatus = false,
             )
         }
     }


### PR DESCRIPTION
## Issue
- close #1116

## Overview (Required)
- bookmark icon has unexpected behaviors at app bar on timetable screen (refer `before` movie)
- HOT to REPRODUCTION
  1. add bookmark on timetable list screen
  2. go to bookmark screen
  3. go back to timetable list screen
- WHY the behavior like this
  - ■ when simply adding bookmark
    <details>
      <summary>expand for detail...</summary>

      | onBookmarkClickState | isPlaying | progress | remarks |
      | :--: | :--: | :--: | :--: |
      NULL | FALSE |   | [[at first]]
      TRUE | FALSE |   | when click bookmark icon
      TRUE | TRUE | 0 | start animation
      TRUE | TRUE | ~1.0 |  
      TRUE | FALSE | 1 | call onReachAnimationEnd()
      FALSE | FALSE | 1 |  
      FALSE | TRUE | 1 | isPlay will be TRUE because onBookmarkClickState is updated
      FALSE | FALSE | 0 |  
      TRUE | FALSE | 0 | [[second click]]
      TRUE | TRUE | 0 | start animation
      TRUE | TRUE | ~1.0 |  
      TRUE | FALSE | 1 | call onReachAnimationEnd()
      FALSE | FALSE | 1 |  
      FALSE | TRUE | 1 | isPlay will be TRUE because onBookmarkClickState is updated
      FALSE | FALSE | 0 |  
    </details>

  - ■ when go back from bookmark list (before going to bookmark list, adding bookmark)
    - ※1,2): operated in one composable execution
    - the problem here is 
      - **onBookmarkClickState is false at first**
      - **onBookmarkClickState is false right after click bookmark**
    <details>
      <summary>expand for detail...</summary>

      onBookmarkClickState | isPlaying | progress | remarks
      -- | -- | -- | --
      FALSE | TRUE | 0 | animation is started because onBookmarkClickState is NOT null
      FALSE | TRUE | ~1.0 |  
      FALSE | FALSE | 1 | onReachAnimationEnd()
      **isPlaying will not be TRUE again because onBookmarkClickState is FALSE at first**
      TRUE | FALSE | 1 | [[second click]]
      TRUE※1 | TRUE※1 | 1 | isPlaying become TRUE (∵onBookmarkClickState is TRUE)
      FALSE※2 | FALSE※2 | 1 | onBookmarkClickState will be updated to FALSE becuase progress is 1.0
      FALSE | TRUE | 0 | start animation becuase onBookmarkState is updated
      FALSE | TRUE | ~1.0 |  
      FALSE | FALSE | 1 | onReachAnimationEnd()
      **isPlaying will not be TRUE again because onBookmarkClickState is FALSE (unchanged)** | | | |
    </details>
- I fix this issue by changing how to judge "animation is finished"
  - use LottieAnimationState (isPlaying, isAtEnd, progress) instead of using only `progress`
  - as a result, first null value of onBookmarkClickState and animationRange could remove
  - by this, variables arround animation are changed as following
    - ■ when simply adding bookmark
      <details>
        <summary>expand for detail...</summary>

        onBookmarkClickState | isPlaying | progress(state) | isPlaying(state) | isAtEnd(state) | remarks
        -- | -- | -- | -- | -- | --
        FALSE | FALSE | 0 | FALSE | TRUE | [[at first]]
        TRUE | FALSE | 0 | FALSE | TRUE | when click bookmark icon
        TRUE | TRUE | 0 | TRUE | FALSE | start animation
        TRUE | TRUE | ~1.0 | TRUE | FALSE |  
        TRUE | TRUE | 1 | TRUE | TRUE | when animation finished
        FALSE | FALSE | 1 | FALSE | TRUE | animation state is updated according to isPlaying
        TRUE | FALSE | 1 | FALSE | TRUE | [[second click]]
        TRUE | TRUE | 0 | TRUE | FALSE | start animation
        TRUE | TRUE | ~1.0 | TRUE | FALSE |  
        TRUE | TRUE | 1 | TRUE | TRUE | when animation finished
        FALSE | FALSE | 1 | FALSE | TRUE | animation state is updated according to isPlaying
      </details>
    - ■ when go back from bookmark list (before going to bookmark list, adding bookmark)
      <details>
        <summary>expand for detail...</summary>

        onBookmarkClickState | isPlaying | progress(state) | isPlaying(state) | isAtEnd(state) | remarks
        -- | -- | -- | -- | -- | --
        FALSE | FALSE | 0 | FALSE | TRUE | animation won't start because isPlaying will be TRUE only when onBookmarkClickState is TRUE
      </details>
## Links
- nothing

## Movie
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/da71fc7c-51c1-4c00-8de2-cca035230f96" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/030bf26b-0638-41a3-bb19-26f02ce7073e" width="300" >


