### PR TITLE
[iOS] improve favorite performance

### DIFF
--- a/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkView.swift
+++ b/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkView.swift
@@ -25,32 +25,32 @@ struct BookmarkView<SessionView: View>: View {
                         await viewModel.load()
                     }
             case .loaded(let timetableItems):
-                if timetableItems.isEmpty {
-                    BookmarkEmptyView()
-                } else {
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack {
+                        FilterLabel(
+                            title: "全て",
+                            isSelection: false,
+                            isSelected: viewModel.state.selectedDay == nil,
+                            onSelect: {
+                                viewModel.selectDay(day: nil)
+                            },
+                            onDeselect: nil
+                        )
+                        ForEach([DroidKaigi2023Day].fromKotlinArray(DroidKaigi2023Day.values())) { day in
                             FilterLabel(
-                                title: "全て",
+                                title: day.name,
                                 isSelection: false,
-                                isSelected: viewModel.state.selectedDay == nil,
+                                isSelected: viewModel.state.selectedDay == day,
                                 onSelect: {
-                                    viewModel.selectDay(day: nil)
+                                    viewModel.selectDay(day: day)
                                 },
                                 onDeselect: nil
                             )
-                            ForEach([DroidKaigi2023Day].fromKotlinArray(DroidKaigi2023Day.values())) { day in
-                                FilterLabel(
-                                    title: day.name,
-                                    isSelection: false,
-                                    isSelected: viewModel.state.selectedDay == day,
-                                    onSelect: {
-                                        viewModel.selectDay(day: day)
-                                    },
-                                    onDeselect: nil
-                                )
-                            }
                         }
+                    }
+                    if timetableItems.map({ $0.items }).flatMap({ $0 }).isEmpty {
+                        BookmarkEmptyView()
+                    } else {
                         ScrollView {
                             TimetableListView(
                                 timetableTimeGroupItems: timetableItems,

--- a/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/Bookmark/BookmarkViewModel.swift
@@ -64,14 +64,18 @@ final class BookmarkViewModel: ObservableObject {
                     .sorted {
                         $0.timetableItem.room.name.currentLangTitle < $1.timetableItem.room.name.currentLangTitle
                     }
+                    .filter { $0.isFavorited }
                 return TimetableTimeGroupItems(
                     startsTimeString: content.timetableItem.startsTimeString,
                     endsTimeString: content.timetableItem.endsTimeString,
                     items: items
                 )
             }
+        var seen: [TimetableTimeGroupItems: Bool] = [:]
+        let distinctedTimetableTimeGroupItems = timetableTimeGroupItems.filter { seen.updateValue(true, forKey: $0) == nil }
+        
         state.timeGroupTimetableItems = .loaded(
-            timetableTimeGroupItems
+            distinctedTimetableTimeGroupItems
         )
     }
 }

--- a/app-ios/Modules/Sources/Timetable/TimetableListView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListView.swift
@@ -10,27 +10,31 @@ struct TimetableListView: View {
     var body: some View {
         VStack(spacing: 0) {
             ForEach(timetableTimeGroupItems) { timetableTimeGroupItem in
-                HStack(alignment: .top, spacing: 16) {
-                    SessionTimeView(
-                        startsTimeString: timetableTimeGroupItem.startsTimeString,
-                        endsTimeString: timetableTimeGroupItem.endsTimeString
-                    )
-                    VStack(spacing: 0) {
-                        ForEach(timetableTimeGroupItem.items, id: \.timetableItem.id.value) { timetableItemWithFavorite in
-                            NavigationLink(value: TimetableRouting.session(timetableItemWithFavorite.timetableItem)) {
-                                TimetableListItemView(
-                                    timetableItemWithFavorite: timetableItemWithFavorite,
-                                    searchWord: searchWord,
-                                    onToggleBookmark: {
-                                        onToggleBookmark(timetableItemWithFavorite.timetableItem.id)
-                                    }
-                                )
+                if timetableTimeGroupItem.items.isEmpty {
+                    EmptyView()
+                } else {
+                    HStack(alignment: .top, spacing: 16) {
+                        SessionTimeView(
+                            startsTimeString: timetableTimeGroupItem.startsTimeString,
+                            endsTimeString: timetableTimeGroupItem.endsTimeString
+                        )
+                        VStack(spacing: 0) {
+                            ForEach(timetableTimeGroupItem.items, id: \.timetableItem.id.value) { timetableItemWithFavorite in
+                                NavigationLink(value: TimetableRouting.session(timetableItemWithFavorite.timetableItem)) {
+                                    TimetableListItemView(
+                                        timetableItemWithFavorite: timetableItemWithFavorite,
+                                        searchWord: searchWord,
+                                        onToggleBookmark: {
+                                            onToggleBookmark(timetableItemWithFavorite.timetableItem.id)
+                                        }
+                                    )
+                                }
                             }
                         }
                     }
+                    .padding(8)
+                    Divider()
                 }
-                .padding(8)
-                Divider()
             }
         }
         .padding(.vertical, 24)


### PR DESCRIPTION
## Issue
- close #1078

## Overview (Required)
- 
Improved performance of favorites.
Filtered out the data that was mixed in with other data in areas where only favorite data was displayed.
Removed duplicate data in some areas.
The UI was different compared to Android, so this has been fixed.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/6025572/06de9779-4137-49c2-8099-85daacdb381a" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/6025572/6004bae4-9824-4a68-8feb-c98229dcc0ac" width="300" >
