### PR TITLE
[iOS] Improve iOS TimetableDayHeader performance

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableView.swift
@@ -62,7 +62,7 @@ public struct TimetableView<SessionView: View>: View {
                     }
                     ScrollViewWithVerticalOffset(
                         onOffsetChange: { offset in
-                            shouldCollapse = (offset < verticalOffsetThreshold)
+                            shouldCollapse = offset < verticalOffsetThreshold
                         },
                         content: {
                             Spacer().frame(height: 130)
@@ -71,9 +71,7 @@ public struct TimetableView<SessionView: View>: View {
                                     header: TimetableDayHeader(
                                         selectedDay: viewModel.state.selectedDay,
                                         shouldCollapse: shouldCollapse,
-                                        onSelect: {
-                                            viewModel.selectDay(day: $0)
-                                        }
+                                        onSelect: viewModel.selectDay(day:)
                                     )
                                     .frame(height: shouldCollapse ? 53 : 82)
                                     .animation(.easeInOut(duration: 0.08), value: shouldCollapse)
@@ -81,9 +79,7 @@ public struct TimetableView<SessionView: View>: View {
                                     TimetableListView(
                                         timetableTimeGroupItems: state.timeGroupTimetableItems,
                                         searchWord: "",
-                                        onToggleBookmark: { id in
-                                            viewModel.toggleBookmark(id)
-                                        }
+                                        onToggleBookmark: viewModel.toggleBookmark
                                     )
                                 }
                             }

--- a/app-ios/Modules/Sources/Timetable/TimetableView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableView.swift
@@ -35,8 +35,8 @@ public struct TimetableView<SessionView: View>: View {
         switch viewModel.state.loadedState {
         case .initial, .loading:
             ProgressView()
-                .onAppear {
-                    viewModel.load()
+                .onAppear { [weak viewModel] in
+                    viewModel?.load()
                 }
         case .failed:
             EmptyView()
@@ -71,7 +71,9 @@ public struct TimetableView<SessionView: View>: View {
                                     header: TimetableDayHeader(
                                         selectedDay: viewModel.state.selectedDay,
                                         shouldCollapse: shouldCollapse,
-                                        onSelect: viewModel.selectDay(day:)
+                                        onSelect: { [weak viewModel] in
+                                            viewModel?.selectDay(day: $0)
+                                        }
                                     )
                                     .frame(height: shouldCollapse ? 53 : 82)
                                     .animation(.easeInOut(duration: 0.08), value: shouldCollapse)
@@ -79,7 +81,9 @@ public struct TimetableView<SessionView: View>: View {
                                     TimetableListView(
                                         timetableTimeGroupItems: state.timeGroupTimetableItems,
                                         searchWord: "",
-                                        onToggleBookmark: viewModel.toggleBookmark
+                                        onToggleBookmark: { [weak viewModel] in
+                                            viewModel?.toggleBookmark($0)
+                                        }
                                     )
                                 }
                             }


### PR DESCRIPTION
## Issue
- close #1075 

## Overview (Required)
- This is caused by circular reference between TimetableViewModel instance and TimetabeListView 's closure ( toggleBookmark ).
- Currently, SwiftUI rendering is recursively called and it is caused by above. 

ref: https://developer.apple.com/forums/thread/126890

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## Movie (Optional)


Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/30540303/627f5c3e-51b9-4e6e-a087-aa24aa40d6c9" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/30540303/5f83e0e2-5f15-4f25-9001-440d6e37d96a" width="300" >


