### PR TITLE
[Android] select first timetable tab on TimetableScreenTest

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
@@ -81,7 +81,10 @@ public enum class DroidKaigi2023Day(
         /**
          * @return appropriate initial day for now
          */
-        fun initialSelectedDay(): DroidKaigi2023Day {
+        fun initialSelectedDay(isTest: Boolean = false): DroidKaigi2023Day {
+            // Timetable tab set initial tab with current date.
+            // To get the consistent test result, fix selected timetable tab to Day1 here.
+            if (isTest) return Day1
             val reversedEntries = entries.sortedByDescending { it.day }
             var selectedDay = reversedEntries.last()
             for (entry in reversedEntries) {

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
@@ -15,6 +15,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import io.github.droidkaigi.confsched2023.data.sessions.FakeSessionsApiClient
 import io.github.droidkaigi.confsched2023.data.sessions.SessionsApiClient
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
+import io.github.droidkaigi.confsched2023.model.DroidKaigi2023Day
 import io.github.droidkaigi.confsched2023.sessions.TimetableScreen
 import io.github.droidkaigi.confsched2023.sessions.TimetableScreenTestTag
 import io.github.droidkaigi.confsched2023.sessions.component.SearchButtonTestTag
@@ -58,6 +59,9 @@ class TimetableScreenRobot @Inject constructor(
                 )
             }
         }
+        // Timetable tab set initial tab with current date.
+        // To get the consistent test result, fix selected timetable tab to Day1 here.
+        clickTimetableTab(DroidKaigi2023Day.Day1.day)
         waitUntilIdle()
     }
 

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
@@ -15,7 +15,6 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import io.github.droidkaigi.confsched2023.data.sessions.FakeSessionsApiClient
 import io.github.droidkaigi.confsched2023.data.sessions.SessionsApiClient
 import io.github.droidkaigi.confsched2023.designsystem.theme.KaigiTheme
-import io.github.droidkaigi.confsched2023.model.DroidKaigi2023Day
 import io.github.droidkaigi.confsched2023.sessions.TimetableScreen
 import io.github.droidkaigi.confsched2023.sessions.TimetableScreenTestTag
 import io.github.droidkaigi.confsched2023.sessions.component.SearchButtonTestTag

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
@@ -60,7 +60,7 @@ class TimetableScreenRobot @Inject constructor(
             }
         }
         // Timetable tab set initial tab with current date.
-        // To get the consistent test result, fix selected timetable tab to Day1 here.
+        // For the consistent test result, fix selected timetable tab to Day1 here.
         clickTimetableTab(DroidKaigi2023Day.Day1.day)
         waitUntilIdle()
     }

--- a/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
+++ b/core/testing/src/main/java/io/github/droidkaigi/confsched2023/testing/robot/TimetableScreenRobot.kt
@@ -59,9 +59,6 @@ class TimetableScreenRobot @Inject constructor(
                 )
             }
         }
-        // Timetable tab set initial tab with current date.
-        // For the consistent test result, fix selected timetable tab to Day1 here.
-        clickTimetableTab(DroidKaigi2023Day.Day1.day)
         waitUntilIdle()
     }
 

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
@@ -36,8 +36,10 @@ import io.github.droidkaigi.confsched2023.sessions.component.rememberTimetableTa
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableSheetUiState.Empty
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableSheetUiState.GridTimetable
 import io.github.droidkaigi.confsched2023.sessions.section.TimetableSheetUiState.ListTimetable
+import io.github.droidkaigi.confsched2023.ui.isTest
 
 const val TimetableTabTestTag = "TimetableTab"
+
 sealed interface TimetableSheetUiState {
     data object Empty : TimetableSheetUiState
     data class ListTimetable(
@@ -58,7 +60,7 @@ fun TimetableSheet(
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    var selectedDay by rememberSaveable { mutableStateOf(DroidKaigi2023Day.initialSelectedDay()) }
+    var selectedDay by rememberSaveable { mutableStateOf(DroidKaigi2023Day.initialSelectedDay(isTest())) }
     val corner by animateIntAsState(
         if (timetableScreenScrollState.isScreenLayoutCalculating || timetableScreenScrollState.isSheetExpandable) 40 else 0,
         label = "Timetable corner state",


### PR DESCRIPTION
## Issue
- close #1217

## Overview (Required)
- Today is Day2 of DroidKaigi2023.
- TimetableScreen initialize own selected tab with current date.
- So, if we run snapshot test for timetable, the Day2 tab will be selected as default.
  - (tomorrow, day3 tab will be selected)
- By above reason, there are some differences on snapshot comparing test. 
- For the consistent test result, fix selected tab to **Day1**.
- (addition) this problem is also occured on PreviewTest.
  - thus, I changed to return Day1 from `initialSelectedDay` if it's on test.

## Links
- https://github.com/DroidKaigi/conference-app-2023/pull/1216#issuecomment-1719867788

## Screenshot (Optional if screenshot test is present or unrelated to UI)
### ※Following screenshots are samples because target snapshots are little bit too many to show here :bow: 
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/ccd3b3cb-57c7-412c-b9e0-0867b1c02d0d" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/6b83a8c7-6c8b-4683-b9a7-1717d0d0edc6" width="300" />
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/26b463b5-5c01-4169-bfb6-77b398fe70d8" width="300" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/74723074/2a32649f-dcaf-4412-a024-99dc12c39097" width="300" />
