### PR TITLE
Set the time zone to the time on the left of the grid

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridHours.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridHours.kt
@@ -34,7 +34,6 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
-import kotlinx.datetime.toLocalTime
 import kotlin.math.roundToInt
 
 @Composable
@@ -279,7 +278,7 @@ private val hoursList by lazy {
     (10..19).map {
         val dateTime = LocalDateTime(
             date = now.date,
-            time = LocalTime(hour = it, minute = 0)
+            time = LocalTime(hour = it, minute = 0),
         ).toInstant(TimeZone.of("Asia/Tokyo"))
         val localDate = dateTime.toLocalDateTime(TimeZone.currentSystemDefault())
         "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridHours.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableGridHours.kt
@@ -28,6 +28,13 @@ import io.github.droidkaigi.confsched2023.sessions.section.TimetableState
 import io.github.droidkaigi.confsched2023.sessions.section.detectDragGestures
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.toLocalTime
 import kotlin.math.roundToInt
 
 @Composable
@@ -267,15 +274,14 @@ private val lineStrokeSize = 1.dp
 private val horizontalLineTopOffset = 48.dp
 private val hoursWidth = 75.dp
 private val hoursItemTopOffset = 11.dp
-private val hoursList = listOf(
-    "10:00",
-    "11:00",
-    "12:00",
-    "13:00",
-    "14:00",
-    "15:00",
-    "16:00",
-    "17:00",
-    "18:00",
-    "19:00",
-)
+private val hoursList by lazy {
+    val now = Clock.System.now().toLocalDateTime(TimeZone.of("Asia/Tokyo"))
+    (10..19).map {
+        val dateTime = LocalDateTime(
+            date = now.date,
+            time = LocalTime(hour = it, minute = 0)
+        ).toInstant(TimeZone.of("Asia/Tokyo"))
+        val localDate = dateTime.toLocalDateTime(TimeZone.currentSystemDefault())
+        "${localDate.hour}".padStart(2, '0') + ":" + "${localDate.minute}".padStart(2, '0')
+    }
+}


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Set the time zone to the time on the left of the grid

## Screenshot (Optional if screenshot test is present or unrelated to UI)
TimeZone | Before | After
:--: | :--: | :--:
America|<img src="https://github.com/DroidKaigi/conference-app-2023/assets/31527039/ea57d5ff-ecfe-4d7d-84d4-5ccbed8aa2f1" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/31527039/c3815896-728b-4138-870d-f11102de69ed" width="300" />
Japan<br>(no change)|<img src="https://github.com/DroidKaigi/conference-app-2023/assets/31527039/81f2fa3b-5dfa-4486-8bca-be27c3017eca" width="300" />  | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/31527039/ac1cf498-2706-4d05-b2e1-52fd2b289ef1" width="300" />
