### PR TITLE
[iOS] delete duplicate session

### DIFF
--- a/app-ios/Modules/Sources/Timetable/Search/SearchViewModel.swift
+++ b/app-ios/Modules/Sources/Timetable/Search/SearchViewModel.swift
@@ -85,13 +85,15 @@ final class SearchViewModel: ObservableObject {
                     items: items
                 )
             }
+        var seen: [TimetableTimeGroupItems: Bool] = [:]
+        let distinctedTimetableTimeGroupItems = timetableTimeGroupItems.filter { seen.updateValue(true, forKey: $0) == nil }
         state.loadingState = .loaded(
             .init(
                 categories: cachedTimetable.categories,
                 sessionTypes: cachedTimetable.sessionTypes,
                 rooms: cachedTimetable.rooms,
                 languages: cachedTimetable.languages,
-                timeGroupTimetableItems: timetableTimeGroupItems
+                timeGroupTimetableItems: distinctedTimetableTimeGroupItems
             )
         )
     }


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- In my environment, there was duplicated content on the search screen, so I have implemented this so that there is no duplicated content.

## Links
- 
## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/6025572/46740aca-4a01-4a67-9550-f91968ef17ed" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/6025572/87f98a02-9873-4016-80ae-8e57d2f9ef4d" width="300" >
