### PR TITLE
[iOS] fix time order and duplicate contents

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableViewModel.swift
@@ -68,14 +68,16 @@ final class TimetableViewModel: ObservableObject {
                         $0.timetableItem.room.name.currentLangTitle < $1.timetableItem.room.name.currentLangTitle
                     }
                 return TimetableTimeGroupItems(
-                    startsTimeString: item.startsTimeString,
-                    endsTimeString: item.endsTimeString,
+                    startsTimeString: items.first?.timetableItem.startsTimeString ?? "",
+                    endsTimeString: items.first?.timetableItem.endsTimeString ?? "",
                     items: items
                 )
             }
+        var seen: [TimetableTimeGroupItems: Bool] = [:]
+        let distinctedTimetableTimeGroupItems = timetableTimeGroupItems.filter { seen.updateValue(true, forKey: $0) == nil }
         state.loadedState = .loaded(
             .init(
-                timeGroupTimetableItems: timetableTimeGroupItems,
+                timeGroupTimetableItems: distinctedTimetableTimeGroupItems,
                 bookmarks: cachedTimetable.bookmarks
             )
         )


### PR DESCRIPTION
## Issue
- close #1165

## Overview (Required)
I resolved the issues with timetable time shifts and duplicate content.
It is not best solution, but now I thought that this issue have to solve immediately.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/6025572/d33709e2-f985-4ba0-b89d-e0cacefca84c" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/6025572/885b0bf7-7cbc-4f88-a99f-31d6ff34c1e6" width="300" >
