### PR TITLE
refactor: Use explicit API for core/model module

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -9,6 +9,7 @@ android.namespace = "io.github.droidkaigi.confsched2023.core.model"
 
 @Suppress("UnusedPrivateProperty")
 kotlin {
+    explicitApi()
     sourceSets {
         commonMain {
             dependencies {

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/contributors/AchievementRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/data/contributors/AchievementRepository.kt
@@ -4,13 +4,13 @@ import io.github.droidkaigi.confsched2023.model.Achievement
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.coroutines.flow.Flow
 
-interface AchievementRepository {
-    fun getAchievementEnabledStream(): Flow<Boolean>
-    fun getAchievementDetailDescriptionStream(): Flow<String>
-    fun getResetAchievementsEnabledStream(): Flow<Boolean>
-    fun getAchievementsStream(): Flow<PersistentSet<Achievement>>
-    fun getIsInitialDialogDisplayStateStream(): Flow<Boolean>
-    suspend fun saveAchievements(achievement: Achievement)
-    suspend fun resetAchievements()
-    suspend fun displayedInitialDialog()
+public interface AchievementRepository {
+    public fun getAchievementEnabledStream(): Flow<Boolean>
+    public fun getAchievementDetailDescriptionStream(): Flow<String>
+    public fun getResetAchievementsEnabledStream(): Flow<Boolean>
+    public fun getAchievementsStream(): Flow<PersistentSet<Achievement>>
+    public fun getIsInitialDialogDisplayStateStream(): Flow<Boolean>
+    public suspend fun saveAchievements(achievement: Achievement)
+    public suspend fun resetAchievements()
+    public suspend fun displayedInitialDialog()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AboutItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AboutItem.kt
@@ -1,13 +1,13 @@
 package io.github.droidkaigi.confsched2023.model
 
-sealed class AboutItem {
-    data object Sponsors : AboutItem()
-    data object Contributors : AboutItem()
-    data object Staff : AboutItem()
-    data object CodeOfConduct : AboutItem()
-    data object License : AboutItem()
-    data object PrivacyPolicy : AboutItem()
-    data object YouTube : AboutItem()
-    data object X : AboutItem()
-    data object Medium : AboutItem()
+public sealed class AboutItem {
+    public data object Sponsors : AboutItem()
+    public data object Contributors : AboutItem()
+    public data object Staff : AboutItem()
+    public data object CodeOfConduct : AboutItem()
+    public data object License : AboutItem()
+    public data object PrivacyPolicy : AboutItem()
+    public data object YouTube : AboutItem()
+    public data object X : AboutItem()
+    public data object Medium : AboutItem()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Achievement.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Achievement.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2023.model
 
-enum class Achievement(val id: String, val sha256: String) {
+public enum class Achievement(public val id: String, public val sha256: String) {
     ArcticFox(
         id = "Arctic Fox",
         sha256 = "8370e6e6326c36f24b22f92a47ded5c3f1897aad46dfd9527016d2f3034d5f6e",
@@ -22,8 +22,8 @@ enum class Achievement(val id: String, val sha256: String) {
         sha256 = "4e52d5a2f091279b365576319ee18384b3340e61f6c97a549ad8a7940c51d0bb",
     ),
     ;
-    companion object {
-        fun ofOrNull(id: String): Achievement? {
+    public companion object {
+        public fun ofOrNull(id: String): Achievement? {
             return entries.find { it.id == id }
         }
     }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AchievementAnimation.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/AchievementAnimation.kt
@@ -1,11 +1,11 @@
 package io.github.droidkaigi.confsched2023.model
 
-data class AchievementAnimation(
+public data class AchievementAnimation(
     val achievement: Achievement,
     val hasDrawableResId: Int,
     val notHasDrawableResId: Int,
     val hasAchievement: Boolean = false,
     val contentDescription: String,
 ) {
-    fun getDrawableResId() = if (hasAchievement) hasDrawableResId else notHasDrawableResId
+    public fun getDrawableResId(): Int = if (hasAchievement) hasDrawableResId else notHasDrawableResId
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/BuildConfigProvider.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/BuildConfigProvider.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2023.model
 
-interface BuildConfigProvider {
-    val versionName: String
-    val debugBuild: Boolean
+public interface BuildConfigProvider {
+    public val versionName: String
+    public val debugBuild: Boolean
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/ContributorsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/ContributorsRepository.kt
@@ -3,8 +3,8 @@ package io.github.droidkaigi.confsched2023.model
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
 
-interface ContributorsRepository {
+public interface ContributorsRepository {
 
-    fun contributors(): Flow<PersistentList<Contributor>>
-    suspend fun refresh()
+    public fun contributors(): Flow<PersistentList<Contributor>>
+    public suspend fun refresh()
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/DroidKaigi2023Day.kt
@@ -45,7 +45,7 @@ public enum class DroidKaigi2023Day(
     ),
     ;
 
-    fun getDropDownText(language: String): String {
+    public fun getDropDownText(language: String): String {
         val japanese = "ja"
 
         val date = this.start.toLocalDateTime(TimeZone.currentSystemDefault())
@@ -81,7 +81,7 @@ public enum class DroidKaigi2023Day(
         /**
          * @return appropriate initial day for now
          */
-        fun initialSelectedDay(clock: Clock): DroidKaigi2023Day {
+        public fun initialSelectedDay(clock: Clock): DroidKaigi2023Day {
             val reversedEntries = entries.sortedByDescending { it.day }
             var selectedDay = reversedEntries.last()
             for (entry in reversedEntries) {

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/FloorLevel.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/FloorLevel.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched2023.model
 
 public enum class FloorLevel(
-    val floorName: String,
+    public val floorName: String,
 ) {
     Basement("B1F"),
     Ground("1F"),

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/RoomType.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/RoomType.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2023.model
 /**
  * Please use [TimetableRoom] to get room information.
  */
-enum class RoomType {
+public enum class RoomType {
     RoomA,
     RoomB,
     RoomC,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SessionsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SessionsRepository.kt
@@ -2,8 +2,8 @@ package io.github.droidkaigi.confsched2023.model
 
 import kotlinx.coroutines.flow.Flow
 
-interface SessionsRepository {
-    fun getTimetableStream(): Flow<Timetable>
-    fun getTimetableItemWithBookmarkStream(id: TimetableItemId): Flow<Pair<TimetableItem, Boolean>>
-    suspend fun toggleBookmark(id: TimetableItemId)
+public interface SessionsRepository {
+    public fun getTimetableStream(): Flow<Timetable>
+    public fun getTimetableItemWithBookmarkStream(id: TimetableItemId): Flow<Pair<TimetableItem, Boolean>>
+    public suspend fun toggleBookmark(id: TimetableItemId)
 }

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/SideEvent.kt
@@ -17,20 +17,20 @@ public data class SideEvent(
     val link: String?,
     val imageLink: String?,
 ) {
-    enum class MarkShape {
+    public enum class MarkShape {
         Favorite,
         Circle,
         Square,
     }
 
-    enum class MarkColor {
+    public enum class MarkColor {
         Pink, Orange, Blue, Red, Purple
     }
 
     public companion object
 }
 
-val SideEvents: PersistentList<SideEvent> = persistentListOf(
+public val SideEvents: PersistentList<SideEvent> = persistentListOf(
     SideEvent(
         title = MultiLangText(
             jaTitle = "Day.3 イベント",
@@ -52,7 +52,7 @@ val SideEvents: PersistentList<SideEvent> = persistentListOf(
     ),
 )
 
-val FakeSideEvents
+public val FakeSideEvents: PersistentList<SideEvent>
     get() = persistentListOf(
         SideEvent(
             title = MultiLangText(

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Staff.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/Staff.kt
@@ -9,11 +9,11 @@ public data class Staff(
     val profileUrl: String,
     val iconUrl: String,
 ) {
-    companion object
+    public companion object
 }
 
 // create fakes
-fun Staff.Companion.fakes(): PersistentList<Staff> {
+public fun Staff.Companion.fakes(): PersistentList<Staff> {
     return (1..20).map {
         Staff(
             id = it.toLong(),

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/StaffRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/StaffRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.coroutines.flow.Flow
 import kotlin.coroutines.cancellation.CancellationException
 
-interface StaffRepository {
+public interface StaffRepository {
 
     public fun staffs(): Flow<PersistentList<Staff>>
 

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableCategory.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableCategory.kt
@@ -7,7 +7,7 @@ public data class TimetableCategory(
     public companion object
 }
 
-fun TimetableCategory.Companion.fakes(): List<TimetableCategory> {
+public fun TimetableCategory.Companion.fakes(): List<TimetableCategory> {
     return listOf(
         TimetableCategory(
             id = 1,

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItem.kt
@@ -99,7 +99,7 @@ public sealed class TimetableItem {
         "https://2023.droidkaigi.jp/en/timetable/${id.value}"
     }
 
-    fun getSupportedLangString(isJapaneseLocale: Boolean): String {
+    public fun getSupportedLangString(isJapaneseLocale: Boolean): String {
         val japanese = if (isJapaneseLocale) "日本語" else "Japanese"
         val english = if (isJapaneseLocale) "英語" else "English"
         val japaneseWithInterpretation =

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItemList.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableItemList.kt
@@ -3,6 +3,6 @@ package io.github.droidkaigi.confsched2023.model
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
-data class TimetableItemList(
+public data class TimetableItemList(
     val timetableItems: PersistentList<TimetableItem> = persistentListOf(),
 ) : PersistentList<TimetableItem> by timetableItems

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableLanguage.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableLanguage.kt
@@ -4,7 +4,7 @@ public data class TimetableLanguage(
     val langOfSpeaker: String,
     val isInterpretationTarget: Boolean,
 ) {
-    val labels = if (langOfSpeaker == Lang.MIXED.tagName) {
+    val labels: List<String> = if (langOfSpeaker == Lang.MIXED.tagName) {
         listOf(Lang.MIXED.tagName)
     } else if (isInterpretationTarget) {
         listOf(Lang.ENGLISH.tagName, Lang.JAPANESE.tagName)
@@ -12,7 +12,7 @@ public data class TimetableLanguage(
         listOf(langOfSpeaker.take(2))
     }
 
-    fun toLang() = if (isInterpretationTarget) {
+    public fun toLang(): Lang = if (isInterpretationTarget) {
         Lang.MIXED
     } else {
         Lang.entries.firstOrNull { it.tagName == langOfSpeaker.take(2) } ?: Lang.MIXED

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableRoom.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableRoom.kt
@@ -1,9 +1,9 @@
 package io.github.droidkaigi.confsched2023.model
 
 @Immutable
-data class TimetableRooms(val rooms: List<TimetableRoom>)
+public data class TimetableRooms(val rooms: List<TimetableRoom>)
 
-data class TimetableRoom(
+public data class TimetableRoom(
     val id: Int,
     val name: MultiLangText,
     val type: RoomType,
@@ -17,7 +17,7 @@ data class TimetableRoom(
     }
 }
 
-val TimetableRoom.nameAndFloor: String
+public val TimetableRoom.nameAndFloor: String
     get() {
         val basementFloorString = MultiLangText(jaTitle = "地下1階", enTitle = "B1F")
         val floor = when (type) {

--- a/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableSessionType.kt
+++ b/core/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2023/model/TimetableSessionType.kt
@@ -1,8 +1,8 @@
 package io.github.droidkaigi.confsched2023.model
 
-enum class TimetableSessionType(
-    val key: String,
-    val label: MultiLangText,
+public enum class TimetableSessionType(
+    public val key: String,
+    public val label: MultiLangText,
 ) {
     WELCOME_TALK(
         key = "WELCOME_TALK",
@@ -34,8 +34,8 @@ enum class TimetableSessionType(
     ),
     ;
 
-    companion object {
-        fun ofOrNull(key: String): TimetableSessionType? {
+    public companion object {
+        public fun ofOrNull(key: String): TimetableSessionType? {
             return entries.firstOrNull {
                 it.key == key
             }


### PR DESCRIPTION
## Issue
- close #1220 

# Overview (Required)
- Adopt `exciplit API` mode in the core/model module.
    - Thereby, avoiding unintentional exposure of declarations to public APIs.

# Links
- https://github.com/DroidKaigi/conference-app-2022/pull/554/files
