### PR TITLE
Fix margin when is collapsing state.

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableDayHeader.swift
@@ -38,7 +38,7 @@ struct TimetableDayHeader: View {
                                     .frame(height: 32)
                             }
                         }
-                        .padding(4)
+                        .padding(shouldCollapse ? 6 : 4)
                         .frame(maxWidth: .infinity)
                         .foregroundStyle(
                             selectedDay == day


### PR DESCRIPTION
## Issue

## Overview (Required)
- Adjust margin when header is collapsing.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/c38f0c6e-3659-48e2-a9c2-70540f34f246" width="424" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/949561/e31a6e2b-d0c2-451a-9b22-ee02c5ad603d" width="424" />