### PR TITLE
Add achivement click animation #1235

### DIFF
--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreen.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -150,6 +151,11 @@ private fun AchievementsScreen(
             },
         )
         if (uiState.clickedAchievement is Clicked) {
+            DisposableEffect(uiState.clickedAchievement) {
+                onDispose {
+                    finishAnimation()
+                }
+            }
             Surface(
                 modifier = Modifier.fillMaxSize(),
                 color = MaterialTheme.colorScheme.background.copy(alpha = 0.6F),

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreen.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreen.kt
@@ -36,7 +36,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import io.github.droidkaigi.confsched2023.achievements.ClickedAchievementState.Clicked
-import io.github.droidkaigi.confsched2023.achievements.component.GetAchievementAnimation
+import io.github.droidkaigi.confsched2023.achievements.component.AchievementHighlightAnimation
 import io.github.droidkaigi.confsched2023.achievements.section.AchievementList
 import io.github.droidkaigi.confsched2023.achievements.section.AchievementListUiState
 import io.github.droidkaigi.confsched2023.model.Achievement
@@ -160,7 +160,7 @@ private fun AchievementsScreen(
                 modifier = Modifier.fillMaxSize(),
                 color = MaterialTheme.colorScheme.background.copy(alpha = 0.6F),
             ) {
-                GetAchievementAnimation(
+                AchievementHighlightAnimation(
                     animationRawId = uiState.clickedAchievement.animationRawId,
                     onFinishAnimation = {
                         finishAnimation()

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreenViewModel.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/AchievementsScreenViewModel.kt
@@ -15,6 +15,7 @@ import io.github.droidkaigi.confsched2023.ui.handleErrorAndRetry
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -120,13 +121,17 @@ class AchievementsScreenViewModel @Inject constructor(
         )
     }
 
+    private val clickedAchievement = MutableStateFlow<ClickedAchievementState>(ClickedAchievementState.NotClicked)
+
     val uiState = buildUiState(
         achievementAnimationListState,
         isInitialDialogDisplayFlow,
-    ) { achievementListUiState, isDisplayedInitialDialog ->
+        clickedAchievement,
+    ) { achievementListUiState, isDisplayedInitialDialog, clickedAchievement ->
         AchievementsScreenUiState(
             achievementListUiState = achievementListUiState,
             isShowInitialDialog = isDisplayedInitialDialog?.not() ?: false,
+            clickedAchievement = clickedAchievement,
         )
     }
 
@@ -140,5 +145,23 @@ class AchievementsScreenViewModel @Inject constructor(
         viewModelScope.launch {
             achievementRepository.displayedInitialDialog()
         }
+    }
+
+    fun onClickAchievement(clickedAchievement: Achievement) {
+        val animationRawId: Int = when (clickedAchievement) {
+            Achievement.ArcticFox -> R.raw.achievement_a_lottie
+            Achievement.Bumblebee -> R.raw.achievement_b_lottie
+            Achievement.Chipmunk -> R.raw.achievement_c_lottie
+            Achievement.Dolphin -> R.raw.achievement_d_lottie
+            Achievement.ElectricEel -> R.raw.achievement_e_lottie
+        }
+        this.clickedAchievement.value = ClickedAchievementState.Clicked(
+            achievement = clickedAchievement,
+            animationRawId = animationRawId,
+        )
+    }
+
+    fun onFinishAnimation() {
+        this.clickedAchievement.value = ClickedAchievementState.NotClicked
     }
 }

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/animation/AchievementAnimationScreen.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/animation/AchievementAnimationScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import io.github.droidkaigi.confsched2023.achievements.component.GetAchievementAnimation
+import io.github.droidkaigi.confsched2023.achievements.component.AchievementHighlightAnimation
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 
 data class AnimationScreenUiState(
@@ -56,7 +56,7 @@ fun AchievementAnimationScreen(
             .fillMaxSize(),
     ) {
         if (uiState.rawId != null) {
-            GetAchievementAnimation(
+            AchievementHighlightAnimation(
                 animationRawId = uiState.rawId,
                 onFinishAnimation = {
                     onReachAnimationEnd()

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/animation/AchievementAnimationScreen.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/animation/AchievementAnimationScreen.kt
@@ -10,10 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.airbnb.lottie.compose.LottieAnimation
-import com.airbnb.lottie.compose.LottieCompositionSpec.RawRes
-import com.airbnb.lottie.compose.animateLottieCompositionAsState
-import com.airbnb.lottie.compose.rememberLottieComposition
+import io.github.droidkaigi.confsched2023.achievements.component.GetAchievementAnimation
 import io.github.droidkaigi.confsched2023.ui.SnackbarMessageEffect
 
 data class AnimationScreenUiState(
@@ -59,19 +56,12 @@ fun AchievementAnimationScreen(
             .fillMaxSize(),
     ) {
         if (uiState.rawId != null) {
-            val lottieComposition by rememberLottieComposition(RawRes(uiState.rawId))
-            val progress by animateLottieCompositionAsState(
-                composition = lottieComposition,
-                isPlaying = true,
-                restartOnPlay = true,
-            )
-            if (progress == 1f) {
-                onReachAnimationEnd()
-                onFinished()
-            }
-            LottieAnimation(
-                composition = lottieComposition,
-                progress = { progress },
+            GetAchievementAnimation(
+                animationRawId = uiState.rawId,
+                onFinishAnimation = {
+                    onReachAnimationEnd()
+                    onFinished()
+                },
             )
         }
     }

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/AchievementHighlightAnimation.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/AchievementHighlightAnimation.kt
@@ -8,7 +8,7 @@ import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 
 @Composable
-fun GetAchievementAnimation(
+fun AchievementHighlightAnimation(
     animationRawId: Int,
     onFinishAnimation: () -> Unit,
 ) {

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/AchievementImage.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/AchievementImage.kt
@@ -1,22 +1,34 @@
 package io.github.droidkaigi.confsched2023.achievements.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.confsched2023.model.Achievement
 import io.github.droidkaigi.confsched2023.model.AchievementAnimation
 
 @Composable
 fun AchievementImage(
     achievementAnimation: AchievementAnimation,
     modifier: Modifier = Modifier,
+    showAnimation: (Achievement) -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Image(
         painter = painterResource(id = achievementAnimation.getDrawableResId()),
         contentDescription = achievementAnimation.contentDescription,
         modifier = modifier
-            .padding(horizontal = 21.dp),
+            .padding(horizontal = 21.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+            ) {
+                showAnimation(achievementAnimation.achievement)
+            },
     )
 }

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/AchievementImage.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/AchievementImage.kt
@@ -24,11 +24,17 @@ fun AchievementImage(
         contentDescription = achievementAnimation.contentDescription,
         modifier = modifier
             .padding(horizontal = 21.dp)
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-            ) {
-                showAnimation(achievementAnimation.achievement)
-            },
+            .then(
+                if (achievementAnimation.hasAchievement) {
+                    Modifier.clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                    ) {
+                        showAnimation(achievementAnimation.achievement)
+                    }
+                } else {
+                    Modifier
+                },
+            ),
     )
 }

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/GetAchivementAnimation.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/component/GetAchivementAnimation.kt
@@ -1,0 +1,28 @@
+package io.github.droidkaigi.confsched2023.achievements.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec.RawRes
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.compose.rememberLottieComposition
+
+@Composable
+fun GetAchievementAnimation(
+    animationRawId: Int,
+    onFinishAnimation: () -> Unit,
+) {
+    val lottieComposition by rememberLottieComposition(RawRes(animationRawId))
+    val progress by animateLottieCompositionAsState(
+        composition = lottieComposition,
+        isPlaying = true,
+        restartOnPlay = true,
+    )
+    if (progress == 1f) {
+        onFinishAnimation()
+    }
+    LottieAnimation(
+        composition = lottieComposition,
+        progress = { progress },
+    )
+}

--- a/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/section/AchievementList.kt
+++ b/feature/achievements/src/main/java/io/github/droidkaigi/confsched2023/achievements/section/AchievementList.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.confsched2023.achievements.component.AchievementImage
 import io.github.droidkaigi.confsched2023.achievements.component.AchievementsDetail
+import io.github.droidkaigi.confsched2023.model.Achievement
 import io.github.droidkaigi.confsched2023.model.AchievementAnimation
 import kotlinx.collections.immutable.ImmutableList
 
@@ -37,6 +38,7 @@ fun AchievementList(
     uiState: AchievementListUiState,
     contentPadding: PaddingValues,
     onReset: () -> Unit,
+    showAnimation: (Achievement) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val layoutDirection = LocalLayoutDirection.current
@@ -77,6 +79,7 @@ fun AchievementList(
             ) { achievementAnimation ->
                 AchievementImage(
                     achievementAnimation = achievementAnimation,
+                    showAnimation = showAnimation,
                 )
             }
             if (uiState.isResetButtonEnabled) {


### PR DESCRIPTION
## Issue
- close #1235 

## Overview (Required)
- add animation on click for acquired achivements.
- refactor and make a component for achivement animation.
- It looked more natural with the background slightly transparent, so I made the background translucent.

## Movie (Optional)
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/43056135/09c5c592-a851-49be-b7d1-6b96769bc3dc" width="300" > 
