### PR TITLE
[iOS] :wrench: Assign the color of RoomD to the color of the tag on day 3 as in Android.

### DIFF
--- a/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
+++ b/app-ios/Modules/Sources/Timetable/TimetableListItemView.swift
@@ -95,6 +95,7 @@ private extension RoomType {
         case .roomc: AssetColors.Custom.hallC
         case .roomd: AssetColors.Custom.hallD
         case .roome: AssetColors.Custom.hallE
+        case .roomde: AssetColors.Custom.hallD
         default: AssetColors.Custom.white
         }
         return colorAsset.swiftUIColor


### PR DESCRIPTION
## Issue
- None.(Maybe)

## Overview (Required)
- The title says it all.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/88790e08-7421-4353-8c7a-95bb09a80529" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/2ea5e2cf-9ea4-4146-a4c1-f529116bcf4f" width="300" />
