### PR TITLE
Fix timetable detail section loading animation

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -215,9 +215,7 @@ fun TimetableItemDetailScreenPreview() {
             TimetableItemDetailScreen(
                 uiState = Loaded(
                     timetableItem = fakeSession,
-                    timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(
-                        fakeSession,
-                    ),
+                    timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(fakeSession),
                     isBookmarked = isBookMarked,
                     isLangSelectable = true,
                     viewBookmarkListRequestState = ViewBookmarkListRequestState.NotRequested,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -150,7 +150,9 @@ private fun TimetableItemDetailScreen(
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             if (uiState is Loaded) {
                 TimetableItemDetailScreenTopAppBar(
@@ -176,10 +178,11 @@ private fun TimetableItemDetailScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { innerPadding ->
         AnimatedContent(
+            modifier = Modifier.fillMaxSize(),
             targetState = uiState,
             transitionSpec = { fadeIn().togetherWith(fadeOut()) },
             contentKey = { uiState is Loaded },
-            label = "TimetableItemDetailScreen",
+            label = "TimetableItemDetailScreen"
         ) {
             when (it) {
                 Loading -> {

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -1,11 +1,14 @@
 package io.github.droidkaigi.confsched2023.sessions
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -177,30 +180,27 @@ private fun TimetableItemDetailScreen(
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { innerPadding ->
-        AnimatedContent(
-            modifier = Modifier.fillMaxSize(),
-            targetState = uiState,
-            transitionSpec = { fadeIn().togetherWith(fadeOut()) },
-            contentKey = { uiState is Loaded },
-            label = "TimetableItemDetailScreen"
-        ) {
-            when (it) {
-                Loading -> {
-                    LoadingText(
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
+        if (uiState is Loaded) {
+            TimetableItemDetail(
+                modifier = Modifier.fillMaxSize(),
+                uiState = uiState.timetableItemDetailSectionUiState,
+                selectedLanguage = uiState.currentLang,
+                onLinkClick = onLinkClick,
+                contentPadding = innerPadding
+            )
+        }
 
-                is Loaded -> {
-                    TimetableItemDetail(
-                        modifier = Modifier.fillMaxSize(),
-                        uiState = it.timetableItemDetailSectionUiState,
-                        selectedLanguage = it.currentLang,
-                        onLinkClick = onLinkClick,
-                        contentPadding = innerPadding,
-                    )
-                }
-            }
+        AnimatedVisibility(
+            modifier = Modifier.fillMaxSize(),
+            visible = (uiState is Loading),
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            LoadingText(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+            )
         }
     }
 }
@@ -217,7 +217,9 @@ fun TimetableItemDetailScreenPreview() {
             TimetableItemDetailScreen(
                 uiState = Loaded(
                     timetableItem = fakeSession,
-                    timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(fakeSession),
+                    timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(
+                        fakeSession
+                    ),
                     isBookmarked = isBookMarked,
                     isLangSelectable = true,
                     viewBookmarkListRequestState = ViewBookmarkListRequestState.NotRequested,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableItemDetailScreen.kt
@@ -1,10 +1,8 @@
 package io.github.droidkaigi.confsched2023.sessions
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -186,7 +184,7 @@ private fun TimetableItemDetailScreen(
                 uiState = uiState.timetableItemDetailSectionUiState,
                 selectedLanguage = uiState.currentLang,
                 onLinkClick = onLinkClick,
-                contentPadding = innerPadding
+                contentPadding = innerPadding,
             )
         }
 
@@ -199,7 +197,7 @@ private fun TimetableItemDetailScreen(
             LoadingText(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
+                    .background(MaterialTheme.colorScheme.background),
             )
         }
     }
@@ -218,7 +216,7 @@ fun TimetableItemDetailScreenPreview() {
                 uiState = Loaded(
                     timetableItem = fakeSession,
                     timetableItemDetailSectionUiState = TimetableItemDetailSectionUiState(
-                        fakeSession
+                        fakeSession,
                     ),
                     isBookmarked = isBookMarked,
                     isLangSelectable = true,

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/TimetableScreen.kt
@@ -254,6 +254,10 @@ fun PreviewTimetableScreenDark() {
                             mapOf<String, List<TimetableItem>>().toPersistentMap(),
                             Timetable(),
                         ),
+                        DroidKaigi2023Day.Day2 to TimetableListUiState(
+                            mapOf<String, List<TimetableItem>>().toPersistentMap(),
+                            Timetable(),
+                        ),
                     ),
                 ),
                 timetableUiType = TimetableUiType.Grid,


### PR DESCRIPTION
## Issue
- TimetableDetailScreen animation is unnatural.

## Overview (Required)
- The contentKey was introduced in #982, but during the initial animation, there is a moment when the content is not displayed, and the loaded section is drawn from there, resulting in a scaled animation that is unnatural.
- Therefore, only the Loading section is faded animated without AnimatedContent.
  - In the first place, this loading never takes more than a few seconds (for local), so I feel that the switching animation is not necessary.

## Movie
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/1819b828-9f4e-4727-8dda-2c7bd34b8d71" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/56629437/df006910-86c3-4487-99e5-7ba553f57bea" width="300" >


