### PR TITLE
Deleted unused `TimetableItemList.getDayTimetableItems()`

### DIFF
--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItemList.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItemList.kt
@@ -2,16 +2,7 @@ package io.github.droidkaigi.confsched2023.model
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
 
-public data class TimetableItemList(
+data class TimetableItemList(
     val timetableItems: PersistentList<TimetableItem> = persistentListOf(),
-) : PersistentList<TimetableItem> by timetableItems {
-    public fun getDayTimetableItems(day: DroidKaigi2023Day): TimetableItemList {
-        return TimetableItemList(
-            timetableItems.filter {
-                it.startsAt in day.start..day.end
-            }.toPersistentList(),
-        )
-    }
-}
+) : PersistentList<TimetableItem> by timetableItems


### PR DESCRIPTION
## Issue
- close #1243 

## Overview (Required)
- Removed unused function `getDayTimetableItems()` in TimetableItemList data class

## Link
https://github.com/DroidKaigi/conference-app-2023/blob/41227489a0eb0af4cef13a5ecbc836e42bdd9fbf/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItemList.kt#L7