### PR TITLE
:wrench: We can see the bottom of the sessions on day 2 grid screen.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
@@ -112,7 +112,6 @@ fun TimetableGrid(
             top = contentPadding.calculateTopPadding(),
             start = contentPadding.calculateStartPadding(layoutDirection),
             end = contentPadding.calculateEndPadding(layoutDirection),
-            bottom = contentPadding.calculateBottomPadding(),
         ),
     ) {
         TimetableGridHours(
@@ -136,7 +135,7 @@ fun TimetableGrid(
                 modifier = modifier,
                 contentPadding = PaddingValues(
                     top = 16.dp + contentPadding.calculateTopPadding(),
-                    bottom = 16.dp + contentPadding.calculateBottomPadding(),
+                    bottom = 16.dp + 80.dp + contentPadding.calculateBottomPadding(),
                     start = 16.dp + contentPadding.calculateStartPadding(layoutDirection),
                     end = 16.dp + contentPadding.calculateEndPadding(layoutDirection),
                 ),

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
@@ -112,6 +112,7 @@ fun TimetableGrid(
             top = contentPadding.calculateTopPadding(),
             start = contentPadding.calculateStartPadding(layoutDirection),
             end = contentPadding.calculateEndPadding(layoutDirection),
+            bottom = contentPadding.calculateBottomPadding(),
         ),
     ) {
         TimetableGridHours(


### PR DESCRIPTION
## Issue
- close #1208 

## Overview (Required)
- The 2022 application did not have a navigation bar at the bottom, but the 2023 application had a navigation bar at the bottom.
- Therefore, we addressed the issue by adding padding to the bottom for it.

## Links
- https://www.figma.com/file/MbElhCEnjqnuodmvwabh9K/DroidKaigi-2023-App-UI?type=design&node-id=54477-38907&mode=dev

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/b8454b1e-f2c5-4326-8640-3922df23d327" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/13657682/7f4592b3-e98b-4ce1-9681-a598112f745f" width="300" />