### PR TITLE
Hide title when enable the BigFont/BigDisplay in FloorMapScreen

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/AutoSizableText.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/AutoSizableText.kt
@@ -1,0 +1,65 @@
+package io.github.droidkaigi.confsched2023.ui
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+private const val CONTRACTION_RATIO = 0.95f
+
+/**
+ * ref: https://blog.canopas.com/autosizing-textfield-in-jetpack-compose-7a80f0270853
+ */
+@Composable
+fun AutoSizableText(
+    text: String,
+    modifier: Modifier = Modifier,
+    minFontSize: TextUnit,
+    maxLines: Int = Int.MAX_VALUE,
+    fontWeight: FontWeight? = null,
+    style: TextStyle,
+) {
+    val density = LocalDensity.current
+    var tempFontSize by remember(text, style) { mutableFloatStateOf(style.fontSize.value) }
+
+    // Calculate size before displaying
+    BoxWithConstraints(modifier = modifier) {
+        val calculateParagraph = @Composable {
+            Paragraph(
+                text = text,
+                style = style.copy(fontSize = tempFontSize.sp),
+                constraints = this.constraints,
+                density = density,
+                fontFamilyResolver = LocalFontFamilyResolver.current,
+            )
+        }
+
+        var paragraph = calculateParagraph()
+        while (
+            tempFontSize > minFontSize.value &&
+            (paragraph.height / density.density > maxHeight.value || paragraph.lineCount > maxLines)
+        ) {
+            tempFontSize *= CONTRACTION_RATIO
+            paragraph = calculateParagraph()
+        }
+    }
+
+    Text(
+        text = text,
+        modifier = modifier,
+        maxLines = maxLines,
+        fontWeight = fontWeight,
+        style = style.copy(fontSize = tempFontSize.sp),
+    )
+}

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -45,6 +44,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -63,6 +63,7 @@ import io.github.droidkaigi.confsched2023.model.FloorLevel
 import io.github.droidkaigi.confsched2023.model.FloorLevel.Basement
 import io.github.droidkaigi.confsched2023.model.FloorLevel.Ground
 import io.github.droidkaigi.confsched2023.model.SideEvents
+import io.github.droidkaigi.confsched2023.ui.AutoSizableText
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.toImmutableList
 
@@ -152,16 +153,20 @@ private fun FloorMapScreen(
             TopAppBar(
                 title = {
                     if (scrollBehavior.state.overlappedFraction == 0f) {
-                        Text(
+                        AutoSizableText(
                             text = FloorMapStrings.Title.asString(),
-                            style = MaterialTheme.typography.headlineLarge,
+                            minFontSize = MaterialTheme.typography.bodySmall.fontSize,
+                            maxLines = 1,
                             fontWeight = FontWeight.Medium,
+                            style = MaterialTheme.typography.headlineLarge,
                         )
                     } else {
-                        Text(
+                        AutoSizableText(
                             text = FloorMapStrings.Title.asString(),
-                            style = MaterialTheme.typography.titleLarge,
                             modifier = Modifier.alpha(scrollBehavior.state.overlappedFraction),
+                            minFontSize = MaterialTheme.typography.bodySmall.fontSize,
+                            maxLines = 1,
+                            style = MaterialTheme.typography.titleLarge,
                         )
                     }
                 },


### PR DESCRIPTION
## Issue
- close #1148 

## Overview (Required)
- Text can now be resized and displayed by creating text for automatic text resizing.

## Links
- [AutoSizing TextField in Jetpack compose](https://blog.canopas.com/autosizing-textfield-in-jetpack-compose-7a80f0270853)

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

