### PR TITLE
[iOS] Add retry support to `NFCReader`

### DIFF
--- a/app-ios/Modules/Sources/Achievements/AchievementsView.swift
+++ b/app-ios/Modules/Sources/Achievements/AchievementsView.swift
@@ -5,6 +5,7 @@ import Theme
 
 public struct AchievementsView: View {
     @ObservedObject var viewModel: AchievementsViewModel = .init()
+    @State private var isReadingNFCTag = false
     @State private var obtainedAchievement: Achievement?
 
     public init() {}
@@ -61,12 +62,18 @@ public struct AchievementsView: View {
                             }
                             Button {
                                 Task {
-                                    let result = await viewModel.read()
+                                    isReadingNFCTag = true
+                                    let result = await viewModel.read(
+                                        didInvalidateHandler: {
+                                            isReadingNFCTag = false
+                                        }
+                                    )
                                     obtainedAchievement = result
                                 }
                             } label: {
-                                Text("Scan NFC Tag")
+                                Text(isReadingNFCTag ? "Scanning..." : "Scan the NFC Tag")
                             }
+                            .disabled(isReadingNFCTag)
                             .buttonStyle(.bordered)
                             .controlSize(.large)
                         }

--- a/app-ios/Modules/Sources/DeepLink/DeepLink.swift
+++ b/app-ios/Modules/Sources/DeepLink/DeepLink.swift
@@ -17,6 +17,15 @@ public class DeepLink {
         DynamicLinks.dynamicLinks().dynamicLink(fromCustomSchemeURL: url)
     }
 
+    public func canBeResolved(from shortLink: URL) async -> Bool {
+        do {
+            let resolvedLink = try await resolveShortLink(url: shortLink)
+            return dynamicLink(customURL: resolvedLink) != nil
+        } catch {
+            return false
+        }
+    }
+
     public func dynamicLink(shortLink: URL) async throws -> DynamicLink? {
         let resolvedLink = try await resolveShortLink(url: shortLink)
         return dynamicLink(customURL: resolvedLink)

--- a/app-ios/Modules/Sources/NFC/NFCReader.swift
+++ b/app-ios/Modules/Sources/NFC/NFCReader.swift
@@ -4,54 +4,111 @@ public enum NFCError: Error {
     case unavailable
 }
 
-public class NFCReader: NSObject {
-    private var activeContinuation: CheckedContinuation<String?, any Error>?
-    private var session: NFCReaderSession?
+public final class NFCReader: NSObject {
+    private var activeContinuation: CheckedContinuation<URL, any Error>?
+    private var session: NFCTagReaderSession?
+    private var didInvalidateHandler: (() -> Void)?
+    private var urlResolver: ((URL) async -> Bool)?
+    private var tagReaderSessionDidDetectTask: Task<(), Never>?
 
-    public override init() {}
-
-    public func read() async throws -> String? {
-        guard NFCNDEFReaderSession.readingAvailable else {
+    public func read(
+        didInvalidateHandler: @escaping () -> Void,
+        urlResolver: @escaping @Sendable (URL) async -> Bool
+    ) async throws -> URL {
+        guard NFCTagReaderSession.readingAvailable,
+              let session = NFCTagReaderSession(pollingOption: .iso14443, delegate: self) else {
             throw NFCError.unavailable
         }
+        self.session = session
+        self.didInvalidateHandler = didInvalidateHandler
+        self.urlResolver = urlResolver
 
+        tagReaderSessionDidDetectTask?.cancel()
         return try await withCheckedThrowingContinuation { continuation in
             activeContinuation = continuation
-
-            session = NFCNDEFReaderSession(delegate: self, queue: nil, invalidateAfterFirstRead: false)
-
-            session?.alertMessage = "Hold your iPhone near the item to learn more about it."
-
-            session?.begin()
+            self.session?.alertMessage = AlertMessage.scanning
+            self.session?.begin()
         }
     }
 
-    private func invalidateSession() {
-        session?.invalidate()
+    private func releaseSession() {
+        tagReaderSessionDidDetectTask?.cancel()
+        tagReaderSessionDidDetectTask = nil
         session = nil
         activeContinuation = nil
     }
-}
 
-extension NFCReader: NFCNDEFReaderSessionDelegate {
-    public func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
-        if let message = messages.first, let record = message.records.first {
-            let result = switch String(data: record.type, encoding: .utf8) {
-            case "T":
-                record.wellKnownTypeTextPayload().0
-            case "U":
-                record.wellKnownTypeURIPayload()?.absoluteString
-            default:
-                record.wellKnownTypeTextPayload().0
-            }
-
-            activeContinuation?.resume(returning: result)
-            invalidateSession()
+    private func restartPolling(session: NFCTagReaderSession, alertMessage: String) {
+        session.alertMessage = alertMessage
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(1)) {
+            session.alertMessage = AlertMessage.scanning
+            session.restartPolling()
         }
     }
+}
 
-    public func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: Error) {
+extension NFCReader: NFCTagReaderSessionDelegate {
+    public func tagReaderSessionDidBecomeActive(_ session: NFCTagReaderSession) {
+        // do nothing...
+    }
+
+    public func tagReaderSession(_ session: NFCTagReaderSession, didInvalidateWithError error: Error) {
         activeContinuation?.resume(throwing: error)
-        invalidateSession()
+        releaseSession()
+        didInvalidateHandler?()
+        didInvalidateHandler = nil
+    }
+
+    public func tagReaderSession(_ session: NFCTagReaderSession, didDetect tags: [NFCTag]) {
+        let ndefTags = tags.compactMap {
+            switch $0 {
+            case .feliCa(let tag as NFCNDEFTag), .iso7816(let tag as NFCNDEFTag), .iso15693(let tag as NFCNDEFTag), .miFare(let tag as NFCNDEFTag):
+                return ($0, tag)
+            @unknown default:
+                return nil
+            }
+        }
+
+        guard ndefTags.count < 2 else {
+            restartPolling(session: session, alertMessage: AlertMessage.moreThanOneTag)
+            return
+        }
+
+        guard let (tag, ndefTag) = ndefTags.first else {
+            restartPolling(session: session, alertMessage: AlertMessage.notSupported)
+            return
+        }
+
+        tagReaderSessionDidDetectTask = Task {
+            do {
+                try await session.connect(to: tag)
+                let message = try await ndefTag.readNDEF()
+                let record = message.records.first
+                guard let url = record?.wellKnownTypeURIPayload() else {
+                    restartPolling(session: session, alertMessage: AlertMessage.notSupported)
+                    return
+                }
+                let success = await urlResolver?(url) ?? false
+                guard success else {
+                    restartPolling(session: session, alertMessage: AlertMessage.notSupported)
+                    return
+                }
+                session.alertMessage = AlertMessage.done
+                session.invalidate()
+                activeContinuation?.resume(returning: url)
+                releaseSession()
+            } catch {
+                restartPolling(session: session, alertMessage: AlertMessage.notSupported)
+            }
+        }
+    }
+}
+
+extension NFCReader {
+    private enum AlertMessage {
+        static let scanning = "Hold the top of your iPhone on the NFC tag and avoid metallic accessories."
+        static let moreThanOneTag = "More than 1 tag is detected, please remove all tags and try again."
+        static let notSupported = "The tag is not supported. Try again."
+        static let done = "Done!"
     }
 }


### PR DESCRIPTION
## Overview (Required)
- In the part of iOS that uses `NFCReader`, add a process that prompts the user to retry when an unexpected NFC tag is scanned.
  - To do so, use `NFCTagReaderSession` instead of `NFCNDEFReaderSession`.
    - NFC tags assume that ISO 14443 (NFC-A) NDEF messages are used.
  - To determine if the URL contained in the data inside the NFC tag is the intended one, add `NFCReader.urlResolver` and use it.
- Add the ability to enable/disable the scan start button to prevent users from tapping the button again to start scanning while scanning is in progress.
  - This prevents errors that often occur when using Core NFC on iOS, where system resources become unavailable.

## Movie (Optional)
|After|
|:--:|
|<video src="https://github.com/DroidKaigi/conference-app-2023/assets/13805382/f1e1601c-0b76-409b-a2a0-149b1828a832" width="300" > |
|In this movie, the intended tag is scanned after two incorrect NFC tags are scanned.|