### PR TITLE
Suppress some typo warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ Thumbs.db
 !/.idea/codeStyles/Project.xml
 !/.idea/codeStyles/codeStyleConfig.xml
 !/.idea/icon*.svg
+# Suppress typo
+!/.idea/dictionaries
+/.idea/dictionaries/*
+!/.idea/dictionaries/dictionary.xml
 
 # Gradle cache
 .gradle

--- a/.idea/dictionaries/dictionary.xml
+++ b/.idea/dictionaries/dictionary.xml
@@ -1,0 +1,30 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="dictionary">
+    <words>
+      <w>arturbosch</w>
+      <w>atomicfu</w>
+      <w>bellesalle</w>
+      <w>composables</w>
+      <w>confsched</w>
+      <w>deps</w>
+      <w>desugaring</w>
+      <w>droidkaigi</w>
+      <w>favorited</w>
+      <w>hoge</w>
+      <w>jensklingenberg</w>
+      <w>kaigi</w>
+      <w>konfig</w>
+      <w>kover</w>
+      <w>ktorfit</w>
+      <w>louiscad</w>
+      <w>placable</w>
+      <w>roborazzi</w>
+      <w>shibuya</w>
+      <w>showkase</w>
+      <w>signin</w>
+      <w>snackbar</w>
+      <w>taka</w>
+      <w>takahirom</w>
+    </words>
+  </dictionary>
+</component>


### PR DESCRIPTION
## Overview (Required)
- Android Studio issues typo warnings for some project-specific words. By registering the words that are not typos in `./idea/dictionaries` , we can suppress these warnings.

To Reproduce (Typo Inspection needs Android Studio Restart)
1. Code -> Analyze Code -> Run Inspection by Name
    + ![image](https://github.com/DroidKaigi/conference-app-2023/assets/3471753/2d0a3195-49dc-479f-9fa5-92814f672953)
2. Enter inspection name: `Typo`
3. select `Typo`
    + ![image](https://github.com/DroidKaigi/conference-app-2023/assets/3471753/32b333f9-edb1-4c60-90d3-8e79f5d8c3dc)
4. add File Name Filter: `*.kt` then click OK
    + ![image](https://github.com/DroidKaigi/conference-app-2023/assets/3471753/66f24089-5029-433b-a100-ecc0138afaf4)
5. result (see next section)



## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before(153 typos) | After(7 typos)
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/3471753/b5385320-9be0-4982-9471-3820b0e85f73" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/3471753/875955dd-a1c9-438f-8b46-513cad0e04e4" width="300" />

