### PR TITLE
[iOS] Fix the tab title for Floor Map

### DIFF
--- a/app-ios/Modules/Sources/Navigation/RootView.swift
+++ b/app-ios/Modules/Sources/Navigation/RootView.swift
@@ -57,7 +57,7 @@ public struct RootView: View {
                     .tag(Tab.floorMap)
                     .tabItem {
                         Label {
-                            Text("FloorMap")
+                            Text("Floor Map")
                         } icon: {
                             if selection == .floorMap {
                                 Assets.Icons.floorMap.swiftUIImage


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- This PR makes space to fix the tab title for Floor Map

## Links
- 

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/0ed1ea6b-77f5-4aa0-b0fc-de9bb8d208a6" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/5673994/4ca1fa42-a9b4-4049-a895-d0cfbb8b4edf" width="300" />

## Movie (Optional)
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
