### PR TITLE
Fade favorite animation end

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/BookmarkIcon.kt
@@ -1,5 +1,9 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -53,7 +57,11 @@ fun BookmarkIcon(
         modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
-        if (lottieState.isPlaying && !lottieState.isAtEnd) {
+        AnimatedVisibility(
+            visible = lottieState.isPlaying,
+            enter = fadeIn(animationSpec = tween(0)),
+            exit = fadeOut(),
+        ) {
             LottieAnimation(
                 composition = lottieComposition,
                 progress = { lottieState.progress },
@@ -62,13 +70,13 @@ fun BookmarkIcon(
                         onClick(label = contentDescription, action = null)
                     },
             )
-        } else {
-            Icon(
-                modifier = Modifier
-                    .padding(12.dp),
-                imageVector = Icons.Outlined.Bookmarks,
-                contentDescription = contentDescription,
-            )
         }
+
+        Icon(
+            modifier = Modifier
+                .padding(12.dp),
+            imageVector = Icons.Outlined.Bookmarks,
+            contentDescription = contentDescription,
+        )
     }
 }

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/component/TimetableTopArea.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2023.sessions.component
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search


### PR DESCRIPTION
## Issue
- close #1254 

## Overview (Required)
- Added fade-out at the end of favorite animations



## Movie (Optional)
Before | After
:--: | :--:
 <video src="https://github.com/DroidKaigi/conference-app-2023/assets/60963155/35a5e52b-6229-42b5-9e66-648e06451c86" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/60963155/718560fa-451d-44d3-987a-d134b9d460e9" width="300" >
