### PR TITLE
:sparkles: Added a run file to run ComposeCompilerMetricsReports from within Android Studio.

### DIFF
--- a/.run/generateComposeCompilerMetricsReports.run.xml
+++ b/.run/generateComposeCompilerMetricsReports.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="generateMetricsReport" type="GradleRunConfiguration" factoryName="Gradle">
+        <ExternalSystemSettings>
+            <option name="executionName" />
+            <option name="externalProjectPath" value="$PROJECT_DIR$" />
+            <option name="externalSystemIdString" value="GRADLE" />
+            <option name="scriptParameters" value="-PenableComposeCompilerMetrics=true -PenableComposeCompilerReports=true" />
+            <option name="taskDescriptions">
+                <list />
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="assembleRelease" />
+                </list>
+            </option>
+            <option name="vmOptions" />
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <method v="2" />
+    </configuration>
+</component>


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- We have established a pathway to generate the previously introduced Compose compiler metrics report from within AndroidStudio.
- We would not have been able to generate this PR without knowing of the existence of the methodology described in the link. 🙏

## Links
- https://github.com/DroidKaigi/conference-app-2023/pull/1162
- https://github.com/DroidKaigi/conference-app-2023/pull/1008#issuecomment-1698509595