### PR TITLE
Bug fix/contributors screen use autosizabletext

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/AutoSizableText.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/AutoSizableText.kt
@@ -24,11 +24,11 @@ private const val CONTRACTION_RATIO = 0.95f
 @Composable
 fun AutoSizableText(
     text: String,
-    modifier: Modifier = Modifier,
     minFontSize: TextUnit,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
     maxLines: Int = Int.MAX_VALUE,
     fontWeight: FontWeight? = null,
-    style: TextStyle,
 ) {
     val density = LocalDensity.current
     var tempFontSize by remember(text, style) { mutableFloatStateOf(style.fontSize.value) }
@@ -53,13 +53,12 @@ fun AutoSizableText(
             tempFontSize *= CONTRACTION_RATIO
             paragraph = calculateParagraph()
         }
-    }
 
-    Text(
-        text = text,
-        modifier = modifier,
-        maxLines = maxLines,
-        fontWeight = fontWeight,
-        style = style.copy(fontSize = tempFontSize.sp),
-    )
+        Text(
+            text = text,
+            maxLines = maxLines,
+            fontWeight = fontWeight,
+            style = style.copy(fontSize = tempFontSize.sp),
+        )
+    }
 }

--- a/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/AutoSizableText.kt
+++ b/core/ui/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/ui/AutoSizableText.kt
@@ -1,0 +1,65 @@
+package io.github.droidkaigi.confsched2023.ui
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+private const val CONTRACTION_RATIO = 0.95f
+
+/**
+ * ref: https://blog.canopas.com/autosizing-textfield-in-jetpack-compose-7a80f0270853
+ */
+@Composable
+fun AutoSizableText(
+    text: String,
+    modifier: Modifier = Modifier,
+    minFontSize: TextUnit,
+    maxLines: Int = Int.MAX_VALUE,
+    fontWeight: FontWeight? = null,
+    style: TextStyle,
+) {
+    val density = LocalDensity.current
+    var tempFontSize by remember(text, style) { mutableFloatStateOf(style.fontSize.value) }
+
+    // Calculate size before displaying
+    BoxWithConstraints(modifier = modifier) {
+        val calculateParagraph = @Composable {
+            Paragraph(
+                text = text,
+                style = style.copy(fontSize = tempFontSize.sp),
+                constraints = this.constraints,
+                density = density,
+                fontFamilyResolver = LocalFontFamilyResolver.current,
+            )
+        }
+
+        var paragraph = calculateParagraph()
+        while (
+            tempFontSize > minFontSize.value &&
+            (paragraph.height / density.density > maxHeight.value || paragraph.lineCount > maxLines)
+        ) {
+            tempFontSize *= CONTRACTION_RATIO
+            paragraph = calculateParagraph()
+        }
+    }
+
+    Text(
+        text = text,
+        modifier = modifier,
+        maxLines = maxLines,
+        fontWeight = fontWeight,
+        style = style.copy(fontSize = tempFontSize.sp),
+    )
+}

--- a/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
+++ b/feature/contributors/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/contributors/ContributorsScreen.kt
@@ -11,10 +11,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -26,6 +26,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import io.github.droidkaigi.confsched2023.contributors.component.ContributorListItem
 import io.github.droidkaigi.confsched2023.model.Contributor
+import io.github.droidkaigi.confsched2023.ui.AutoSizableText
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.PersistentList
 
@@ -79,7 +80,12 @@ private fun ContributorsScreen(
             if (scrollBehavior != null) {
                 LargeTopAppBar(
                     title = {
-                        Text(text = "Contributor")
+                        AutoSizableText(
+                            text = "Contributor",
+                            minFontSize = MaterialTheme.typography.bodySmall.fontSize,
+                            style = MaterialTheme.typography.titleLarge,
+                            maxLines = 1,
+                        )
                     },
                     navigationIcon = {
                         IconButton(

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/FloorMapScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -45,6 +44,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -63,6 +63,7 @@ import io.github.droidkaigi.confsched2023.model.FloorLevel
 import io.github.droidkaigi.confsched2023.model.FloorLevel.Basement
 import io.github.droidkaigi.confsched2023.model.FloorLevel.Ground
 import io.github.droidkaigi.confsched2023.model.SideEvents
+import io.github.droidkaigi.confsched2023.ui.AutoSizableText
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 import kotlinx.collections.immutable.toImmutableList
 
@@ -152,16 +153,20 @@ private fun FloorMapScreen(
             TopAppBar(
                 title = {
                     if (scrollBehavior.state.overlappedFraction == 0f) {
-                        Text(
+                        AutoSizableText(
                             text = FloorMapStrings.Title.asString(),
-                            style = MaterialTheme.typography.headlineLarge,
+                            minFontSize = MaterialTheme.typography.bodySmall.fontSize,
+                            maxLines = 1,
                             fontWeight = FontWeight.Medium,
+                            style = MaterialTheme.typography.headlineLarge,
                         )
                     } else {
-                        Text(
+                        AutoSizableText(
                             text = FloorMapStrings.Title.asString(),
-                            style = MaterialTheme.typography.titleLarge,
                             modifier = Modifier.alpha(scrollBehavior.state.overlappedFraction),
+                            minFontSize = MaterialTheme.typography.bodySmall.fontSize,
+                            maxLines = 1,
+                            style = MaterialTheme.typography.titleLarge,
                         )
                     }
                 },


### PR DESCRIPTION
## Issue
- close #1150 

## Overview (Required)
- Using AutoSizableText no longer causes character breaks.

## Links
- [AutoSizing TextField in Jetpack compose](https://blog.canopas.com/autosizing-textfield-in-jetpack-compose-7a80f0270853)
- https://github.com/DroidKaigi/conference-app-2023/pull/1149

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Settings | Before | After
:--: | :--:  | :--:
<img src="" width="300" /> | <img src="" width="300" /> | <img src="" width="300" />
<img src="" width="300" /> | <img src="" width="300" /> | <img src="" width="300" />
<img src="" width="300" /> | <img src="" width="300" /> | <img src="" width="300" />
<img src="" width="300" /> | <img src="" width="300" /> | <img src="" width="300" />

