### PR TITLE
Support fling for nested scroll on TimetableGrid.

### DIFF
--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
@@ -35,8 +35,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
@@ -84,14 +86,12 @@ data class TimetableGridUiState(val timetable: Timetable)
 @Composable
 fun TimetableGrid(
     uiState: TimetableGridUiState,
-    nestedScrollDispatcher: NestedScrollDispatcher,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
 ) {
     TimetableGrid(
         timetable = uiState.timetable,
-        nestedScrollDispatcher = nestedScrollDispatcher,
         onTimetableItemClick = onTimetableItemClick,
         modifier = modifier,
         contentPadding = contentPadding,
@@ -101,7 +101,6 @@ fun TimetableGrid(
 @Composable
 fun TimetableGrid(
     timetable: Timetable,
-    nestedScrollDispatcher: NestedScrollDispatcher,
     onTimetableItemClick: (TimetableItem) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
@@ -133,7 +132,6 @@ fun TimetableGrid(
             TimetableGrid(
                 timetable = timetable,
                 timetableState = timetableGridState,
-                nestedScrollDispatcher = nestedScrollDispatcher,
                 modifier = modifier,
                 contentPadding = PaddingValues(
                     top = 16.dp + contentPadding.calculateTopPadding(),
@@ -157,7 +155,6 @@ fun TimetableGrid(
 fun TimetableGrid(
     timetable: Timetable,
     timetableState: TimetableState,
-    nestedScrollDispatcher: NestedScrollDispatcher,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
     content: @Composable (TimetableItem, Int) -> Unit,
@@ -186,10 +183,14 @@ fun TimetableGrid(
         content(timetableItemWithFavorite.timetableItem, itemHeightPx)
     }
 
+    val nestedScrollConnection = remember { object : NestedScrollConnection {} }
+    val nestedScrollDispatcher = remember { NestedScrollDispatcher() }
+
     LazyLayout(
         modifier = modifier
             .focusGroup()
             .clipToBounds()
+            .nestedScroll(nestedScrollConnection, nestedScrollDispatcher)
             .drawBehind {
                 timetableScreen.timeHorizontalLines.value.forEach {
                     drawLine(
@@ -322,7 +323,6 @@ fun TimetableGrid(
 fun TimetablePreview() {
     TimetableGrid(
         timetable = Timetable.fake(),
-        nestedScrollDispatcher = remember { NestedScrollDispatcher() },
         onTimetableItemClick = {},
         modifier = Modifier.fillMaxSize(),
     )

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableGrid.kt
@@ -526,7 +526,7 @@ class ScreenScrollState(
             initialValue = 0f,
             initialVelocity = velocity.y,
         ).animateDecay(
-            exponentialDecay()
+            exponentialDecay(),
         ) {
             launch {
                 val delta = Offset(0f, value - lastValue)

--- a/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
+++ b/feature/sessions/src/main/java/io/github/droidkaigi/confsched2023/sessions/section/TimetableSheet.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollDispatcher
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -128,17 +127,11 @@ fun TimetableSheet(
                 }
 
                 is GridTimetable -> {
-                    val nestedScrollDispatcher = remember { NestedScrollDispatcher() }
                     TimetableGrid(
                         uiState = requireNotNull(uiState.timetableGridUiState[selectedDay]),
-                        nestedScrollDispatcher = nestedScrollDispatcher,
                         onTimetableItemClick = onTimetableItemClick,
                         modifier = Modifier
                             .fillMaxSize()
-                            .nestedScroll(
-                                timetableSheetContentScrollState.nestedScrollConnection,
-                                nestedScrollDispatcher,
-                            )
                             .weight(1f),
                         contentPadding = PaddingValues(
                             bottom = contentPadding.calculateBottomPadding(),


### PR DESCRIPTION
## Issue
- close #776 

## Overview (Required)
- Support fling operation for nested scroll on TimetableGrid.

After drag gesture on TimetableGrid ends, the header height and the tab height expand or shrink in conjunction with TimetableGrid flinging.

## Movie (Optional)
Before | After
:--: | :--:
<video src="https://github.com/DroidKaigi/conference-app-2023/assets/17829294/a1c27972-6b22-48ef-9cc1-d51f363830b0" width="300" > | <video src="https://github.com/DroidKaigi/conference-app-2023/assets/17829294/5952d37e-8f57-4148-b60d-5977322ab152" width="300" >

