### PR TITLE
Changing the fetch timing of RemotoConfig

### DIFF
--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/data/remoteconfig/DefaultRemoteConfigApi.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/data/remoteconfig/DefaultRemoteConfigApi.kt
@@ -4,6 +4,9 @@ import co.touchlab.kermit.Logger
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.remoteconfig.get
 import dev.gitlive.firebase.remoteconfig.remoteConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class DefaultRemoteConfigApi : RemoteConfigApi {
 
@@ -12,13 +15,12 @@ class DefaultRemoteConfigApi : RemoteConfigApi {
     /**
      * If you want to change the interval time to fetch, please change it here
      */
-//    init {
-//        CoroutineScope(Dispatchers.IO).launch {
-//            firebaseRemoteConfig.settings {
-//                minimumFetchIntervalInSeconds = 1 * 60
-//            }
-//        }
-//    }
+    init {
+        CoroutineScope(Dispatchers.IO).launch {
+            firebaseRemoteConfig.reset()
+            fetchConfig()
+        }
+    }
 
     override suspend fun getBoolean(key: String): Boolean {
         fetchConfig()

--- a/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/data/remoteconfig/DefaultRemoteConfigApi.kt
+++ b/core/data/src/androidMain/kotlin/io/github/droidkaigi/confsched2023/data/remoteconfig/DefaultRemoteConfigApi.kt
@@ -12,9 +12,6 @@ class DefaultRemoteConfigApi : RemoteConfigApi {
 
     private val firebaseRemoteConfig = Firebase.remoteConfig
 
-    /**
-     * If you want to change the interval time to fetch, please change it here
-     */
     init {
         CoroutineScope(Dispatchers.IO).launch {
             firebaseRemoteConfig.reset()


### PR DESCRIPTION
## Overview (Required)
- I changed the update timing in RemoteConfig to the app's first launch and when the app is restarted.
  - It has been confirmed that updates are made through RemoteConfig upon app restart.