### PR TITLE
Replace enum values() with entries

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableLanguage.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableLanguage.kt
@@ -15,6 +15,6 @@ public data class TimetableLanguage(
     fun toLang() = if (isInterpretationTarget) {
         Lang.MIXED
     } else {
-        Lang.values().firstOrNull { it.tagName == langOfSpeaker.take(2) } ?: Lang.MIXED
+        Lang.entries.firstOrNull { it.tagName == langOfSpeaker.take(2) } ?: Lang.MIXED
     }
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableSessionType.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableSessionType.kt
@@ -36,7 +36,7 @@ enum class TimetableSessionType(
 
     companion object {
         fun ofOrNull(key: String): TimetableSessionType? {
-            return values().firstOrNull {
+            return entries.firstOrNull {
                 it.key == key
             }
         }

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/PreviewFloorMapSwitcherFloorLevelProvider.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/component/PreviewFloorMapSwitcherFloorLevelProvider.kt
@@ -5,5 +5,5 @@ import io.github.droidkaigi.confsched2023.model.FloorLevel
 
 class PreviewFloorMapSwitcherFloorLevelProvider : PreviewParameterProvider<FloorLevel> {
     override val values: Sequence<FloorLevel>
-        get() = FloorLevel.values().asSequence()
+        get() = FloorLevel.entries.asSequence()
 }

--- a/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/section/FloorMap.kt
+++ b/feature/floor-map/src/main/java/io/github/droidkaigi/confsched2023/floormap/section/FloorMap.kt
@@ -29,7 +29,7 @@ enum class FloorMapUiState(
     ;
 
     companion object {
-        fun of(floorLevel: FloorLevel) = values().find {
+        fun of(floorLevel: FloorLevel) = entries.find {
             it.floorLevel == floorLevel
         } ?: error("There's no such floorLevel $floorLevel")
     }


### PR DESCRIPTION
## Issue
- no issue
## Overview (Required)
- In Kotlin 1.9.0, the entries property of Enum is Stable. The official documentation recommends replacing values() with entries, so I have fixed as much as possible.
- it does not return an array, so a new instance is not created with each call, which may improve Kotlin performance slightly.

## Links
- https://kotlinlang.org/docs/whatsnew19.html#stable-replacement-of-the-enum-class-values-function

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
