### PR TITLE
Hide text when enable the BigFont/BigDisplay in AchievementScreenDialog

### DIFF
--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreen.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -138,7 +140,7 @@ fun AchievementScreenDialog(
             )
         },
         text = {
-            Column {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 OrderedListText(
                     order = 1,
                     text = AchievementsStrings.DialogDescription1.asString(),


### PR DESCRIPTION
## Issue
- close #1147

## Overview (Required)
- Modified AlertDialog text to be scrollable.

## Links
- https://developer.android.com/reference/kotlin/androidx/compose/foundation/ScrollState


## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Pixel 7 Pro API 34 (Emulator)

Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/12296647/2dd7864a-ed3f-4adb-9c2a-b74ed13376c3" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/12296647/070eb777-b9ad-493e-8193-e6b3c1754239" width="300" >
