### PR TITLE
Renamed `generateMetricsReport` to `generateComposeMetricsReport`.

### DIFF
--- a/.run/generateComposeCompilerMetricsReports.run.xml
+++ b/.run/generateComposeCompilerMetricsReports.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="generateMetricsReport" type="GradleRunConfiguration" factoryName="Gradle">
+    <configuration default="false" name="generateComposeMetricsReport" type="GradleRunConfiguration" factoryName="Gradle">
         <ExternalSystemSettings>
             <option name="executionName" />
             <option name="externalProjectPath" value="$PROJECT_DIR$" />


### PR DESCRIPTION
## Issue
- close #1222 

## Overview (Required)
- `generateMetricsReport` is a little confusing, so renamed `generateMetricsReport` to `generateComposeMetricsReport`.

## Screenshot (Optional if screenshot test is present or unrelated to UI)
Before | After
:--: | :--:
<img src="https://github.com/DroidKaigi/conference-app-2023/assets/62137820/e368df61-8594-4996-9422-41647e0876ea" width="400" /> | <img src="https://github.com/DroidKaigi/conference-app-2023/assets/62137820/a83f91b5-d34d-4658-9c81-5c86aa599478" width="400" />
