### PR TITLE
[iOS] Show empty search results properly

### DIFF
--- a/app-ios/Modules/Sources/Timetable/Search/SearchView.swift
+++ b/app-ios/Modules/Sources/Timetable/Search/SearchView.swift
@@ -209,7 +209,7 @@ private struct SearchEmptyView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(AssetColors.Surface.onSurfaceVariant.swiftUIColor)
         }
-        .frame(minWidth: .infinity, minHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR fixes a view's frame to show empty search results properly

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/d00baccb-7d80-4365-a64a-2c01ad75f3a4" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/e05382ba-966c-4383-91dd-9131c86c94a4" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
