### PR TITLE
[iOS] :wrench: Nothing is displayed when side event images cannot be loaded.

### DIFF
--- a/app-ios/Modules/Sources/FloorMap/SideEventRow.swift
+++ b/app-ios/Modules/Sources/FloorMap/SideEventRow.swift
@@ -40,24 +40,22 @@ struct SideEventRow: View {
             Spacer(minLength: 0)
 
             // Image
-            Group {
-                if let imageLink = sideEvent.imageLink, let imageUrl = URL(string: imageLink) {
+            if let imageLink = sideEvent.imageLink, let imageUrl = URL(string: imageLink) {
+                Group {
                     CacheAsyncImage(url: imageUrl) { image in
                         image.resizable()
                     } placeholder: {
                         Color.gray
                     }
-                } else {
-                    Color.gray
                 }
+                .frame(width: 88, height: 88)
+                .scaledToFill()
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(AssetColors.Outline.outline.swiftUIColor, lineWidth: 1)
+                )
             }
-            .frame(width: 88, height: 88)
-            .scaledToFill()
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(AssetColors.Outline.outline.swiftUIColor, lineWidth: 1)
-            )
         }
     }
 }


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Figma also does not seem to display anything when an image does not exist, so we changed the appearance of the image when it could not be loaded accordingly.

## Links
- https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=56145-69943&mode=dev

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/4d6f7caa-3a69-4c1c-8b19-5bd371eab2eb" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/37d2957a-a7ff-4654-8926-0fe2a220ad94" width="300" />