### PR TITLE
:sparkles: Added a shell script to create the XCFramework needed when developing the iOS side.

### DIFF
--- a/scripts/assemble_xc_framework.sh
+++ b/scripts/assemble_xc_framework.sh
@@ -1,0 +1,6 @@
+#!/bin/zsh
+
+cd ../
+./gradlew :app-io-shared:assembleSharedReleaseXCFramework
+./gradlew :app-io-shared:assembleSharedDebugXCFramework 
+echo -e "\a"


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Since I forget the command every time when outputting XCFramework, I added a script that can output the minimum required XCFramework by executing a shell script.